### PR TITLE
Fix regression caused by d37b4a1 "Reduce property change logging to 3 decimals"

### DIFF
--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -632,14 +632,15 @@ void MpvObject::hideCursor()
 
 void MpvObject::ctrl_mpvPropertyChanged(QString name, QVariant v)
 {
+    QVariant vForLog = v;
     // Don't show more than 3 decimals or none if those are zero
-    if (v.typeId() == QVariant::Double) {
-        v = QString("%1").arg(QString::number(v.toDouble(), 'f', 3));
-        if (v.toString().section('.', 1) == "000")
-            v = v.toString().section('.', 0, 0);
+    if (vForLog.typeId() == QVariant::Double) {
+        vForLog = QString("%1").arg(QString::number(vForLog.toDouble(), 'f', 3));
+        if (vForLog.toString().section('.', 1) == "000")
+            vForLog = vForLog.toString().section('.', 0, 0);
     }
     if (debugMessages)
-        LogStream("mpvobject") << name << " property changed to " << v;
+        LogStream("mpvobject") << name << " property changed to " << vForLog;
 
     bool ok = v.metaType().id() < QMetaType::User
               && v.metaType().id() != QMetaType::UnknownType;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -633,7 +633,7 @@ void MpvObject::hideCursor()
 void MpvObject::ctrl_mpvPropertyChanged(QString name, QVariant v)
 {
     // Don't show more than 3 decimals or none if those are zero
-    if (v.canConvert(QMetaType(QMetaType::Double))) {
+    if (v.typeId() == QVariant::Double) {
         v = QString("%1").arg(QString::number(v.toDouble(), 'f', 3));
         if (v.toString().section('.', 1) == "000")
             v = v.toString().section('.', 0, 0);


### PR DESCRIPTION
- Fix type detection in MpvObject::ctrl_mpvPropertyChanged
Fixes regression caused by d37b4a1e279110e49de308ae8ff0f6817a69fc5e "Reduce property change logging to 3 decimals".
Since a title contains at least one dot, this regression causes it to be replaced by 0.
- Don't modify the property value in MpvObject::ctrl_mpvPropertyChanged
This prevents any other regression