### PR TITLE
Reduce logging time precision to 1 millisecond

### DIFF
--- a/logger.cpp
+++ b/logger.cpp
@@ -216,7 +216,7 @@ void Logger::makeLog(QString line)
 {
     if (!loggingEnabled)
         return;
-    line = QString("[%1] %2").arg(QString::number(elapsed.nsecsElapsed()/1000000000.0, 'f', 9), line.trimmed());
+    line = QString("[%1] %2").arg(QString::number(elapsed.nsecsElapsed()/1000000000.0, 'f', 3), line.trimmed());
     // If you're encountering early or fantastic errors, uncomment this line:
     //fprintf(realStdErr.ptr, "%s\n",  line.toLocal8Bit().constData());
     if (immediateMode) {


### PR DESCRIPTION
Showing nanoseconds doesn't really make sense and just makes it harder to spot differences or copy/paste them.