### PR TITLE
Support full file seamless loop

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2639,14 +2639,17 @@ void MainWindow::on_actionPlayLoopEnd_triggered()
 
 void MainWindow::on_actionPlayLoopUse_triggered(bool checked)
 {
-    if (checked && !positionSlider_->isLoopEmpty()) {
+    if (checked) {
+        if (positionSlider_->loopA() < 0)
+            positionSlider_->setLoopA(0);
+        if (positionSlider_->loopB() < 0 )
+            positionSlider_->setLoopB(mpvObject_->playLength());
+
         mpvObject_->setLoopPoints(positionSlider_->loopA(),
                                   positionSlider_->loopB());
-    } else if (checked) {
-        ui->actionPlayLoopUse->setChecked(false);
-    } else {
-        mpvObject_->setLoopPoints(-1, -1);
     }
+    else
+        mpvObject_->setLoopPoints(-1, -1);
 }
 
 void MainWindow::on_actionPlayLoopClear_triggered()

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1648,7 +1648,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>&amp;Use Loop Points</string>
+    <string>&amp;Repeat</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Backspace</string>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -851,7 +851,7 @@
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
-        <translation>&amp;Use Loop Points</translation>
+        <translation type="vanished">&amp;Use Loop Points</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -851,7 +851,7 @@
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
-        <translation>&amp;Usar los puntos del bucle</translation>
+        <translation type="vanished">&amp;Usar los puntos del bucle</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -846,10 +846,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Use Loop Points</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Ctrl+Backspace</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -851,7 +851,7 @@
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
-        <translation>&amp;Usa punti di ciclo</translation>
+        <translation type="vanished">&amp;Usa punti di ciclo</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -851,7 +851,7 @@
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
-        <translation>&amp;Использовать точки цикла</translation>
+        <translation type="vanished">&amp;Использовать точки цикла</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -851,7 +851,7 @@
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
-        <translation>使用循环点(&amp;U)</translation>
+        <translation type="vanished">使用循环点(&amp;U)</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>

--- a/widgets/drawnslider.cpp
+++ b/widgets/drawnslider.cpp
@@ -333,11 +333,6 @@ double MediaSlider::loopB() {
     return vLoopB;
 }
 
-bool MediaSlider::isLoopEmpty()
-{
-    return vLoopA < 0 || vLoopB < 0;
-}
-
 void MediaSlider::resizeEvent(QResizeEvent *event)
 {
     DrawnSlider::resizeEvent(event);

--- a/widgets/drawnslider.h
+++ b/widgets/drawnslider.h
@@ -82,7 +82,6 @@ public:
     void setLoopB(double b);
     double loopA();
     double loopB();
-    bool isLoopEmpty();
 
 signals:
     void hoverBegin();


### PR DESCRIPTION
Unlike "Play > After Playback > Repeat", this uses mpv's ab-loop-a and ab-loop-b, which allows a seamless loop.
Enabling repeat sets by default the loop points at the start and end of the file.

#50