### PR TITLE
Add missing tooltips translations

### DIFF
--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1265,6 +1265,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">Subtitles</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1261,6 +1261,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">Subtítulos</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1257,6 +1257,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1261,6 +1261,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">Sottotitoli</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1265,6 +1265,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">Субтитры</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1261,6 +1261,14 @@
         <source>Play next &amp;file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Subtitles</source>
+        <translation type="unfinished">字幕</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Add translations missing from "Add missing tooltips to bottom bar (mainwindow)" (8ff20e75d5cf6e91c80fca34368f9b506b0eb369)