### PR TITLE
Add a setting for Remember file position

### DIFF
--- a/main.h
+++ b/main.h
@@ -62,7 +62,7 @@ private:
 private slots:
     void self_windowsRestored();
     void mainwindow_instanceShouldQuit();
-    void mainwindow_recentOpened(const TrackInfo &track);
+    void mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents = false);
     void mainwindow_recentClear();
     void mainwindow_takeImage(Helpers::ScreenshotRender render);
     void mainwindow_takeImageAutomatically(Helpers::ScreenshotRender render);
@@ -77,6 +77,7 @@ private slots:
     void mpcHcServer_fileSelected(QString fileName);
     void settingswindow_settingsData(const QVariantMap &settings);
     void settingswindow_inhibitScreensaver(bool yes);
+    void settingswindow_rememberFilePosition(bool yes);
     void settingswindow_rememberWindowGeometry(bool yes);
     void settingswindow_keymapData(const QVariantMap &keyMap);
     void settingswindow_mprisIpc(bool enabled);
@@ -128,6 +129,7 @@ private:
     static bool settingsDisableWindowManagement;
     bool inhibitScreensaver = false;
     bool manipulateScreensaver = false;
+    bool rememberFilePosition = false;
     bool rememberWindowGeometry = false;
     bool nowPlayingDisplayingSubtitles = true;
     bool nowPlayingNoSubtitleTracks = false;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1593,7 +1593,7 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
         QAction *a = new QAction(QString("%1 - %2").arg(i).arg(displayString),
                                  this);
         connect(a, &QAction::triggered, this, [=]() {
-            emit recentOpened(track);
+            emit recentOpened(track, true);
         });
         ui->menuFileRecent->addAction(a);
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -117,7 +117,7 @@ signals:
     void severalFilesOpenedForPlaylist(QUuid destination, QList<QUrl> what);
     void dvdbdOpened(QUrl what);
     void streamOpened(QUrl what);
-    void recentOpened(TrackInfo info);
+    void recentOpened(TrackInfo info, bool isFromRecents = false);
     void recentClear();
     void takeImage(Helpers::ScreenshotRender render);
     void takeImageAutomatically(Helpers::ScreenshotRender render);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -471,6 +471,7 @@ void SettingsWindow::setupUnimplementedWidgets()
     ui->playerDisableOpenDisc->setVisible(false);
     ui->playerTitleBox->setVisible(false);
     ui->playerKeepHistory->setVisible(false);
+    ui->playerRememberFilePosition->setVisible(false);
     ui->playerRememberLastPlaylist->setVisible(false);
     ui->playerRememberPanScanZoom->setVisible(false);
 
@@ -719,6 +720,7 @@ void SettingsWindow::sendSignals()
                         : WIDGET_LOOKUP(ui->playerTitleFileNameOnly).toBool() ? Helpers::PrefixFileName : Helpers::NoPrefix);
     emit titleUseMediaTitle(WIDGET_LOOKUP(ui->playerTitleReplaceName).toBool());
     emit rememberHistory(WIDGET_LOOKUP(ui->playerKeepHistory).toBool());
+    emit rememberFilePosition(WIDGET_LOOKUP(ui->playerRememberFilePosition).toBool());
     emit rememberSelectedPlaylist(WIDGET_LOOKUP(ui->playerRememberLastPlaylist).toBool());
     emit rememberWindowGeometry(WIDGET_LOOKUP(ui->playerRememberWindowGeometry).toBool());
     emit rememberPanNScan(WIDGET_LOOKUP(ui->playerRememberPanScanZoom).toBool());
@@ -1093,6 +1095,7 @@ void SettingsWindow::setFreestanding(bool freestanding)
     ui->ipcNotice->setVisible(yes);
     ui->ipcMpris->setVisible(yes);
     ui->playerKeepHistory->setVisible(yes);
+    ui->playerRememberFilePosition->setVisible(yes);
     ui->playerRememberLastPlaylist->setVisible(false /*yes*/);
     ui->playerRememberWindowGeometry->setVisible(yes);
     ui->playerRememberPanScanZoom->setVisible(false /*yes*/);
@@ -1183,6 +1186,15 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
     if (buttonRole == QDialogButtonBox::AcceptRole ||
             buttonRole == QDialogButtonBox::RejectRole)
         close();
+}
+
+void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state)
+{
+    // playerRememberFilePosition depends on playerKeepHistory
+    bool playerKeepHistoryEnabled = state == Qt::Checked;
+    if (!playerKeepHistoryEnabled)
+        ui->playerRememberFilePosition->setChecked(false);
+    ui->playerRememberFilePosition->setEnabled(playerKeepHistoryEnabled);
 }
 
 void SettingsWindow::on_ccHdrMapper_currentIndexChanged(int index)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -87,6 +87,7 @@ signals:
     void titleBarFormat(Helpers::TitlePrefix format);
     void titleUseMediaTitle(bool yes);
     void rememberHistory(bool yes);
+    void rememberFilePosition(bool yes);
     void rememberSelectedPlaylist(bool yes);
     void rememberWindowGeometry(bool yes);
     void rememberPanNScan(bool yes);
@@ -212,6 +213,8 @@ private slots:
     void on_pageTree_itemSelectionChanged();
 
     void on_buttonBox_clicked(QAbstractButton *button);
+
+    void on_playerKeepHistory_checkStateChanged(Qt::CheckState state);
 
     void on_ccHdrMapper_currentIndexChanged(int index);
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -198,6 +198,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="playerRememberFilePosition">
+                <property name="text">
+                 <string>Remember file position</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="playerRememberLastPlaylist">
                 <property name="text">
                  <string>Remember last selected playlist</string>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3748,6 +3748,10 @@ media file played</translation>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3740,6 +3740,10 @@ archivo multimedia reproducido</translation>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3724,6 +3724,10 @@ media file played</source>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3736,6 +3736,10 @@ ogni file multimediale riprodotto</translation>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3744,6 +3744,10 @@ media file played</source>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3726,6 +3726,10 @@ media file played</source>
         <source>Send key events to mpv</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember file position</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
Enabled by default.
The position is still saved when disabled, but the position isn't resumed.
For real privacy, the "Keep history of recently opened files" option should be disabled instead (and disables this too), but it doesn't do anything right now.