### PR TITLE
Remove remaining mac code for Quick Open

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -529,9 +529,6 @@ void MainWindow::setupMenu()
 
     ui->infoStats->setVisible(false);
 
-    QString quickOpenKeys = tr("Ctrl+Q");
-    ui->actionFileOpenQuick->setShortcut(quickOpenKeys);
-
     connect(Platform::deviceManager(), &DeviceManager::deviceListChanged,
             this, [this]() { updateDiscList(); });
 }

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -912,6 +912,9 @@
    <property name="text">
     <string>&amp;Quick Open File...</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="actionFileOpen">
    <property name="text">


### PR DESCRIPTION
Quick Open File or Quick Add To Playlist (if opened). Added by 93e7ab159bbc8a4a91eef75b4aefc097b221dd90 (mainwindow: conditionally set quick open shortcut) and left behind by efa5c64dcb49cb2b49ef11cbc717bc85f2ed03d2 (platform: completely remove mac code from project)