### PR TITLE
Improve subtitles auto selection

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -602,16 +602,15 @@ void PlaybackManager::selectDesiredTracks()
     auto findSubIdByPreference = [&](void) -> int64_t {
         if (subtitlesPreferExternal) {
             for (auto it = subtitleListData.constBegin();
-                 it != subtitleListData.constEnd(); it++) {
+                it != subtitleListData.constEnd(); it++) {
                 if (it.value().isExternal)
                     return it.key();
             }
         }
         if (subtitlesPreferDefaultForced) {
             for (auto it = subtitleListData.constBegin();
-                 it != subtitleListData.constEnd(); it++)
-                if (it.value().isForced
-                    || it.value().isDefault)
+                it != subtitleListData.constEnd(); it++)
+                if (it.value().isForced || it.value().isDefault)
                     return it.key();
         }
         return -1;
@@ -621,7 +620,7 @@ void PlaybackManager::selectDesiredTracks()
         int64_t lastGoodTrack = -1;
         for (const QString &lang : langPref) {
             for (auto it = tracks.constBegin();
-                 it != tracks.constEnd(); it++)
+                it != tracks.constEnd(); it++)
                 if (it.value().lang == lang) {
                     if (it.value().isForced || it.value().isDefault)
                         lastGoodTrack = it.key();

--- a/manager.cpp
+++ b/manager.cpp
@@ -618,13 +618,18 @@ void PlaybackManager::selectDesiredTracks()
     };
     auto findTrackByLangPreference = [&](const QStringList &langPref,
                                          const QMap<int64_t,TrackData> &tracks) -> int64_t {
+        int64_t lastGoodTrack = -1;
         for (const QString &lang : langPref) {
             for (auto it = tracks.constBegin();
                  it != tracks.constEnd(); it++)
-                if (it.value().lang == lang)
-                    return it.key();
+                if (it.value().lang == lang) {
+                    if (it.value().isForced || it.value().isDefault)
+                        lastGoodTrack = it.key();
+                    else
+                        return it.key();
+                }
         }
-        return -1;
+        return lastGoodTrack;
     };
     bool audioSoftly = false;
     bool subsSoftly = false;

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6765,6 +6765,9 @@ media file played</string>
              <property name="text">
               <string>Prefer external subtitles over embedded subtitles</string>
              </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item>


### PR DESCRIPTION
- Don't use the first subtitle for non forced/default ones
Since forced/default subtitles are usually the first ones, it makes sense to look further if the user doesn't prefer those (subtitlesPreferDefaultForced == false).
- Improve code style in PlaybackManager::selectDesiredTracks
- Enable "Prefer external subtitles" by default
If the user downloaded subtitles, it's probably to use them.