### PR TITLE
Cleanup code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1236,7 +1236,8 @@ void Flow::manager_stateChanged(PlaybackManager::PlaybackState state)
 
     // If inhibiting the screensaver is switched off, or we just entered the
     // stopped or paused state, unihibit the screensaver
-    if (!inhibitScreensaver || state == PlaybackManager::StoppedState || state == PlaybackManager::PausedState) {
+    if (!inhibitScreensaver || state == PlaybackManager::StoppedState
+                            || state == PlaybackManager::PausedState) {
         screenSaver->uninhibitSaver();
         return;
     }
@@ -1259,8 +1260,10 @@ void Flow::manager_hasNoSubtitles(bool none)
     nowPlayingNoSubtitleTracks = none;
 }
 
-void Flow::manager_nowPlayingChanged(QUrl url, QUuid listUuid, QUuid itemUuid) {
-    updateRecentPosition();
+void Flow::manager_nowPlayingChanged(__attribute__((unused)) QUrl url,
+                                     __attribute__((unused)) QUuid listUuid,
+                                     __attribute__((unused)) QUuid itemUuid) {
+    updateRecentPosition(false);
 }
 
 void Flow::manager_startingPlayingFile(QUrl url)
@@ -1413,7 +1416,8 @@ void Flow::updateRecentPosition(bool resetPosition)
 }
 
 // Update the Recents list
-void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length, double position)
+void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length,
+                         double position)
 {
     // Insert playing track as the most recent item
     TrackInfo track(url, listUuid, itemUuid, title, length, position);
@@ -1434,7 +1438,7 @@ void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title
 void Flow::endProgram()
 {
     Logger::log("main", "endProgram");
-    updateRecentPosition();
+    updateRecentPosition(false);
     // We're about to quit, so write out our config
     writeConfig();
     QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);

--- a/main.h
+++ b/main.h
@@ -38,7 +38,8 @@ public:
 
 signals:
     void recentFilesChanged(QList<TrackInfo> urls);
-    void fullscreenControls(bool hide, int showWhen, int showWhenDuration, bool setControlsInFullscreen = true);
+    void fullscreenControls(bool hide, int showWhen, int showWhenDuration,
+                            bool setControlsInFullscreen = true);
     void windowsRestored();
 
 private:
@@ -51,7 +52,7 @@ private:
     void setupFlowConnections();
     void setupMpris();
     void setupMpcHc();
-    void updateRecentPosition(bool resetPosition = false);
+    void updateRecentPosition(bool resetPosition);
     void updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length, double position);
     QByteArray makePayload() const;
     QString pictureTemplate(Helpers::DisabledTrack tracks, Helpers::Subtitles subs) const;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1604,8 +1604,8 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
     ui->menuFileRecent->addAction(ui->actionFileRecentClear);
 }
 
-void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration, \
-    bool setControlsInFullscreen = true)
+void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration,
+                                         bool setControlsInFullscreen = true)
 {
     if (hide) {
         Helpers::ControlHiding method = static_cast<Helpers::ControlHiding>(showWhen);

--- a/manager.cpp
+++ b/manager.cpp
@@ -514,7 +514,8 @@ void PlaybackManager::sendCurrentTrackInfo()
                            nowPlayingTitle, mpvLength, mpvTime});
 }
 
-void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString title, double& length, double& position)
+void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString title,
+                                          double& length, double& position)
 {
     url = playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem);
     listUuid = nowPlayingList;

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -131,7 +131,8 @@ signals:
     void fullscreenScreen(QString screen);
     void fullscreenAtLaunch(bool yes);
     void fullscreenExitAtEnd(bool yes);
-    void fullscreenHideControls(bool yes, int showWhen, int showWhenDuration, bool setControlsInFullscreen = true);
+    void fullscreenHideControls(bool yes, int showWhen, int showWhenDuration,
+                                bool setControlsInFullscreen = true);
     void hidePanels(bool yes);
 
     void playbackPlayTimes(int count);


### PR DESCRIPTION
Remove unnecessary default argument
Split long lines from previous PRs
Prevent warning for unused arguments