### PR TITLE
make-release-msys2.sh: add libmujs.dll

### DIFF
--- a/make-release-msys2.sh
+++ b/make-release-msys2.sh
@@ -161,6 +161,7 @@ cp $BINDIR/xvidcore.dll                 "$DEST"
 cp $BINDIR/libgmp-*.dll                 "$DEST"
 cp $BINDIR/libhogweed-*.dll             "$DEST"
 cp $BINDIR/libnettle-*.dll              "$DEST"
+cp $BINDIR/libmujs.dll                  "$DEST"
 echo Copying extra libraries
 cp $BINDIR/libidn2-*.dll                "$DEST"
 cp $BINDIR/libp11-kit-*.dll             "$DEST"


### PR DESCRIPTION
mpv-2.dll now requires libmujs.dll.

Note that there is a better way to do this: use a recursive ntldd search.  Perhaps one day when I'm bored.