### PR TITLE
Switch to C++17 and replace qAsConst with standard C++ feature

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -636,7 +636,7 @@ void IconThemer::setIconFolders(FolderMode folderMode,
     mode = folderMode;
     fallback = fallbackFolder;
     custom = customFolder;
-    for (const IconData &data : qAsConst(iconDataList))
+    for (const IconData &data : std::as_const(iconDataList))
         updateButton(data);
 }
 

--- a/logger.cpp
+++ b/logger.cpp
@@ -139,7 +139,7 @@ void Logger::fatalMessage()
     // Oops!  Something went very wrong!
     // Try to flush anything pending to stderr and abort
     if (loggerInstance) {
-        for (const auto &i : qAsConst(loggerInstance->pendingMessages))
+        for (const auto &i : std::as_const(loggerInstance->pendingMessages))
             std::fprintf(realStdErr.ptr, "%s\n", i.toLocal8Bit().data());
     }
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1654,7 +1654,7 @@ void MainWindow::setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> stre
         }
     };
 
-    for (auto a : qAsConst(menuFavoritesTail))
+    for (auto a : std::as_const(menuFavoritesTail))
         delete a;
     menuFavoritesTail.clear();
 

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -11,7 +11,7 @@ QMAKE_CXXFLAGS += -Wall
 TARGET = mpc-qt
 TEMPLATE = app
 
-CONFIG += c++14
+CONFIG += c++17
 
 unix {
     DESTDIR=bin

--- a/platform/devicemanager.cpp
+++ b/platform/devicemanager.cpp
@@ -65,7 +65,7 @@ void DeviceManager::removeDeviceById(int id)
 
 void DeviceManager::iterateDevices(std::function<void(DeviceInfo *)> callback)
 {
-    for (auto i : qAsConst(devices)) {
+    for (auto i : std::as_const(devices)) {
         callback(i);
     }
 }

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -657,7 +657,7 @@ void SettingsWindow::setAudioDevices(const QList<AudioDevice> &devices)
 {
     audioDevices = devices;
     ui->audioDevice->clear();
-    for (const AudioDevice &device : qAsConst(audioDevices))
+    for (const AudioDevice &device : std::as_const(audioDevices))
         ui->audioDevice->addItem(device.displayString());
 }
 

--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -87,7 +87,7 @@ void ActionEditor::setCommand(int index, const Command &c)
 void ActionEditor::updateActions()
 {
     MouseStateMap fullscreen, windowed;
-    for (const Command &c : qAsConst(commands)) {
+    for (const Command &c : std::as_const(commands)) {
         c.action->setShortcut(c.keys);
         if (!!c.mouseFullscreen)
             fullscreen[c.mouseFullscreen] = c.action;


### PR DESCRIPTION
Switch to c++17 (gcc default since version 11).

Replace qAsConst with std::as_const
qAsConst is deprecated with Qt6, c++17 introduced std::as_const which does the exact same thing.