### PR TITLE
Decrease the default subtitles delay step to 100 ms

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -451,7 +451,7 @@ private:
     bool hasAudio = false;
     bool hasSubs = false;
     QString subtitleText;
-    int subtitlesDelayStep = 500;
+    int subtitlesDelayStep = 100;
     int volumeStep = 10;
     bool frozenWindow = true;
     double sizeFactor_ = 1;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -408,7 +408,7 @@ void MpvObject::setSubtitlesDelay(int subDelayStep)
 {
     double newSubDelay = getMpvPropertyVariant("sub-delay").toDouble() + (double) subDelayStep / 1000;
     setMpvPropertyVariant("sub-delay", QString::number(newSubDelay, 'f', 3));
-    showMessage(tr("Subtitles delay: %1 ms").arg(newSubDelay * 1000));
+    showMessage(tr("Subtitles delay: %1 ms").arg(std::round(newSubDelay * 1000)));
 }
 
 void MpvObject::setVideoAspect(double aspectDiff)


### PR DESCRIPTION
- Decrease the default subtitles delay step to 100 ms
500 ms is too high to correctly synchronize subtitles.
- Round the subtitle delay shown in OSD
Sometimes, mpv returns a very small double value instead of zero.