### PR TITLE
Always reset the saved position when at the end of the file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1459,6 +1459,8 @@ void Flow::updateRecentPosition(bool resetPosition)
     int64_t videoTrack;
     int64_t audioTrack;
     int64_t subtitleTrack;
+    if (playbackManager->eofReached())
+        resetPosition = true;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
                                          videoTrack, audioTrack, subtitleTrack);
     if (!itemUuid.isNull())

--- a/manager.cpp
+++ b/manager.cpp
@@ -120,6 +120,11 @@ QUrl PlaybackManager::nowPlaying()
     return nowPlaying_;
 }
 
+bool PlaybackManager::eofReached()
+{
+    return mpvObject_->eofReached();
+}
+
 PlaybackManager::PlaybackState PlaybackManager::playbackState()
 {
     return playbackState_;

--- a/manager.h
+++ b/manager.h
@@ -43,6 +43,7 @@ public:
     void setPlaylistWindow(PlaylistWindow *playlistWindow);
     QUrl nowPlaying();
     PlaybackState playbackState();
+    bool eofReached();
 
 signals:
     void playerSettingsRequested();


### PR DESCRIPTION
The position gets saved again without forcing a reset (updateRecentPosition(false)) on various events after having already been forced reset. So we have to check every time if we are at the end of the file and then reset the position if we are.