### PR TITLE
Update hardware decoding backends

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -369,6 +369,7 @@ void Flow::earlyPlatformOverride()
     } else if (!qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY")) {
         settingsDisableWindowManagement = true;
     }
+    qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
 }
 
 void Flow::readConfig()

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -423,6 +423,7 @@ void SettingsWindow::setupPlatformWidgets()
 
     ui->ipcMpris->setVisible(Platform::isUnix);
     ui->hwdecBackendVaapi->setEnabled(Platform::isUnix);
+    ui->hwdecBackendNvdec->setEnabled(Platform::isWindows || Platform::isUnix);
     ui->hwdecBackendVdpau->setEnabled(Platform::isUnix);
     ui->hwdecBackendDxva2->setEnabled(Platform::isWindows);
     ui->hwdecBackendD3d11va->setEnabled(Platform::isWindows);
@@ -918,6 +919,8 @@ void SettingsWindow::sendSignals()
         QString backend = "auto";
         if (WIDGET_LOOKUP(ui->hwdecBackendVaapi).toBool())
             backend = "vaapi,vaapi-copy";
+        if (WIDGET_LOOKUP(ui->hwdecBackendNvdec).toBool())
+            backend = "nvdec,nvdec-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendVdpau).toBool())
             backend = "vdpau,vdpau-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendDxva2).toBool())

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -427,7 +427,6 @@ void SettingsWindow::setupPlatformWidgets()
     ui->hwdecBackendVdpau->setEnabled(Platform::isUnix);
     ui->hwdecBackendDxva2->setEnabled(Platform::isWindows);
     ui->hwdecBackendD3d11va->setEnabled(Platform::isWindows);
-    ui->hwdecBackendRaspberryPi->setEnabled(Platform::isUnix);
 }
 
 void SettingsWindow::setupPaletteEditor()
@@ -927,8 +926,6 @@ void SettingsWindow::sendSignals()
             backend = "dxva2,dxva2-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendD3d11va).toBool())
             backend = "d3d11va,d3d11va-copy";
-        if (WIDGET_LOOKUP(ui->hwdecBackendRaspberryPi).toBool())
-            backend = "rpi,rpi-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendCuda).toBool())
             backend = "cuda,cuda-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendCrystalHd).toBool())

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -915,19 +915,19 @@ void SettingsWindow::sendSignals()
     emit option("video-sync-max-audio-change", WIDGET_LOOKUP(ui->syncMaxAudioChange).toDouble());
     emit option("video-sync-max-video-change", WIDGET_LOOKUP(ui->syncMaxVideoChange).toDouble());
     if (WIDGET_LOOKUP(ui->hwdecEnable).toBool()) {
-        QString backend = "auto-copy";
+        QString backend = "auto";
         if (WIDGET_LOOKUP(ui->hwdecBackendVaapi).toBool())
-            backend = "vaapi-copy";
+            backend = "vaapi,vaapi-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendVdpau).toBool())
-            backend = "vdpau-copy";
+            backend = "vdpau,vdpau-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendDxva2).toBool())
-            backend = "dxva2-copy";
+            backend = "dxva2,dxva2-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendD3d11va).toBool())
-            backend = "d3d11va-copy";
+            backend = "d3d11va,d3d11va-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendRaspberryPi).toBool())
-            backend = "rpi-copy";
+            backend = "rpi,rpi-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendCuda).toBool())
-            backend = "cuda-copy";
+            backend = "cuda,cuda-copy";
         if (WIDGET_LOOKUP(ui->hwdecBackendCrystalHd).toBool())
             backend = "crystalhd";
         emit option("hwdec", backend);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5497,6 +5497,16 @@ media file played</string>
                 </widget>
                </item>
                <item>
+                <widget class="QRadioButton" name="hwdecBackendNvdec">
+                 <property name="toolTip">
+                  <string>nVidia only (faster than CUDA)</string>
+                 </property>
+                 <property name="text">
+                  <string notr="true">&amp;NVDEC</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
                 <widget class="QRadioButton" name="hwdecBackendVdpau">
                  <property name="toolTip">
                   <string>Linux - some gpus, does not always treat certain colorspaces like BT.2020 correctly</string>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5537,16 +5537,6 @@ media file played</string>
                 </widget>
                </item>
                <item>
-                <widget class="QRadioButton" name="hwdecBackendRaspberryPi">
-                 <property name="toolTip">
-                  <string>Raspberry PI - hardware overlay renderer</string>
-                 </property>
-                 <property name="text">
-                  <string notr="true">&amp;Raspberry Pi</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <widget class="QRadioButton" name="hwdecBackendCuda">
                  <property name="toolTip">
                   <string>nVidia only (likely 10x0+ only) - safe</string>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5476,7 +5476,7 @@ media file played</string>
                <item>
                 <widget class="QRadioButton" name="hwdecBackendAuto">
                  <property name="toolTip">
-                  <string>Autodetect - best of VAAPI, DXVA, D3D11VA</string>
+                  <string>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</string>
                  </property>
                  <property name="text">
                   <string>A&amp;utodetect</string>
@@ -5489,7 +5489,7 @@ media file played</string>
                <item>
                 <widget class="QRadioButton" name="hwdecBackendVaapi">
                  <property name="toolTip">
-                  <string>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</string>
+                  <string>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</string>
                  </property>
                  <property name="text">
                   <string notr="true">&amp;VAAPI</string>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3060,7 +3060,7 @@ media file played</translation>
     </message>
     <message>
         <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation>Autodetect - best of VAAPI, DXVA, D3D11VA</translation>
+        <translation type="vanished">Autodetect - best of VAAPI, DXVA, D3D11VA</translation>
     </message>
     <message>
         <source>A&amp;utodetect</source>
@@ -3068,7 +3068,7 @@ media file played</translation>
     </message>
     <message>
         <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
-        <translation>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</translation>
+        <translation type="vanished">Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</translation>
     </message>
     <message>
         <source>Linux - some gpus, does not always treat certain colorspaces like BT.2020 correctly</source>
@@ -3084,7 +3084,7 @@ media file played</translation>
     </message>
     <message>
         <source>Raspberry PI - hardware overlay renderer</source>
-        <translation>Raspberry PI - hardware overlay renderer</translation>
+        <translation type="vanished">Raspberry PI - hardware overlay renderer</translation>
     </message>
     <message>
         <source>MacOS - safe</source>
@@ -3821,6 +3821,18 @@ media file played</translation>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3048,7 +3048,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation>Autodetectar - el mejor entre VAAPI, DXVA, D3D11VA</translation>
+        <translation type="vanished">Autodetectar - el mejor entre VAAPI, DXVA, D3D11VA</translation>
     </message>
     <message>
         <source>A&amp;utodetect</source>
@@ -3056,7 +3056,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
-        <translation>Linux - requiere Mesa 11 y seguramente funcione solo con las GPU de Intel; puede ser correcto solo para BT.601 y BT.709</translation>
+        <translation type="vanished">Linux - requiere Mesa 11 y seguramente funcione solo con las GPU de Intel; puede ser correcto solo para BT.601 y BT.709</translation>
     </message>
     <message>
         <source>Linux - some gpus, does not always treat certain colorspaces like BT.2020 correctly</source>
@@ -3072,7 +3072,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Raspberry PI - hardware overlay renderer</source>
-        <translation>Raspberry PI - renderizador de superposición por hardware</translation>
+        <translation type="vanished">Raspberry PI - renderizador de superposición por hardware</translation>
     </message>
     <message>
         <source>MacOS - safe</source>
@@ -3801,6 +3801,18 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3015,15 +3015,7 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A&amp;utodetect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3036,10 +3028,6 @@ media file played</source>
     </message>
     <message>
         <source>Windows 8+ - usually safe but rounds 10 bit to 8 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Raspberry PI - hardware overlay renderer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3765,6 +3753,18 @@ media file played</source>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3047,15 +3047,7 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A&amp;utodetect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3068,10 +3060,6 @@ media file played</source>
     </message>
     <message>
         <source>Windows 8+ - usually safe but rounds 10 bit to 8 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Raspberry PI - hardware overlay renderer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3809,6 +3797,18 @@ media file played</source>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3039,15 +3039,7 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A&amp;utodetect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3060,10 +3052,6 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Windows 8+ - usually safe but rounds 10 bit to 8 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Raspberry PI - hardware overlay renderer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3789,6 +3777,18 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3056,7 +3056,7 @@ media file played</source>
     </message>
     <message>
         <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation>Автоопределение - лучший из VAAPI, DXVA, D3D11VA</translation>
+        <translation type="vanished">Автоопределение - лучший из VAAPI, DXVA, D3D11VA</translation>
     </message>
     <message>
         <source>A&amp;utodetect</source>
@@ -3064,7 +3064,7 @@ media file played</source>
     </message>
     <message>
         <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
-        <translation>Linux - требует Mesa 11 и скорее всего работает только с графическими процессорами Intel; может быть правильным только в BT.601 и BT.709</translation>
+        <translation type="vanished">Linux - требует Mesa 11 и скорее всего работает только с графическими процессорами Intel; может быть правильным только в BT.601 и BT.709</translation>
     </message>
     <message>
         <source>Linux - some gpus, does not always treat certain colorspaces like BT.2020 correctly</source>
@@ -3080,7 +3080,7 @@ media file played</source>
     </message>
     <message>
         <source>Raspberry PI - hardware overlay renderer</source>
-        <translation>Raspberry PI - аппаратный оверлей рендеринга</translation>
+        <translation type="vanished">Raspberry PI - аппаратный оверлей рендеринга</translation>
     </message>
     <message>
         <source>MacOS - safe</source>
@@ -3813,6 +3813,18 @@ media file played</source>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3037,15 +3037,7 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Autodetect - best of VAAPI, DXVA, D3D11VA</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>A&amp;utodetect</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Linux - requires Mesa 11 and most likely works with Intel GPUs only; may only be correct in BT.601 and BT.709</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3058,10 +3050,6 @@ media file played</source>
     </message>
     <message>
         <source>Windows 8+ - usually safe but rounds 10 bit to 8 bit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Raspberry PI - hardware overlay renderer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3787,6 +3775,18 @@ media file played</source>
     </message>
     <message>
         <source>Delay step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Autodetect - best of VAAPI, DXVA, D3D11VA, etc.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Linux - works with Intel and AMD GPUs through Mesa, and with nVidia through a translation layer; may only be correct in BT.601 and BT.709</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>nVidia only (faster than CUDA)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- Switch to non copy-back hardware acceleration by default 
It should be faster than copy-back
- Use EGL instead of GLX as OpenGL interface
Allows the use of non copy-back VA-API (aka VAAPI)
- Update description for VAAPI
- Add NVDEC as hardware decoding backend
It should be faster than CUDA
- Remove Raspberry Pi hwdec backend (no longer supported by mpv)

Fixes #176