### PR TITLE
Support adjusting subtitles delay

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -613,6 +613,8 @@ void Flow::setupSettingsConnections()
             mainWindow, &MainWindow::setFullscreenHidePanels);
     connect(settingsWindow, &SettingsWindow::volumeMax,
             mainWindow, &MainWindow::setVolumeMax);
+    connect(settingsWindow, &SettingsWindow::subtitlesDelayStep,
+            mainWindow, &MainWindow::setSubtitlesDelayStep);
     connect(settingsWindow, &SettingsWindow::timeShorten,
             mainWindow, &MainWindow::setTimeShortMode);
     connect(settingsWindow, &SettingsWindow::timeTooltip,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1961,6 +1961,8 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesNext);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesPrevious);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesCopy);
+    ui->menuPlaySubtitles->addAction(ui->actionDecreaseSubtitlesDelay);
+    ui->menuPlaySubtitles->addAction(ui->actionIncreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addSeparator();
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
@@ -2640,6 +2642,16 @@ void MainWindow::on_actionPlaySubtitlesCopy_triggered()
 {
     QClipboard *clippy = qApp->clipboard();
     clippy->setText(subtitleText);
+}
+
+void MainWindow::on_actionDecreaseSubtitlesDelay_triggered()
+{
+    mpvObject_->setSubtitlesDelay(-subtitlesDelayStep);
+}
+
+void MainWindow::on_actionIncreaseSubtitlesDelay_triggered()
+{
+    mpvObject_->setSubtitlesDelay(subtitlesDelayStep);
 }
 
 void MainWindow::on_actionPlayLoopStart_triggered()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2021,6 +2021,11 @@ void MainWindow::setVolumeMax(int level)
     volumeSlider_->setMaximum(level);
 }
 
+void MainWindow::setSubtitlesDelayStep(int subtitlesDelayStep)
+{
+    this->subtitlesDelayStep = subtitlesDelayStep;
+}
+
 void MainWindow::setTimeShortMode(bool shortened)
 {
     timePosition->setShortMode(shortened);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -351,6 +351,8 @@ private slots:
     void on_actionPlaySubtitlesNext_triggered();
     void on_actionPlaySubtitlesPrevious_triggered();
     void on_actionPlaySubtitlesCopy_triggered();
+    void on_actionDecreaseSubtitlesDelay_triggered();
+    void on_actionIncreaseSubtitlesDelay_triggered();
 
     void on_actionPlayLoopStart_triggered();
     void on_actionPlayLoopEnd_triggered();
@@ -443,6 +445,7 @@ private:
     bool hasAudio = false;
     bool hasSubs = false;
     QString subtitleText;
+    int subtitlesDelayStep = 500;
     int volumeStep = 10;
     bool frozenWindow = true;
     double sizeFactor_ = 1;

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -257,6 +257,7 @@ public slots:
     void setVolume(int level);
     void setVolumeDouble(double level);
     void setVolumeMax(int level);
+    void setSubtitlesDelayStep(int subtitlesDelayStep);
     void setTimeShortMode(bool shortened);
     void resetPlayAfterOnce();
     void setPlayAfterAlways(Helpers::AfterPlayback action);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -759,6 +759,8 @@
      <addaction name="actionPlaySubtitlesNext"/>
      <addaction name="actionPlaySubtitlesPrevious"/>
      <addaction name="actionPlaySubtitlesCopy"/>
+     <addaction name="actionDecreaseSubtitlesDelay"/>
+     <addaction name="actionIncreaseSubtitlesDelay"/>
      <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuPlayVideo">
@@ -2001,6 +2003,22 @@
    </property>
    <property name="shortcut">
     <string notr="true">Shift+S</string>
+   </property>
+  </action>
+  <action name="actionDecreaseSubtitlesDelay">
+   <property name="text">
+    <string>&amp;Decrease Delay</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">F1</string>
+   </property>
+  </action>
+  <action name="actionIncreaseSubtitlesDelay">
+   <property name="text">
+    <string>&amp;Increase Delay</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">F2</string>
    </property>
   </action>
   <action name="actionViewHideLog">

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -408,6 +408,7 @@ void MpvObject::setSubtitlesDelay(int subDelayStep)
 {
     double newSubDelay = getMpvPropertyVariant("sub-delay").toDouble() + (double) subDelayStep / 1000;
     setMpvPropertyVariant("sub-delay", QString::number(newSubDelay, 'f', 3));
+    showMessage(tr("Subtitles delay: %1 ms").arg(newSubDelay * 1000));
 }
 
 int64_t MpvObject::chapter()

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -404,6 +404,12 @@ void MpvObject::addSubFile(QString filename)
     emit ctrlCommand(QStringList({"sub-add", filename}));
 }
 
+void MpvObject::setSubtitlesDelay(int subDelayStep)
+{
+    double newSubDelay = getMpvPropertyVariant("sub-delay").toDouble() + (double) subDelayStep / 1000;
+    setMpvPropertyVariant("sub-delay", QString::number(newSubDelay, 'f', 1));
+}
+
 int64_t MpvObject::chapter()
 {
     return getMpvPropertyVariant("chapter").toLongLong();

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -407,7 +407,7 @@ void MpvObject::addSubFile(QString filename)
 void MpvObject::setSubtitlesDelay(int subDelayStep)
 {
     double newSubDelay = getMpvPropertyVariant("sub-delay").toDouble() + (double) subDelayStep / 1000;
-    setMpvPropertyVariant("sub-delay", QString::number(newSubDelay, 'f', 1));
+    setMpvPropertyVariant("sub-delay", QString::number(newSubDelay, 'f', 3));
 }
 
 int64_t MpvObject::chapter()

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -61,6 +61,7 @@ public:
     void setLogoBackground(const QColor &color);
     void setSubFile(QString filename);
     void addSubFile(QString filename);
+    void setSubtitlesDelay(int subDelayStep);
 
     int64_t chapter();
     bool setChapter(int64_t chapter);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -988,6 +988,7 @@ void SettingsWindow::sendSignals()
     emit option("sub-font-size", WIDGET_LOOKUP(ui->fontSize).toInt());
     emit option("sub-border-size", WIDGET_LOOKUP(ui->borderSize).toInt());
     emit option("sub-shadow-offset", WIDGET_LOOKUP(ui->borderShadowOffset).toInt());
+    emit subtitlesDelayStep(WIDGET_LOOKUP(ui->subtitlesDelayStep).toInt());
     {
         struct AlignData { QRadioButton *btn; int x; int y; };
         QVector<AlignData> alignments {

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -142,6 +142,8 @@ signals:
     void playbackLoopImages(bool yes);
     void playlistFormat(const QString &fmt);
 
+    void subtitlesDelayStep(int subtitlesDelayStep);
+
     // does mpv even *need* this?
     void subsPreferDefaultForced(bool yes);
     void subsPreferExternal(bool yes);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6274,6 +6274,35 @@ media file played</string>
                 </property>
                </widget>
               </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="subtitlesDelayStepLabel">
+                <property name="text">
+                 <string>Delay step</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QSpinBox" name="subtitlesDelayStep">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="suffix">
+                 <string notr="true"> ms</string>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>9999999</number>
+                </property>
+                <property name="value">
+                 <number>500</number>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="0" colspan="2">
                <widget class="QCheckBox" name="subtitlesFixTiming">
                 <property name="text">

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1434,6 +1434,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1277,6 +1277,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3808,6 +3808,10 @@ media file played</translation>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1426,6 +1426,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1269,6 +1269,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3788,6 +3788,10 @@ archivo multimedia reproducido</translation>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3756,6 +3756,10 @@ media file played</source>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1253,6 +1253,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1410,6 +1410,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3780,6 +3780,10 @@ ogni file multimediale riprodotto</translation>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1422,6 +1422,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1265,6 +1265,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1434,6 +1434,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3800,6 +3800,10 @@ media file played</source>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1277,6 +1277,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3774,6 +3774,10 @@ media file played</source>
         <source>Play next file</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1426,6 +1426,13 @@
     </message>
 </context>
 <context>
+    <name>MpvObject</name>
+    <message>
+        <source>Subtitles delay: %1 ms</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>OpenFileDialog</name>
     <message>
         <source>Open File</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1269,6 +1269,14 @@
         <source>&amp;Add to Favorites</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Decrease Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
- Support adjusting subtitles delay
By default F1 and F2 adjust the subtitles delay in a default step of 500 ms.
- Add a setting to change the default subtitles delay step
- Show the current subtitles delay in OSD when changing it
Shown as "Subtitles delay: xxx ms"

Fixes #94