### PR TITLE
Add radio buttons in the Audio, Subtitles and Video Stream menus

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -718,6 +718,14 @@ void Flow::setupMpvObjectConnections()
     connect(mpvObject, &MpvObject::chaptersChanged,
             propertiesWindow, &PropertiesWindow::setChapters);
 
+    // mpvwidget -> mainwindow
+    connect(mpvObject, &MpvObject::audioTrackSet,
+            mainWindow, &MainWindow::audioTrackSet);
+    connect(mpvObject, &MpvObject::subtitleTrackSet,
+            mainWindow, &MainWindow::subtitleTrackSet);
+    connect(mpvObject, &MpvObject::videoTrackSet,
+            mainWindow, &MainWindow::videoTrackSet);
+
     // settingswindow -> log
     auto logger = Logger::singleton();
     connect(settingsWindow, &SettingsWindow::loggingEnabled,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1885,37 +1885,50 @@ void MainWindow::setChapters(QList<QPair<double, QString>> chapters)
 void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayAudio->clear();
+    audioTracksGroup = new QActionGroup(this);
+    hasAudio = !tracks.isEmpty();
+    if (!hasAudio)
+        return;
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
+        action->setCheckable(true);
+        action->setActionGroup(audioTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index] {
             emit audioTrackSelected(index);
         });
         ui->menuPlayAudio->addAction(action);
     }
-    hasAudio = !tracks.isEmpty();
+    audioTracksGroup->actions()[0]->setChecked(true);
 }
 
 void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayVideo->clear();
+    videoTracksGroup = new QActionGroup(this);
+    hasVideo = !tracks.isEmpty();
+    if (!hasVideo)
+        return;
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
+        action->setCheckable(true);
+        action->setActionGroup(videoTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index]() {
-           emit videoTrackSelected(index);
+            emit videoTrackSelected(index);
         });
         ui->menuPlayVideo->addAction(action);
     }
-    hasVideo = !tracks.isEmpty();
+    videoTracksGroup->actions()[0]->setChecked(true);
     updateOnTop();
 }
 
 void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
 {
     ui->menuPlaySubtitles->clear();
+    subtitleTracksGroup = new QActionGroup(this);
     hasSubs = !tracks.isEmpty();
     ui->actionPlaySubtitlesEnabled->setEnabled(hasSubs);
     ui->subs->setEnabled(hasSubs);
@@ -1931,11 +1944,35 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
+        action->setCheckable(true);
+        action->setActionGroup(subtitleTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit subtitleTrackSelected(index);
         });
         ui->menuPlaySubtitles->addAction(action);
+    }
+    subtitleTracksGroup->actions()[0]->setChecked(true);
+}
+
+void MainWindow::audioTrackSet(int64_t id)
+{
+    if (audioTracksGroup != nullptr)
+        audioTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+}
+
+void MainWindow::videoTrackSet(int64_t id)
+{
+    if (videoTracksGroup != nullptr)
+        videoTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+}
+
+void MainWindow::subtitleTrackSet(int64_t id)
+{
+    if (subtitleTracksGroup != nullptr) {
+        if (id == 0)
+            id = subtitleTracksGroup->actions().length();
+        subtitleTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -248,6 +248,9 @@ public slots:
     void setAudioTracks(QList<QPair<int64_t,QString>> tracks);
     void setVideoTracks(QList<QPair<int64_t,QString>> tracks);
     void setSubtitleTracks(QList<QPair<int64_t,QString>> tracks);
+    void audioTrackSet(int64_t id);
+    void videoTrackSet(int64_t id);
+    void subtitleTrackSet(int64_t id);
     void setSubtitleText(QString subText);
     void setVolume(int level);
     void setVolumeDouble(double level);
@@ -410,6 +413,9 @@ private:
     QMenu *trayMenu = nullptr;
     QTimer hideTimer;
     QSystemTrayIcon *trayIcon = nullptr;
+    QActionGroup* audioTracksGroup = nullptr;
+    QActionGroup* videoTracksGroup = nullptr;
+    QActionGroup* subtitleTracksGroup = nullptr;
 
     bool freestanding_ = false;
     DecorationState decorationState_ = AllDecorations;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -466,16 +466,19 @@ void MpvObject::setLoopPoints(double first, double end)
 void MpvObject::setAudioTrack(int64_t id)
 {
     setMpvPropertyVariant("aid", qlonglong(id));
+    emit audioTrackSet(id);
 }
 
 void MpvObject::setSubtitleTrack(int64_t id)
 {
     setMpvPropertyVariant("sid", qlonglong(id));
+    emit subtitleTrackSet(id);
 }
 
 void MpvObject::setVideoTrack(int64_t id)
 {
     setMpvPropertyVariant("vid", qlonglong(id));
+    emit videoTrackSet(id);
 }
 
 void MpvObject::setDrawLogo(bool yes)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -132,6 +132,10 @@ signals:
     void subTextChanged(QString subText);
     void playlistChanged(QVariantList playlist);
 
+    void audioTrackSet(int64_t id);
+    void subtitleTrackSet(int64_t id);
+    void videoTrackSet(int64_t id);
+
     void logoSizeChanged(QSize size);
 
     void mouseMoved(int x, int y);


### PR DESCRIPTION
Adds radio buttons in the Audio, Subtitles and Video Stream menus, showing the selected one.
Because calling MpvObject::setMpvPropertyVariant while using radio buttons (instead of checkboxes) leads to strange behavior, we need to check the right button manually. Otherwise, two clicks are needed.

Fixes #106