### PR TITLE
Add a command to show/hide the controls in fullscreen

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -601,10 +601,8 @@ void Flow::setupSettingsConnections()
             mainWindow, &MainWindow::setFullscreenOnPlay);
     connect(settingsWindow, &SettingsWindow::fullscreenExitAtEnd,
             mainWindow, &MainWindow::setFullscreenExitOnEnd);
-    connect(settingsWindow, &SettingsWindow::hideMethod,
-            mainWindow, &MainWindow::setBottomAreaBehavior);
-    connect(settingsWindow, &SettingsWindow::hideTime,
-            mainWindow, &MainWindow::setBottomAreaHideTime);
+    connect(settingsWindow, &SettingsWindow::fullscreenHideControls,
+            mainWindow, &MainWindow::setControlsInFullscreen);
     connect(settingsWindow, &SettingsWindow::hidePanels,
             mainWindow, &MainWindow::setFullscreenHidePanels);
     connect(settingsWindow, &SettingsWindow::volumeMax,
@@ -745,6 +743,8 @@ void Flow::setupFlowConnections()
             this, &Flow::mainwindow_optionsOpenRequested);
     connect(mainWindow, &MainWindow::instanceShouldQuit,
             this, &Flow::mainwindow_instanceShouldQuit);
+    connect(mainWindow, &MainWindow::fullscreenHideControls,
+            this, &Flow::mainwindow_fullscreenHideControls);
 
     // manager -> this
     connect(playbackManager, &PlaybackManager::nowPlayingChanged,
@@ -821,6 +821,8 @@ void Flow::setupFlowConnections()
     // this -> mainwindow
     connect(this, &Flow::recentFilesChanged,
             mainWindow, &MainWindow::setRecentDocuments);
+    connect(this, &Flow::fullscreenControls,
+            mainWindow, &MainWindow::setControlsInFullscreen);
 
     // this -> this
     connect(this, &Flow::windowsRestored,
@@ -1130,6 +1132,13 @@ void Flow::mainwindow_instanceShouldQuit()
     endProgram();
 }
 
+void Flow::mainwindow_fullscreenHideControls(bool hide)
+{
+    this->settings["fullscreenHideControls"] = hide;
+    emit fullscreenControls(hide, this->settings.value("fullscreenShowWhen").toInt(), \
+        this->settings.value("fullscreenShowWhenDuration").toInt(), false);
+}
+
 void Flow::mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents)
 {
     // attempt to play the playlist item if possible, otherwise act like it
@@ -1285,6 +1294,7 @@ void Flow::settingswindow_settingsData(const QVariantMap &settings)
     // The selected options have changed, so write them to disk
     this->settings = settings;
     writeConfig(true);
+    LogStream("main") << "settingswindow_settingsData";
 }
 
 void Flow::settingswindow_inhibitScreensaver(bool yes)

--- a/main.h
+++ b/main.h
@@ -38,6 +38,7 @@ public:
 
 signals:
     void recentFilesChanged(QList<TrackInfo> urls);
+    void fullscreenControls(bool hide, int showWhen, int showWhenDuration, bool setControlsInFullscreen = true);
     void windowsRestored();
 
 private:
@@ -62,6 +63,7 @@ private:
 private slots:
     void self_windowsRestored();
     void mainwindow_instanceShouldQuit();
+    void mainwindow_fullscreenHideControls(bool hide);
     void mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents = false);
     void mainwindow_recentClear();
     void mainwindow_takeImage(Helpers::ScreenshotRender render);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -161,6 +161,7 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionViewHideNavigation) },
         { WRAP(ui->actionViewHideLog) },
         { WRAP(ui->actionViewHideLibrary) },
+        { WRAP(ui->actionViewHideControlsInFullscreen) },
         { WRAP(ui->actionViewOntopDefault) },
         { WRAP(ui->actionViewOntopAlways) },
         { WRAP(ui->actionViewOntopPlaying) },
@@ -190,6 +191,7 @@ void MainWindow::setState(const QVariantMap &map)
     UNWRAP(ui->actionViewHideNavigation, false);
     UNWRAP(ui->actionViewHideLog, false);
     UNWRAP(ui->actionViewHideLibrary, false);
+    UNWRAP(ui->actionViewHideControlsInFullscreen, false);
     UNWRAP(ui->actionViewOntopDefault, true);
     UNWRAP(ui->actionViewOntopAlways, false);
     UNWRAP(ui->actionViewOntopPlaying, false);
@@ -2261,6 +2263,16 @@ void MainWindow::on_actionViewHideLibrary_toggled(bool checked)
         emit showLibraryWindow();
     else
         emit hideLibraryWindow();
+}
+
+void MainWindow::on_actionViewHideControlsInFullscreen_toggled(__attribute__((unused)) bool checked)
+{
+    if (fullscreenMode_) {
+        if (ui->bottomArea->isVisible())
+            ui->bottomArea->hide();
+        else
+            ui->bottomArea->show();
+    }
 }
 
 void MainWindow::on_actionViewPresetsMinimal_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -567,6 +567,7 @@ void MainWindow::setupContextMenu()
     contextView->addAction(ui->actionViewHideStatus);
     contextView->addAction(ui->actionViewHideSubresync);
     contextView->addAction(ui->actionViewHidePlaylist);
+    contextView->addAction(ui->actionViewHideControlsInFullscreen);
     contextView->addAction(ui->actionViewHideCapture);
     contextView->addAction(ui->actionViewHideNavigation);
     contextView->addMenu(ui->menuViewPresets);
@@ -1603,6 +1604,25 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
     ui->menuFileRecent->addAction(ui->actionFileRecentClear);
 }
 
+void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration, \
+    bool setControlsInFullscreen = true)
+{
+    if (hide) {
+        Helpers::ControlHiding method = static_cast<Helpers::ControlHiding>(showWhen);
+        if (method == Helpers::ShowWhenMoving && !showWhenDuration) {
+            setBottomAreaBehavior(Helpers::ShowWhenHovering);
+            emit setBottomAreaHideTime(0);
+        } else {
+            setBottomAreaBehavior(method);
+            emit setBottomAreaHideTime(showWhenDuration);
+        }
+    } else
+        setBottomAreaBehavior(Helpers::AlwaysShow);
+
+    if (setControlsInFullscreen)
+        ui->actionViewHideControlsInFullscreen->setChecked(!hide);
+}
+
 void MainWindow::setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> streams)
 {
     auto addAction = [&](QAction *a) {
@@ -2265,14 +2285,9 @@ void MainWindow::on_actionViewHideLibrary_toggled(bool checked)
         emit hideLibraryWindow();
 }
 
-void MainWindow::on_actionViewHideControlsInFullscreen_toggled(__attribute__((unused)) bool checked)
+void MainWindow::on_actionViewHideControlsInFullscreen_toggled(bool checked)
 {
-    if (fullscreenMode_) {
-        if (ui->bottomArea->isVisible())
-            ui->bottomArea->hide();
-        else
-            ui->bottomArea->show();
-    }
+    emit fullscreenHideControls(!checked);
 }
 
 void MainWindow::on_actionViewPresetsMinimal_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -291,6 +291,7 @@ private slots:
     void on_actionViewHideNavigation_toggled(bool checked);
     void on_actionViewHideLog_toggled(bool checked);
     void on_actionViewHideLibrary_toggled(bool checked);
+    void on_actionViewHideControlsInFullscreen_toggled(bool checked);
 
     void on_actionViewOSDNone_triggered();
     void on_actionViewOSDMessages_triggered();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -157,6 +157,7 @@ signals:
     void playCurrentItemRequested();
     void favoriteCurrentTrack();
     void organizeFavorites();
+    void fullscreenHideControls(bool checked);
 
 public slots:
     void httpQuickOpenFile();
@@ -215,6 +216,7 @@ public slots:
     void setWindowedMouseMap(const MouseStateMap &map);
     void setFullscreenMouseMap(const MouseStateMap &map);
     void setRecentDocuments(QList<TrackInfo> tracks);
+    void setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration, bool setControlsInFullscreen);
     void setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> streams);
     void setIconTheme(IconThemer::FolderMode mode, QString fallback, QString custom);
     void setHighContrastWidgets(bool yes);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -718,6 +718,7 @@
     <addaction name="actionViewHideNavigation"/>
     <addaction name="actionViewHideLog"/>
     <addaction name="actionViewHideLibrary"/>
+    <addaction name="actionViewHideControlsInFullscreen"/>
     <addaction name="menuOSD"/>
     <addaction name="menuViewPresets"/>
     <addaction name="separator"/>
@@ -1991,6 +1992,17 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+=</string>
+   </property>
+  </action>
+  <action name="actionViewHideControlsInFullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Controls in Fullscreen</string>
+   </property>
+   <property name="shortcut">
+    <string>i</string>
    </property>
   </action>
   <action name="actionPlaySubtitlesCopy">

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -900,21 +900,9 @@ void SettingsWindow::sendSignals()
     emit fullscreenScreen(WIDGET_LOOKUP(screenCombo).toString());
     emit fullscreenAtLaunch(WIDGET_LOOKUP(ui->fullscreenLaunch).toBool());
     emit fullscreenExitAtEnd(WIDGET_LOOKUP(ui->fullscreenWindowedAtEnd).toBool());
-    if (WIDGET_LOOKUP(ui->fullscreenHideControls).toBool()) {
-        Helpers::ControlHiding method = static_cast<Helpers::ControlHiding>(WIDGET_LOOKUP(ui->fullscreenShowWhen).toInt());
-        int timeOut = WIDGET_LOOKUP(ui->fullscreenShowWhenDuration).toInt();
-        if (method == Helpers::ShowWhenMoving && !timeOut) {
-            emit hideMethod(Helpers::ShowWhenHovering);
-            emit hideTime(0);
-        } else {
-            emit hideMethod(method);
-            emit hideTime(timeOut);
-        }
-        emit hidePanels(WIDGET_LOOKUP(ui->fullscreenHidePanels).toBool());
-    } else {
-        emit hideMethod(Helpers::AlwaysShow);
-        emit hidePanels(false);
-    }
+    emit fullscreenHideControls(WIDGET_LOOKUP(ui->fullscreenHideControls).toBool(), \
+        WIDGET_LOOKUP(ui->fullscreenShowWhen).toInt(), WIDGET_LOOKUP(ui->fullscreenShowWhenDuration).toInt());
+    emit hidePanels(WIDGET_LOOKUP(ui->fullscreenHidePanels).toBool());
     emit option("framedrop", WIDGET_TO_TEXT(ui->framedroppingMode));
     emit option("vf-lavc-framedrop", WIDGET_TO_TEXT(ui->framedroppingDecoderMode));
     emit option("video-sync-adrop-size", WIDGET_LOOKUP(ui->syncAudioDropSize).toDouble());
@@ -1315,7 +1303,6 @@ void SettingsWindow::on_fullscreenHideControls_toggled(bool checked)
 {
     ui->fullscreenShowWhen->setEnabled(checked);
     ui->fullscreenShowWhenDuration->setEnabled(checked);
-    ui->fullscreenHidePanels->setEnabled(checked);
 }
 
 void SettingsWindow::on_playbackAutoZoom_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -131,8 +131,7 @@ signals:
     void fullscreenScreen(QString screen);
     void fullscreenAtLaunch(bool yes);
     void fullscreenExitAtEnd(bool yes);
-    void hideMethod(Helpers::ControlHiding method);
-    void hideTime(int milliseconds);
+    void fullscreenHideControls(bool yes, int showWhen, int showWhenDuration, bool setControlsInFullscreen = true);
     void hidePanels(bool yes);
 
     void playbackPlayTimes(int count);

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1237,6 +1237,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation>&amp;Copy Subtitle</translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1233,6 +1233,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1233,6 +1233,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1233,6 +1233,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1237,6 +1237,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation>&amp;Скопировать субтитры</translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1233,6 +1233,14 @@
         <source>&amp;Copy Subtitle</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Controls in Fullscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>i</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Instead of moving the mouse, just pressing i (by default) shows/hides the controls while in fullscreen.