### PR TITLE
Disable tracks submenus when empty, enable chapters menu when not empty

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -771,6 +771,8 @@ void Flow::setupFlowConnections()
             this, &Flow::manager_stoppedPlaying);
     connect(playbackManager, &PlaybackManager::stateChanged,
             this, &Flow::manager_stateChanged);
+    connect(playbackManager, &PlaybackManager::fileOpenedOrClosed,
+            this, &Flow::manager_fileOpenedOrClosed);
     connect(playbackManager, &PlaybackManager::instanceShouldClose,
             this, &Flow::mainwindow_instanceShouldQuit);
     connect(playbackManager, &PlaybackManager::subtitlesVisible,
@@ -1260,6 +1262,11 @@ void Flow::manager_stateChanged(PlaybackManager::PlaybackState state)
 
     // Else: inhibit the screensaver because we're not stopped
     screenSaver->inhibitSaver(tr("Playing Media"));
+}
+
+void Flow::manager_fileOpenedOrClosed()
+{
+    mainWindow->disableChaptersMenus();
 }
 
 void Flow::manager_subtitlesVisible(bool visible)

--- a/main.h
+++ b/main.h
@@ -73,6 +73,7 @@ private slots:
     void mainwindow_optionsOpenRequested();
     void manager_playLengthChanged();
     void manager_stateChanged(PlaybackManager::PlaybackState state);
+    void manager_fileOpenedOrClosed();
     void manager_subtitlesVisible(bool visible);
     void manager_hasNoSubtitles(bool none);
     void manager_openingNewFile();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -974,9 +974,11 @@ void MainWindow::setUiEnabledState(bool enabled)
 
     ui->menuFileSubtitleDatabase->setEnabled(false);
     ui->menuPlayLoop->setEnabled(enabled);
-    ui->menuPlayAudio->setEnabled(enabled);
-    ui->menuPlaySubtitles->setEnabled(enabled);
-    ui->menuPlayVideo->setEnabled(enabled);
+    if (!enabled) {
+        ui->menuPlayAudio->setEnabled(enabled);
+        ui->menuPlaySubtitles->setEnabled(enabled);
+        ui->menuPlayVideo->setEnabled(enabled);
+    }
     ui->menuNavigateChapters->setEnabled(enabled && false);
 }
 
@@ -1885,10 +1887,12 @@ void MainWindow::setChapters(QList<QPair<double, QString>> chapters)
 void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayAudio->clear();
+    ui->menuPlayAudio->setEnabled(false);
     audioTracksGroup = new QActionGroup(this);
     hasAudio = !tracks.isEmpty();
     if (!hasAudio)
         return;
+    ui->menuPlayAudio->setEnabled(true);
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
@@ -1906,10 +1910,12 @@ void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
 void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
 {
     ui->menuPlayVideo->clear();
+    ui->menuPlayVideo->setEnabled(false);
     videoTracksGroup = new QActionGroup(this);
     hasVideo = !tracks.isEmpty();
     if (!hasVideo)
         return;
+    ui->menuPlayVideo->setEnabled(true);
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
@@ -1928,6 +1934,7 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
 void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
 {
     ui->menuPlaySubtitles->clear();
+    ui->menuPlaySubtitles->setEnabled(false);
     subtitleTracksGroup = new QActionGroup(this);
     hasSubs = !tracks.isEmpty();
     ui->actionPlaySubtitlesEnabled->setEnabled(hasSubs);
@@ -1936,6 +1943,7 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     ui->actionPlaySubtitlesPrevious->setEnabled(hasSubs);
     if (!hasSubs)
         return;
+    ui->menuPlaySubtitles->setEnabled(true);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesEnabled);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesNext);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesPrevious);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -5,6 +5,7 @@
 #include "ui_mainwindow.h"
 #include "openfiledialog.h"
 #include "helpers.h"
+#include "logger.h"
 #include "platform/unify.h"
 #include "platform/devicemanager.h"
 #include <QActionGroup>
@@ -975,11 +976,11 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->menuFileSubtitleDatabase->setEnabled(false);
     ui->menuPlayLoop->setEnabled(enabled);
     if (!enabled) {
-        ui->menuPlayAudio->setEnabled(enabled);
-        ui->menuPlaySubtitles->setEnabled(enabled);
-        ui->menuPlayVideo->setEnabled(enabled);
+        ui->menuPlayAudio->setEnabled(false);
+        ui->menuPlaySubtitles->setEnabled(false);
+        ui->menuPlayVideo->setEnabled(false);
+        ui->menuNavigateChapters->setEnabled(false);
     }
-    ui->menuNavigateChapters->setEnabled(enabled && false);
 }
 
 void MainWindow::reparentBottomArea(bool overlay)
@@ -1867,10 +1868,19 @@ void MainWindow::setPlaybackType(PlaybackManager::PlaybackType type)
     setUiEnabledState(type != PlaybackManager::None);
 }
 
+void MainWindow::disableChaptersMenus()
+{
+    ui->menuNavigateChapters->setEnabled(false);
+}
+
 void MainWindow::setChapters(QList<QPair<double, QString>> chapters)
 {
     positionSlider_->clearTicks();
     ui->menuNavigateChapters->clear();
+    ui->menuNavigateChapters->setEnabled(false);
+    if (chapters.isEmpty())
+        return;
+    ui->menuNavigateChapters->setEnabled(true);
     int64_t index = 0;
     for (const QPair<double,QString> &chapter : chapters) {
         positionSlider_->setTick(chapter.first, chapter.second);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -245,6 +245,7 @@ public slots:
     void setFullscreenHidePanels(bool hidden);
     void setPlaybackState(PlaybackManager::PlaybackState state);
     void setPlaybackType(PlaybackManager::PlaybackType type);
+    void disableChaptersMenus();
     void setChapters(QList<QPair<double,QString>> chapters);
     void setAudioTracks(QList<QPair<int64_t,QString>> tracks);
     void setVideoTracks(QList<QPair<int64_t,QString>> tracks);

--- a/manager.cpp
+++ b/manager.cpp
@@ -852,8 +852,10 @@ void PlaybackManager::mpvw_playbackFinished() {
 
 void PlaybackManager::mpvw_eofReachedChanged(bool eof) {
     LogStream("manager") << "mpvw_eofReachedChanged";
-    if (!eof)
+    if (!eof) {
+        emit fileOpenedOrClosed();
         return;
+    }
 
     emit stoppedPlaying();
 

--- a/manager.h
+++ b/manager.h
@@ -53,6 +53,7 @@ signals:
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
     void stateChanged(PlaybackManager::PlaybackState state);
+    void fileOpenedOrClosed();
     void typeChanged(PlaybackManager::PlaybackType type);
     // Transmit a map of chapter index to time,description pairs
     void chaptersAvailable(QList<QPair<double,QString>> chapters);


### PR DESCRIPTION
 - Only enable tracks submenus when tracks are available
Disable audio, subtitles and video submenus by default and enable them when not empty.
- Enable chapters menu when not empty
Disable it when changing file to avoid showing the chapters from the previous file.