### PR TITLE
Fix MSYS2

### DIFF
--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -13,10 +13,12 @@ TEMPLATE = app
 
 CONFIG += c++14
 
-DESTDIR=bin
-OBJECTS_DIR=.obj
-MOC_DIR=.moc
-UI_DIR=.ui
+unix {
+    DESTDIR=bin
+    OBJECTS_DIR=.obj
+    MOC_DIR=.moc
+    UI_DIR=.ui
+}
 
 !isEmpty(MPCQT_VERSION) {
     message("Version provided on the commandline: $$MPCQT_VERSION")


### PR DESCRIPTION
Only use subdirs for unix build because windres doesn't like subdirs (hence the "syntax error" message).