### PR TITLE
Fix early finish

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -70,6 +70,8 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_pausedChanged);
         connect(mpvObject, &MpvObject::playbackIdling,
                 this, &PlaybackManager::mpvw_playbackIdling);
+        connect(mpvObject, &MpvObject::playbackFinished,
+                this, &PlaybackManager::mpvw_playbackFinished);
         connect(mpvObject, &MpvObject::eofReachedChanged,
                 this, &PlaybackManager::mpvw_eofReachedChanged);
         connect(mpvObject, &MpvObject::mediaTitleChanged,
@@ -837,6 +839,14 @@ void PlaybackManager::mpvw_playbackIdling()
         playbackState_ = StoppedState;
         emit stateChanged(playbackState_);
         return;
+    }
+}
+
+void PlaybackManager::mpvw_playbackFinished() {
+    if (playbackState_ == BufferingState || playbackState_ == WaitingState) {
+        playbackState_ = StoppedState;
+        emit stateChanged(playbackState_);
+        mpvw_eofReachedChanged(true);
     }
 }
 

--- a/manager.h
+++ b/manager.h
@@ -176,6 +176,7 @@ private slots:
     void mpvw_playbackStarted();
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling();
+    void mpvw_playbackFinished();
     void mpvw_eofReachedChanged(bool eof);
     void mpvw_mediaTitleChanged(QString title);
     void mpvw_chapterDataChanged(QVariantMap metadata);


### PR DESCRIPTION
Fake a file end event when a file does not properly initialize.

Consider the case where a stream is opened but fails to properly initialize such as the url https://chiru.no:8000/stream.mp3.  In these scenarios libmpv would finish playback before it starts, and the player would be stuck in the Buffering state.  We need to progress to the next file in the playlist.  We need to get out of the Buffering state when there is no file after us in the playlist.  So send a stopped state event and jump to the code that handles an end of file event.  This mimics the behviour of mpc-hc from my tests.