### PR TITLE
Support changing the video aspect ratio

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1935,6 +1935,7 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
     ui->menuPlayVideo->addAction(ui->actionDecreaseVideoAspect);
     ui->menuPlayVideo->addAction(ui->actionIncreaseVideoAspect);
     ui->menuPlayVideo->addAction(ui->actionResetVideoAspect);
+    ui->menuPlayVideo->addAction(ui->actionDisableVideoAspect);
     ui->menuPlayVideo->addSeparator();
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
@@ -2562,6 +2563,12 @@ void MainWindow::on_actionIncreaseVideoAspect_triggered()
 void MainWindow::on_actionResetVideoAspect_triggered()
 {
     mpvObject_->setVideoAspectPreset(-1);
+}
+
+void MainWindow::on_actionDisableVideoAspect_toggled(bool checked)
+{
+    mpvObject_->disableVideoAspect(checked);
+    ui->actionDisableVideoAspect->setChecked(checked);
 }
 
 void MainWindow::on_actionViewOntopDefault_toggled(bool checked)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1932,6 +1932,10 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
         return;
     ui->menuPlayVideo->setEnabled(true);
     videoTracksGroup = new QActionGroup(this);
+    ui->menuPlayVideo->addAction(ui->actionDecreaseVideoAspect);
+    ui->menuPlayVideo->addAction(ui->actionIncreaseVideoAspect);
+    ui->menuPlayVideo->addAction(ui->actionResetVideoAspect);
+    ui->menuPlayVideo->addSeparator();
     for (const QPair<int64_t, QString> &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.second);
@@ -2543,6 +2547,21 @@ void MainWindow::on_actionViewZoomDisable_triggered()
 {
     setZoomPreset(-1);
     emit zoomPresetChanged(-1);
+}
+
+void MainWindow::on_actionDecreaseVideoAspect_triggered()
+{
+    mpvObject_->setVideoAspect(-0.05);
+}
+
+void MainWindow::on_actionIncreaseVideoAspect_triggered()
+{
+    mpvObject_->setVideoAspect(0.05);
+}
+
+void MainWindow::on_actionResetVideoAspect_triggered()
+{
+    mpvObject_->setVideoAspectPreset(-1);
 }
 
 void MainWindow::on_actionViewOntopDefault_toggled(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -332,6 +332,7 @@ private slots:
     void on_actionDecreaseVideoAspect_triggered();
     void on_actionIncreaseVideoAspect_triggered();
     void on_actionResetVideoAspect_triggered();
+    void on_actionDisableVideoAspect_toggled(bool checked);
 
     void on_actionViewOntopDefault_toggled(bool checked);
     void on_actionViewOntopAlways_toggled(bool checked);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -329,6 +329,10 @@ private slots:
     void on_actionViewZoomAutofitSmaller_triggered();
     void on_actionViewZoomDisable_triggered();
 
+    void on_actionDecreaseVideoAspect_triggered();
+    void on_actionIncreaseVideoAspect_triggered();
+    void on_actionResetVideoAspect_triggered();
+
     void on_actionViewOntopDefault_toggled(bool checked);
     void on_actionViewOntopAlways_toggled(bool checked);
     void on_actionViewOntopPlaying_toggled(bool checked);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -2028,7 +2028,7 @@
   </action>
   <action name="actionDecreaseVideoAspect">
    <property name="text">
-    <string>&amp;Decrease Aspect</string>
+    <string>&amp;Decrease Aspect ratio</string>
    </property>
    <property name="shortcut">
     <string notr="true">4</string>
@@ -2036,7 +2036,7 @@
   </action>
   <action name="actionIncreaseVideoAspect">
    <property name="text">
-    <string>&amp;Increase Aspect</string>
+    <string>&amp;Increase Aspect ratio</string>
    </property>
    <property name="shortcut">
     <string notr="true">6</string>
@@ -2044,7 +2044,7 @@
   </action>
   <action name="actionResetVideoAspect">
    <property name="text">
-    <string>&amp;Reset Aspect</string>
+    <string>&amp;Reset Aspect ratio</string>
    </property>
    <property name="shortcut">
     <string notr="true">5</string>
@@ -2055,7 +2055,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Disable &amp;aspect</string>
+    <string>Disable &amp;Aspect ratio</string>
    </property>
    <property name="shortcut">
     <string>9</string>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -770,6 +770,7 @@
      <addaction name="actionDecreaseVideoAspect"/>
      <addaction name="actionIncreaseVideoAspect"/>
      <addaction name="actionResetVideoAspect"/>
+     <addaction name="actionDisableVideoAspect"/>
      <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuPlayVolume">
@@ -2047,6 +2048,17 @@
    </property>
    <property name="shortcut">
     <string notr="true">5</string>
+   </property>
+  </action>
+  <action name="actionDisableVideoAspect">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Disable &amp;aspect</string>
+   </property>
+   <property name="shortcut">
+    <string>9</string>
    </property>
   </action>
   <action name="actionViewHideLog">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -765,8 +765,12 @@
     </widget>
     <widget class="QMenu" name="menuPlayVideo">
      <property name="title">
-      <string>&amp;Video Stream</string>
+      <string>&amp;Video</string>
      </property>
+     <addaction name="actionDecreaseVideoAspect"/>
+     <addaction name="actionIncreaseVideoAspect"/>
+     <addaction name="actionResetVideoAspect"/>
+     <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuPlayVolume">
      <property name="title">
@@ -2019,6 +2023,30 @@
    </property>
    <property name="shortcut">
     <string notr="true">F2</string>
+   </property>
+  </action>
+  <action name="actionDecreaseVideoAspect">
+   <property name="text">
+    <string>&amp;Decrease Aspect</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">4</string>
+   </property>
+  </action>
+  <action name="actionIncreaseVideoAspect">
+   <property name="text">
+    <string>&amp;Increase Aspect</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">6</string>
+   </property>
+  </action>
+  <action name="actionResetVideoAspect">
+   <property name="text">
+    <string>&amp;Reset Aspect</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">5</string>
    </property>
   </action>
   <action name="actionViewHideLog">

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -422,6 +422,11 @@ void MpvObject::setVideoAspectPreset(double aspect)
     setMpvPropertyVariant("video-aspect-override", aspect);
 }
 
+void MpvObject::disableVideoAspect(bool yes)
+{
+    setMpvPropertyVariant("keepaspect", !yes ? "yes" : "no");
+}
+
 int64_t MpvObject::chapter()
 {
     return getMpvPropertyVariant("chapter").toLongLong();

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -411,6 +411,17 @@ void MpvObject::setSubtitlesDelay(int subDelayStep)
     showMessage(tr("Subtitles delay: %1 ms").arg(newSubDelay * 1000));
 }
 
+void MpvObject::setVideoAspect(double aspectDiff)
+{
+    double currAspect = getMpvPropertyVariant("video-params/aspect").toDouble();
+    setMpvPropertyVariant("video-aspect-override", currAspect + aspectDiff);
+}
+
+void MpvObject::setVideoAspectPreset(double aspect)
+{
+    setMpvPropertyVariant("video-aspect-override", aspect);
+}
+
 int64_t MpvObject::chapter()
 {
     return getMpvPropertyVariant("chapter").toLongLong();

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -62,6 +62,8 @@ public:
     void setSubFile(QString filename);
     void addSubFile(QString filename);
     void setSubtitlesDelay(int subDelayStep);
+    void setVideoAspect(double aspectDiff);
+    void setVideoAspectPreset(double aspect);
 
     int64_t chapter();
     bool setChapter(int64_t chapter);

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -64,6 +64,7 @@ public:
     void setSubtitlesDelay(int subDelayStep);
     void setVideoAspect(double aspectDiff);
     void setVideoAspectPreset(double aspect);
+    void disableVideoAspect(bool yes);
 
     int64_t chapter();
     bool setChapter(int64_t chapter);

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1305,6 +1305,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -271,7 +271,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>&amp;Video Stream</translation>
+        <translation type="vanished">&amp;Video Stream</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1288,6 +1288,22 @@
     <message>
         <source>&amp;Increase Delay</source>
         <translation>&amp;Increase Delay</translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -271,7 +271,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>Flujo de &amp;vídeo</translation>
+        <translation type="vanished">Flujo de &amp;vídeo</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1279,6 +1279,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1297,6 +1297,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1277,6 +1277,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -263,7 +263,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>&amp;Video-streamaus</translation>
+        <translation type="vanished">&amp;Video-streamaus</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1259,6 +1259,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -271,7 +271,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>Siaran &amp;Video</translation>
+        <translation type="vanished">Siaran &amp;Video</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1279,6 +1279,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1297,6 +1297,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -263,7 +263,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>Flusso &amp;video</translation>
+        <translation type="vanished">Flusso &amp;video</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1271,6 +1271,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1289,6 +1289,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1305,6 +1305,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -271,7 +271,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>&amp;Видеопоток</translation>
+        <translation type="vanished">&amp;Видеопоток</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1287,6 +1287,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -271,7 +271,7 @@
     </message>
     <message>
         <source>&amp;Video Stream</source>
-        <translation>视频轨道(&amp;V)</translation>
+        <translation type="vanished">视频轨道(&amp;V)</translation>
     </message>
     <message>
         <source>V&amp;olume</source>
@@ -1279,6 +1279,22 @@
     </message>
     <message>
         <source>&amp;Increase Delay</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1297,6 +1297,10 @@
         <source>&amp;Reset Aspect</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Disable &amp;aspect</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Unlike MPC-HC, it's not a horizontal or vertical zooming/unzooming action, the video always uses as much space as possible given the aspect ratio.
An other advantage is that it requires only two keys instead of four.

#55
Fixes #62