### PR TITLE
Enable by default short time indicator option

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7675,6 +7675,9 @@ media file played</string>
              <property name="text">
               <string>Shorten the playback time indicator like mpc-hc</string>
              </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="6" column="0" colspan="2">


### PR DESCRIPTION
Enable by default the "Shorten the playback time indicator like mpc-hc" option which applies to both normal time indicator and seekbar tooltip.