### PR TITLE
Don't update recents with current file when it's null

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1433,7 +1433,8 @@ void Flow::updateRecentPosition(bool resetPosition)
     double length;
     double position;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position);
-    updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position);
+    if (!itemUuid.isNull())
+        updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position);
 }
 
 // Update the Recents list


### PR DESCRIPTION
When stopping playing a file, updateRecentPosition gets triggered by playLengthChanged (since 418f808 ("Recents and eof fixes for play next/previous in folder", 2024-08-26)).
But since no new file is being played, an empty recent file is added to the list.
This prevents that from happening.

Fixes #161