### PR TITLE
Remember audio, video and subtitle tracks

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -886,7 +886,8 @@ QString DisplayParser::parseMetadata(QVariantMap metaData,
 
 
 
-TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length, double position)
+TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length,
+                     double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack)
 {
     this->url = url;
     this->list = list;
@@ -894,13 +895,18 @@ TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QStr
     this->text = text.isEmpty() ? url.toString() : text;
     this->length = length;
     this->position = position;
+    this->videoTrack = videoTrack;
+    this->audioTrack = audioTrack;
+    this->subtitleTrack = subtitleTrack;
 }
 
 QVariantMap TrackInfo::toVMap() const
 {
     return QVariantMap({{"url", url}, {"list", list}, {"item", item},
                         {"text", text}, {"length", length},
-                        {"position", position}});
+                        {"position", position}, {"videoTrack", (long long) videoTrack},
+                        {"audioTrack", (long long) audioTrack},
+                        {"subtitleTrack", (long long) subtitleTrack}});
 }
 
 void TrackInfo::fromVMap(const QVariantMap &map)
@@ -913,6 +919,9 @@ void TrackInfo::fromVMap(const QVariantMap &map)
         text = url.toString();
     length = map.value("length").toDouble();
     position = map.value("position").toDouble();
+    videoTrack = map.value("videoTrack").toLongLong();
+    audioTrack = map.value("audioTrack").toLongLong();
+    subtitleTrack = map.value("subtitleTrack").toLongLong();
 }
 
 bool TrackInfo::operator ==(const TrackInfo &track) const

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -922,6 +922,11 @@ void TrackInfo::fromVMap(const QVariantMap &map)
     videoTrack = map.value("videoTrack").toLongLong();
     audioTrack = map.value("audioTrack").toLongLong();
     subtitleTrack = map.value("subtitleTrack").toLongLong();
+    // FIXME: this is only needed for as long as users recents and favorites files
+    // don't have a subtitleTrack value for every file, which is fixed as soon as they
+    // use a version that includes this
+    if (subtitleTrack == 0 && map.value("subtitleTrack") != 0)
+        subtitleTrack = -1;
 }
 
 bool TrackInfo::operator ==(const TrackInfo &track) const

--- a/helpers.h
+++ b/helpers.h
@@ -104,13 +104,17 @@ private:
 class TrackInfo {
 public:
     TrackInfo() {}
-    TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length, double position);
+    TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length,
+              double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack);
     QUrl url;
     QUuid list;
     QUuid item;
     QString text;
     double length;
     double position;
+    int64_t videoTrack;
+    int64_t audioTrack;
+    int64_t subtitleTrack;
     QVariantMap toVMap() const;
     void fromVMap(const QVariantMap &map);
     bool operator ==(const TrackInfo &track) const;

--- a/main.cpp
+++ b/main.cpp
@@ -1170,8 +1170,12 @@ void Flow::mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents)
 
     // Navigate to a particular position if set and if this is from the favorites menu
     // or if this is from the recents menu and not disabled
-    if (track.position > 0 && track.url.isLocalFile() && (!isFromRecents || rememberFilePosition))
+    if (track.position > 0 && track.url.isLocalFile() && (!isFromRecents || rememberFilePosition)) {
         playbackManager->navigateToTime(track.position);
+        playbackManager->setVideoTrack(track.videoTrack, true);
+        playbackManager->setAudioTrack(track.audioTrack, true);
+        playbackManager->setSubtitleTrack(track.subtitleTrack, true);
+    }
 }
 
 void Flow::mainwindow_recentClear()
@@ -1301,6 +1305,9 @@ void Flow::manager_startingPlayingFile(QUrl url)
         foreach (TrackInfo track, recentFiles) {
             if (track.url == url) {
                 playbackManager->navigateToTime(track.position);
+                playbackManager->setVideoTrack(track.videoTrack, true);
+                playbackManager->setAudioTrack(track.audioTrack, true);
+                playbackManager->setSubtitleTrack(track.subtitleTrack, true);
                 break;
             }
         }

--- a/main.cpp
+++ b/main.cpp
@@ -1440,17 +1440,23 @@ void Flow::updateRecentPosition(bool resetPosition)
     QString title;
     double length;
     double position;
-    playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position);
+    int64_t videoTrack;
+    int64_t audioTrack;
+    int64_t subtitleTrack;
+    playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
+                                         videoTrack, audioTrack, subtitleTrack);
     if (!itemUuid.isNull())
-        updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position);
+        updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position,
+                      videoTrack, audioTrack, subtitleTrack);
 }
 
 // Update the Recents list
 void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length,
-                         double position)
+                         double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack)
 {
     // Insert playing track as the most recent item
-    TrackInfo track(url, listUuid, itemUuid, title, length, position);
+    TrackInfo track(url, listUuid, itemUuid, title, length, position,
+                    videoTrack, audioTrack, subtitleTrack);
     if (recentFiles.contains(track)) {
         // Remove all prior mention of it
         recentFiles.removeAll(track);

--- a/main.h
+++ b/main.h
@@ -53,7 +53,8 @@ private:
     void setupMpris();
     void setupMpcHc();
     void updateRecentPosition(bool resetPosition);
-    void updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length, double position);
+    void updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title, double length,
+                       double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack);
     QByteArray makePayload() const;
     QString pictureTemplate(Helpers::DisabledTrack tracks, Helpers::Subtitles subs) const;
     QVariantList recentToVList() const;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1910,7 +1910,7 @@ void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
         action->setActionGroup(audioTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index] {
-            emit audioTrackSelected(index);
+            emit audioTrackSelected(index, true);
         });
         ui->menuPlayAudio->addAction(action);
     }
@@ -1933,7 +1933,7 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
         action->setActionGroup(videoTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index]() {
-            emit videoTrackSelected(index);
+            emit videoTrackSelected(index, true);
         });
         ui->menuPlayVideo->addAction(action);
     }
@@ -1966,7 +1966,7 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
         action->setActionGroup(subtitleTracksGroup);
         int64_t index = track.first;
         connect(action, &QAction::triggered, this, [this,index]() {
-            emit subtitleTrackSelected(index);
+            emit subtitleTrackSelected(index, true);
         });
         ui->menuPlaySubtitles->addAction(action);
     }
@@ -1988,7 +1988,7 @@ void MainWindow::videoTrackSet(int64_t id)
 void MainWindow::subtitleTrackSet(int64_t id)
 {
     if (subtitleTracksGroup != nullptr) {
-        if (id == 0)
+        if (id <= 0)
             id = subtitleTracksGroup->actions().length();
         subtitleTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1898,11 +1898,12 @@ void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayAudio->clear();
     ui->menuPlayAudio->setEnabled(false);
-    audioTracksGroup = new QActionGroup(this);
+    audioTracksGroup = nullptr;
     hasAudio = !tracks.isEmpty();
     if (!hasAudio)
         return;
     ui->menuPlayAudio->setEnabled(true);
+    audioTracksGroup = new QActionGroup(this);
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
@@ -1921,11 +1922,12 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayVideo->clear();
     ui->menuPlayVideo->setEnabled(false);
-    videoTracksGroup = new QActionGroup(this);
+    videoTracksGroup = nullptr;
     hasVideo = !tracks.isEmpty();
     if (!hasVideo)
         return;
     ui->menuPlayVideo->setEnabled(true);
+    videoTracksGroup = new QActionGroup(this);
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
@@ -1945,7 +1947,7 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
 {
     ui->menuPlaySubtitles->clear();
     ui->menuPlaySubtitles->setEnabled(false);
-    subtitleTracksGroup = new QActionGroup(this);
+    subtitleTracksGroup = nullptr;
     hasSubs = !tracks.isEmpty();
     ui->actionPlaySubtitlesEnabled->setEnabled(hasSubs);
     ui->subs->setEnabled(hasSubs);
@@ -1954,6 +1956,7 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     if (!hasSubs)
         return;
     ui->menuPlaySubtitles->setEnabled(true);
+    subtitleTracksGroup = new QActionGroup(this);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesEnabled);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesNext);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesPrevious);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -138,9 +138,9 @@ signals:
     void speedUp();
     void speedReset();
     void relativeSeek(bool forwards, bool isSmall);
-    void audioTrackSelected(int64_t id);
-    void subtitleTrackSelected(int64_t id);
-    void videoTrackSelected(int64_t id);
+    void audioTrackSelected(int64_t id, bool userSelected);
+    void subtitleTrackSelected(int64_t id, bool userSelected);
+    void videoTrackSelected(int64_t id, bool userSelected);
     void subtitlesEnabled(bool enabled);
     void nextSubtitleSelected();
     void previousSubtitleSelected();

--- a/manager.cpp
+++ b/manager.cpp
@@ -390,49 +390,31 @@ void PlaybackManager::setAudioTrackPreference(QString langs)
     audioLangPref = langs.split(*wordSplitter, Qt::SkipEmptyParts);
 }
 
-static QString findSecondById(QList<QPair<int64_t,QString>> list, int64_t id) {
-    // this *should* return the string at id-1
-    for (int i = 0; i < list.count(); ++i)
-        if (list.value(i).first == id)
-            return list.value(i).second;
-    return QString();
+void PlaybackManager::setAudioTrack(int64_t id, bool userSelected)
+{
+    if (id > 0) {
+        if (userSelected)
+            audioTrackSelected = id;
+        mpvObject_->setAudioTrack(id);
+    }
 }
 
-void PlaybackManager::setAudioTrack(int64_t id)
+void PlaybackManager::setSubtitleTrack(int64_t id, bool userSelected)
 {
-    setAudioTrackEx(id, false);
+    if (id >= 0) {
+        if (userSelected)
+            subtitleTrackSelected = id;
+        updateSubtitleTrack();
+    }
 }
 
-void PlaybackManager::setAudioTrackEx(int64_t id, bool softly)
+void PlaybackManager::setVideoTrack(int64_t id, bool userSelected)
 {
-    if (softly)
-        audioListSelected.clear();
-    else
-        audioListSelected = findSecondById(audioList, id);
-    mpvObject_->setAudioTrack(id);
-    audioTrackSelected = id;
-}
-
-void PlaybackManager::setSubtitleTrack(int64_t id)
-{
-    setSubtitleTrackEx(id, false);
-}
-
-void PlaybackManager::setSubtitleTrackEx(int64_t id, bool softly)
-{
-    if (softly)
-        subtitleListSelected.clear();
-    else
-        subtitleListSelected = findSecondById(subtitleList, id);
-    subtitleTrackSelected = id;
-    updateSubtitleTrack();
-}
-
-void PlaybackManager::setVideoTrack(int64_t id)
-{
-    videoListSelected = findSecondById(videoList, id);
-    mpvObject_->setVideoTrack(id);
-    videoTrackSelected = id;
+    if (id > 0) {
+        if (userSelected)
+            videoTrackSelected = id;
+        mpvObject_->setVideoTrack(id);
+    }
 }
 
 void PlaybackManager::setSubtitleEnabled(bool enabled)
@@ -448,7 +430,7 @@ void PlaybackManager::selectNextSubtitle()
     int64_t nextSubs = subtitleTrackSelected + 1;
     if (nextSubs >= subtitleList.count())
         nextSubs = 0;
-    setSubtitleTrack(nextSubs);
+    setSubtitleTrack(nextSubs, true);
 }
 
 void PlaybackManager::selectPrevSubtitle()
@@ -458,7 +440,7 @@ void PlaybackManager::selectPrevSubtitle()
     int64_t previousSubs = subtitleTrackSelected - 1;
     if (previousSubs < 0)
         previousSubs = subtitleList.count() - 1;
-    setSubtitleTrack(previousSubs);
+    setSubtitleTrack(previousSubs, true);
 }
 
 void PlaybackManager::setVolume(int64_t volume)
@@ -591,21 +573,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
 
 void PlaybackManager::selectDesiredTracks()
 {
-    // search current tracks by mangled string of no id and no spaces
-    auto mangle = [](QString s) {
-        return QStringList(s.split(' ').mid(1)).join("");
-    };
-    auto findIdBySecond = [&](QList<QPair<int64_t,QString>> list,
-                              QString needle) -> int64_t {
-        if (list.isEmpty() || (needle = mangle(needle)).isEmpty())
-            return -1;
-        for (int i = 0; i < list.count(); i++) {
-            if (mangle(list[i].second) == needle) {
-                return list[i].first;
-            }
-        }
-        return -1;
-    };
+    LogStream("manager") << "selectDesiredTracks";
     auto findSubIdByPreference = [&](void) -> int64_t {
         if (subtitlesPreferExternal) {
             for (auto it = subtitleListData.constBegin();
@@ -637,40 +605,19 @@ void PlaybackManager::selectDesiredTracks()
         }
         return lastGoodTrack;
     };
-    bool audioSoftly = false;
-    bool subsSoftly = false;
+    int64_t videoId = videoTrackSelected;
+    int64_t audioId = audioTrackSelected;
+    int64_t subsId = subtitleTrackSelected;
 
-    int64_t videoId = findIdBySecond(videoList, videoListSelected);
-    int64_t audioId = findIdBySecond(audioList, audioListSelected);
-    if (audioId < 0) {
+    if (audioId < 0)
         audioId = findTrackByLangPreference(audioLangPref, audioListData);
-        if (audioId)
-            audioSoftly = true;
-    }
-    int64_t subsId = findIdBySecond(subtitleList, subtitleListSelected);
     if (subsId < 0) subsId = findSubIdByPreference();
-    if (subsId < 0) {
+    if (subsId < 0)
         subsId = findTrackByLangPreference(subtitleLangPref, subtitleListData);
-        if (subsId)
-            subsSoftly = true;
-    }
-
-    // Set detected tracks; if no preferred track from a list could be found,
-    // clear user selection
-    if (videoId >= 0)
-        setVideoTrack(videoId);
-    else if (!videoList.isEmpty())
-        videoListSelected.clear();
-    if (audioId >= 0)
-        setAudioTrackEx(audioId, audioSoftly);
-    else if (!audioList.isEmpty())
-        audioListSelected.clear();
-    if (subsId >= 0)
-        setSubtitleTrackEx(subsId, subsSoftly);
-    else if (!subtitleList.isEmpty()) {
-        subtitleListSelected.clear();
-        setSubtitleTrack(1);
-    }
+    // Set detected tracks
+    setVideoTrack(videoId, false);
+    setAudioTrack(audioId, false);
+    setSubtitleTrack(subsId, false);
 }
 
 void PlaybackManager::updateSubtitleTrack()
@@ -899,6 +846,7 @@ void PlaybackManager::mpvw_chaptersChanged(QVariantList chapters)
 
 void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
 {
+    LogStream("manager") << "mpvw_tracksChanged";
     videoList.clear();
     audioList.clear();
     audioListData.clear();

--- a/manager.cpp
+++ b/manager.cpp
@@ -410,6 +410,7 @@ void PlaybackManager::setAudioTrackEx(int64_t id, bool softly)
     else
         audioListSelected = findSecondById(audioList, id);
     mpvObject_->setAudioTrack(id);
+    audioTrackSelected = id;
 }
 
 void PlaybackManager::setSubtitleTrack(int64_t id)
@@ -431,6 +432,7 @@ void PlaybackManager::setVideoTrack(int64_t id)
 {
     videoListSelected = findSecondById(videoList, id);
     mpvObject_->setVideoTrack(id);
+    videoTrackSelected = id;
 }
 
 void PlaybackManager::setSubtitleEnabled(bool enabled)
@@ -535,11 +537,13 @@ void PlaybackManager::sendCurrentTrackInfo()
 {
     QUrl url(playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem));
     emit currentTrackInfo({url, nowPlayingList, nowPlayingItem,
-                           nowPlayingTitle, mpvLength, mpvTime});
+                           nowPlayingTitle, mpvLength, mpvTime,
+                           videoTrackSelected, audioTrackSelected, subtitleTrackSelected});
 }
 
 void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString title,
-                                          double& length, double& position)
+                                          double& length, double& position, int64_t& videoTrack,
+                                          int64_t& audioTrack, int64_t& subtitleTrack)
 {
     url = playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem);
     listUuid = nowPlayingList;
@@ -547,6 +551,9 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
     title = nowPlayingTitle;
     length = mpvLength;
     position = mpvTime;
+    videoTrack = videoTrackSelected;
+    audioTrack = audioTrackSelected;
+    subtitleTrack = subtitleTrackSelected;
 }
 
 void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,

--- a/manager.cpp
+++ b/manager.cpp
@@ -404,6 +404,7 @@ void PlaybackManager::setSubtitleTrack(int64_t id, bool userSelected)
     if (id >= 0) {
         if (userSelected)
             subtitleTrackSelected = id;
+        subtitleTrackActive = id;
         updateSubtitleTrack();
     }
 }
@@ -614,6 +615,8 @@ void PlaybackManager::selectDesiredTracks()
     if (subsId < 0) subsId = findSubIdByPreference();
     if (subsId < 0)
         subsId = findTrackByLangPreference(subtitleLangPref, subtitleListData);
+    if (subsId < 0)
+        subsId = 1;
     // Set detected tracks
     setVideoTrack(videoId, false);
     setAudioTrack(audioId, false);
@@ -622,8 +625,8 @@ void PlaybackManager::selectDesiredTracks()
 
 void PlaybackManager::updateSubtitleTrack()
 {
-    emit subtitlesVisible(subtitleEnabled && subtitleTrackSelected != 0);
-    mpvObject_->setSubtitleTrack(subtitleEnabled ? subtitleTrackSelected : 0);
+    emit subtitlesVisible(subtitleEnabled && subtitleTrackActive != 0);
+    mpvObject_->setSubtitleTrack(subtitleEnabled ? subtitleTrackActive : 0);
 }
 
 void PlaybackManager::checkAfterPlayback()

--- a/manager.h
+++ b/manager.h
@@ -153,7 +153,9 @@ public slots:
 
     // misc functions
     void sendCurrentTrackInfo();
-    void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString title, double &length, double &position);
+    void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString title,
+                             double &length, double &position, int64_t &videoTrack,
+                             int64_t &audioTrack, int64_t &subtitleTrack);
 
 private:
     void startPlayWithUuid(QUrl what, QUuid playlistUuid, QUuid itemUuid,
@@ -222,7 +224,9 @@ private:
     QStringList audioLangPref;
     QStringList subtitleLangPref;
     QString videoListSelected;
+    int64_t videoTrackSelected = 1;
     QString audioListSelected;
+    int64_t audioTrackSelected = 1;
     QString subtitleListSelected;
     int64_t subtitleTrackSelected = 1;
     bool subtitleEnabled = true;

--- a/manager.h
+++ b/manager.h
@@ -224,6 +224,7 @@ private:
     int64_t videoTrackSelected = -1;
     int64_t audioTrackSelected = -1;
     int64_t subtitleTrackSelected = -1;
+    int64_t subtitleTrackActive = 0;
     bool subtitleEnabled = true;
     bool subtitlesIgnoreEmbedded = false;
     bool subtitlesPreferDefaultForced = false;

--- a/manager.h
+++ b/manager.h
@@ -128,11 +128,9 @@ public slots:
     void setStepTimeSmall(int smallMsec);
     void setSubtitleTrackPreference(QString langs);
     void setAudioTrackPreference(QString langs);
-    void setAudioTrack(int64_t id);
-    void setAudioTrackEx(int64_t id, bool softly);
-    void setSubtitleTrack(int64_t id);
-    void setSubtitleTrackEx(int64_t id, bool softly);
-    void setVideoTrack(int64_t id);
+    void setAudioTrack(int64_t id, bool userSelected);
+    void setSubtitleTrack(int64_t id, bool userSelected);
+    void setVideoTrack(int64_t id, bool userSelected);
     void setSubtitleEnabled(bool enabled);
     void selectNextSubtitle();
     void selectPrevSubtitle();
@@ -223,12 +221,9 @@ private:
 
     QStringList audioLangPref;
     QStringList subtitleLangPref;
-    QString videoListSelected;
-    int64_t videoTrackSelected = 1;
-    QString audioListSelected;
-    int64_t audioTrackSelected = 1;
-    QString subtitleListSelected;
-    int64_t subtitleTrackSelected = 1;
+    int64_t videoTrackSelected = -1;
+    int64_t audioTrackSelected = -1;
+    int64_t subtitleTrackSelected = -1;
     bool subtitleEnabled = true;
     bool subtitlesIgnoreEmbedded = false;
     bool subtitlesPreferDefaultForced = false;


### PR DESCRIPTION
- Save current video, audio and subtitle tracks for the current file.
- Restore current tracks on file load:
When a track is set to -1, it means the user didn't select it manually.
In that case, we check if an other track isn't better given the current settings.
Refactoring of the tracks selection.
Using the track id instead of the track name + id string simplifies the process.
- Reset the tracks menus actions groups on track change
This avoids accessing non existing actions in audioTrackSet, videoTrackSet and subtitleTrackSet.
- Includes a "temporary" fix to avoid setting subtitles to track 0 if using an older version of recents or favorites.