### PR TITLE
Remember video position

### DIFF
--- a/main.h
+++ b/main.h
@@ -50,6 +50,8 @@ private:
     void setupFlowConnections();
     void setupMpris();
     void setupMpcHc();
+    void updateRecentPosition(bool resetPosition = false);
+    void updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length, double position);
     QByteArray makePayload() const;
     QString pictureTemplate(Helpers::DisabledTrack tracks, Helpers::Subtitles subs) const;
     QVariantList recentToVList() const;
@@ -70,6 +72,8 @@ private slots:
     void manager_stateChanged(PlaybackManager::PlaybackState state);
     void manager_subtitlesVisibile(bool visible);
     void manager_hasNoSubtitles(bool none);
+    void manager_startingPlayingFile(QUrl url);
+    void manager_stoppedPlaying();
     void mpcHcServer_fileSelected(QString fileName);
     void settingswindow_settingsData(const QVariantMap &settings);
     void settingswindow_inhibitScreensaver(bool yes);

--- a/manager.h
+++ b/manager.h
@@ -73,6 +73,8 @@ signals:
     void systemShouldStandby();
     void systemShouldHibernate();
     void currentTrackInfo(TrackInfo track);
+    void startingPlayingFile(QUrl url);
+    void stoppedPlaying();
 
     void fpsChanged(double fps);
     void avsyncChanged(double sync);
@@ -147,6 +149,7 @@ public slots:
 
     // misc functions
     void sendCurrentTrackInfo();
+    void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString title, double &length, double &position);
 
 private:
     void startPlayWithUuid(QUrl what, QUuid playlistUuid, QUuid itemUuid,


### PR DESCRIPTION
Fixes #44
Saves the position in recents and reuses it when opening a file from the file manager.
Stopping (not pausing) a video resets the position to the start.