### PR TITLE
Fix current file position not remembered when opening new file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -763,6 +763,8 @@ void Flow::setupFlowConnections()
     // manager -> this
     connect(playbackManager, &PlaybackManager::playLengthChanged,
             this, &Flow::manager_playLengthChanged);
+    connect(playbackManager, &PlaybackManager::openingNewFile,
+            this, &Flow::manager_openingNewFile);
     connect(playbackManager, &PlaybackManager::startingPlayingFile,
             this, &Flow::manager_startingPlayingFile);
     connect(playbackManager, &PlaybackManager::stoppedPlaying,
@@ -1276,6 +1278,11 @@ void Flow::manager_hasNoSubtitles(bool none)
 
 void Flow::manager_playLengthChanged() {
     LogStream("main") << "manager_playLengthChanged";
+    updateRecentPosition(false);
+}
+
+void Flow::manager_openingNewFile()
+{
     updateRecentPosition(false);
 }
 

--- a/main.h
+++ b/main.h
@@ -75,6 +75,7 @@ private slots:
     void manager_stateChanged(PlaybackManager::PlaybackState state);
     void manager_subtitlesVisible(bool visible);
     void manager_hasNoSubtitles(bool none);
+    void manager_openingNewFile();
     void manager_startingPlayingFile(QUrl url);
     void manager_stoppedPlaying();
     void mpcHcServer_fileSelected(QString fileName);

--- a/manager.cpp
+++ b/manager.cpp
@@ -125,6 +125,9 @@ PlaybackManager::PlaybackState PlaybackManager::playbackState()
 
 void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
 {
+    if (!nowPlayingItem.isNull())
+        emit openingNewFile();
+
     if (important) {
         playlistWindow_->setCurrentPlaylist(QUuid());
         playlistWindow_->clearPlaylist(QUuid());
@@ -141,6 +144,9 @@ void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
 
 void PlaybackManager::openFile(QUrl what, QUrl with)
 {
+    if (!nowPlayingItem.isNull())
+        emit openingNewFile();
+
     auto info = playlistWindow_->urlToQuickPlaylist(what);
     if (!info.second.isNull()) {
         QUrl urlToPlay = playlistWindow_->getUrlOf(info.first, info.second);

--- a/manager.h
+++ b/manager.h
@@ -74,6 +74,7 @@ signals:
     void systemShouldStandby();
     void systemShouldHibernate();
     void currentTrackInfo(TrackInfo track);
+    void openingNewFile();
     void startingPlayingFile(QUrl url);
     void stoppedPlaying();
 


### PR DESCRIPTION
When opening a new file through File -> Open File or the files manager: if a file is already opened, save its current position.