### PR TITLE
Improve seekbar tooltip

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -456,6 +456,8 @@ void Flow::setupMainWindowConnections()
             playbackManager, &PlaybackManager::setAfterPlaybackOnce);
     connect(mainWindow, &MainWindow::afterPlaybackAlways,
             playbackManager, &PlaybackManager::setAfterPlaybackAlways);
+    connect(mainWindow, &MainWindow::timeShortModeSet,
+            playbackManager, &PlaybackManager::setTimeShortMode);
     connect(mainWindow, &MainWindow::chapterPrevious,
             playbackManager, &PlaybackManager::navigateToPrevChapter);
     connect(mainWindow, &MainWindow::chapterNext,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2002,6 +2002,8 @@ void MainWindow::setTimeShortMode(bool shortened)
 {
     timePosition->setShortMode(shortened);
     timeDuration->setShortMode(shortened);
+    timeShortMode = shortened;
+    emit timeShortModeSet(timeShortMode);
 }
 
 void MainWindow::resetPlayAfterOnce()
@@ -2827,7 +2829,9 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
     if (!timeTooltipShown)
         return;
 
-    QString t = QString("%1%2%3").arg(Helpers::toDateFormat(position),
+    QString t = QString("%1%2%3").arg(Helpers::toDateFormatFixed(
+                                            position,
+                                            timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
     QPoint where = positionSlider_->mapToGlobal(QPoint(int(x), timeTooltipAbove ? -40 : 0));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2822,14 +2822,14 @@ void MainWindow::position_sliderMoved(int position)
     emit timeSelected(position);
 }
 
-void MainWindow::position_hoverValue(double value, QString text, double x)
+void MainWindow::position_hoverValue(double position, QString chapterInfo, double x)
 {
     if (!timeTooltipShown)
         return;
-    if (text.isEmpty())
-        text = tr("<unknown>");
+    if (chapterInfo.isEmpty())
+        chapterInfo = tr("<unknown>");
 
-    QString t = QString("%1 - %2").arg(Helpers::toDateFormat(value), text);
+    QString t = QString("%1 - %2").arg(Helpers::toDateFormat(position), chapterInfo);
     QPoint where = positionSlider_->mapToGlobal(QPoint(int(x), timeTooltipAbove ? -40 : 0));
     QToolTip::showText(where, t, positionSlider_);
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2826,10 +2826,10 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
 {
     if (!timeTooltipShown)
         return;
-    if (chapterInfo.isEmpty())
-        chapterInfo = tr("<unknown>");
 
-    QString t = QString("%1 - %2").arg(Helpers::toDateFormat(position), chapterInfo);
+    QString t = QString("%1%2%3").arg(Helpers::toDateFormat(position),
+                                      chapterInfo.isEmpty() ? "" : " - ",
+                                      chapterInfo);
     QPoint where = positionSlider_->mapToGlobal(QPoint(int(x), timeTooltipAbove ? -40 : 0));
     QToolTip::showText(where, t, positionSlider_);
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -160,6 +160,7 @@ signals:
     void favoriteCurrentTrack();
     void organizeFavorites();
     void fullscreenHideControls(bool checked);
+    void timeShortModeSet(bool timeShortMode);
 
 public slots:
     void httpQuickOpenFile();
@@ -431,6 +432,7 @@ private:
     int bottomAreaHideTime = 0;
     bool timeTooltipShown = true;
     bool timeTooltipAbove = true;
+    bool timeShortMode = false;
 
     QString previousOpenDir;
     QSize noVideoSize_ = QSize(500,270);

--- a/manager.cpp
+++ b/manager.cpp
@@ -481,6 +481,11 @@ void PlaybackManager::setAfterPlaybackAlwaysDefault(Helpers::AfterPlayback mode)
     }
 }
 
+void PlaybackManager::setTimeShortMode(bool shortMode)
+{
+    timeShortMode = shortMode;
+}
+
 void PlaybackManager::setSubtitlesPreferDefaultForced(bool forced)
 {
     subtitlesPreferDefaultForced = forced;
@@ -838,7 +843,8 @@ void PlaybackManager::mpvw_chaptersChanged(QVariantList chapters)
     for (QVariant &v : chapters) {
         QMap<QString, QVariant> node = v.toMap();
         QString text = QString("[%1] - %2").arg(
-                toDateFormat(node["time"].toDouble()),
+                toDateFormatFixed(node["time"].toDouble(),
+                                  timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
                 node["title"].toString());
         QPair<double,QString> item(node["time"].toDouble(), text);
         list.append(item);

--- a/manager.h
+++ b/manager.h
@@ -158,6 +158,7 @@ private:
                            bool isRepeating, QUrl with = QUrl());
     void selectDesiredTracks();
     void updateSubtitleTrack();
+    void updateChapters();
     void checkAfterPlayback();
     void playNextTrack();
     void playPrevTrack();
@@ -213,6 +214,7 @@ private:
     QList<QPair<int64_t,QString>> subtitleList;
     QMap<int64_t,TrackData> audioListData;
     QMap<int64_t,TrackData> subtitleListData;
+    QVariantList chapters = QVariantList();
 
     QStringList audioLangPref;
     QStringList subtitleLangPref;

--- a/manager.h
+++ b/manager.h
@@ -139,6 +139,7 @@ public slots:
     void setAfterPlaybackOnce(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlways(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlwaysDefault(Helpers::AfterPlayback mode);
+    void setTimeShortMode(bool shortMode);
     void setSubtitlesPreferDefaultForced(bool forced);
     void setSubtitlesPreferExternal(bool external);
     void setSubtitlesIgnoreEmbedded(bool ignore);
@@ -229,6 +230,8 @@ private:
     bool playbackStartPaused = false;
     bool playbackForever = false;
     bool folderFallback = false;
+
+    bool timeShortMode = false;
 
     Helpers::AfterPlayback afterPlaybackOnce = Helpers::DoNothingAfter;
     Helpers::AfterPlayback afterPlaybackAlways = Helpers::DoNothingAfter;

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1219,7 +1219,7 @@
     </message>
     <message>
         <source>&lt;unknown&gt;</source>
-        <translation>&lt;unknown&gt;</translation>
+        <translation type="vanished">&lt;unknown&gt;</translation>
     </message>
     <message>
         <source>Libr&amp;ary</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1214,10 +1214,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;unknown&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Libr&amp;ary</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1210,10 +1210,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;unknown&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Libr&amp;ary</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1214,10 +1214,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;unknown&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Libr&amp;ary</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1219,7 +1219,7 @@
     </message>
     <message>
         <source>&lt;unknown&gt;</source>
-        <translation>&lt;неизвестно&gt;</translation>
+        <translation type="vanished">&lt;неизвестно&gt;</translation>
     </message>
     <message>
         <source>Libr&amp;ary</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1214,10 +1214,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&lt;unknown&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Libr&amp;ary</source>
         <translation type="unfinished"></translation>
     </message>

--- a/widgets/drawnslider.h
+++ b/widgets/drawnslider.h
@@ -87,7 +87,7 @@ public:
 signals:
     void hoverBegin();
     void hoverEnd();
-    void hoverValue(double value, QString text, double x);
+    void hoverValue(double position, QString chapterInfo, double x);
 
 protected:
     void resizeEvent(QResizeEvent *event);


### PR DESCRIPTION
Improve readability of parameters in MainWindow::position_hoverValue

Don't show chapter info in the seekbar tooltip when there are no chapters. No more " - <unknown>" in the tooltip.

Make the seekbar tooltip follow the playback time short mode setting in Tweaks. "00:00:00" instead of "00:00:00.000".
Note that MPC-HC had always had a bug where the chapter time was always shown in long mode.

Update the chapters when changing the playback time short mode option.