### PR TITLE
Add an OSD timer

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -914,6 +914,7 @@ void MainWindow::setOSDPage(int page)
     ui->actionViewOSDMessages->setChecked(page == 0);
     ui->actionViewOSDStatistics->setChecked(page == 1);
     ui->actionViewOSDFrameTimings->setChecked(page == 2);
+    ui->actionViewOSDTimer->setEnabled(page == 0);
     mpvObject_->showStatsPage(page);
 }
 
@@ -2426,21 +2427,25 @@ void MainWindow::on_actionViewPresetsNormal_triggered()
 void MainWindow::on_actionViewOSDNone_triggered()
 {
     mpvObject_->showStatsPage(-1);
+    ui->actionViewOSDTimer->setEnabled(false);
 }
 
 void MainWindow::on_actionViewOSDMessages_triggered()
 {
     mpvObject_->showStatsPage(0);
+    ui->actionViewOSDTimer->setEnabled(true);
 }
 
 void MainWindow::on_actionViewOSDStatistics_triggered()
 {
     mpvObject_->showStatsPage(1);
+    ui->actionViewOSDTimer->setEnabled(false);
 }
 
 void MainWindow::on_actionViewOSDFrameTimings_triggered()
 {
     mpvObject_->showStatsPage(2);
+    ui->actionViewOSDTimer->setEnabled(false);
 }
 
 void MainWindow::on_actionViewOSDCycle_triggered()
@@ -2453,6 +2458,16 @@ void MainWindow::on_actionViewOSDCycle_triggered()
     nextOsdAction = osdActionGroup->actions().value(newpage+1, nullptr);
     if (nextOsdAction)
         nextOsdAction->setChecked(true);
+    ui->actionViewOSDTimer->setEnabled(newpage == 0);
+
+}
+
+void MainWindow::on_actionViewOSDTimer_triggered()
+{
+    double time = mpvObject_->playTime();
+    double length = mpvObject_->playLength();
+    mpvObject_->showMessage(tr("%1 / %2").arg(Helpers::toDateFormatFixed(time, Helpers::ShortFormat),
+                                              Helpers::toDateFormatFixed(length, Helpers::ShortFormat))); 
 }
 
 void MainWindow::on_actionViewFullscreen_toggled(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -308,6 +308,7 @@ private slots:
     void on_actionViewOSDStatistics_triggered();
     void on_actionViewOSDFrameTimings_triggered();
     void on_actionViewOSDCycle_triggered();
+    void on_actionViewOSDTimer_triggered();
 
     void on_actionViewPresetsMinimal_triggered();
     void on_actionViewPresetsCompact_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -718,6 +718,8 @@
      <addaction name="actionViewOSDFrameTimings"/>
      <addaction name="separator"/>
      <addaction name="actionViewOSDCycle"/>
+     <addaction name="separator"/>
+     <addaction name="actionViewOSDTimer"/>
     </widget>
     <addaction name="actionViewHideMenu"/>
     <addaction name="actionViewHideSeekbar"/>
@@ -1967,6 +1969,14 @@
    </property>
    <property name="text">
     <string>&amp;No Messages</string>
+   </property>
+  </action>
+  <action name="actionViewOSDTimer">
+   <property name="text">
+    <string>&amp;Show OSD Timer</string>
+   </property>
+   <property name="shortcut">
+    <string>I</string>
    </property>
   </action>
   <action name="actionViewFullscreenEscape">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -2101,7 +2101,7 @@
     <string>Controls in Fullscreen</string>
    </property>
    <property name="shortcut">
-    <string>i</string>
+    <string>C</string>
    </property>
   </action>
   <action name="actionPlaySubtitlesCopy">


### PR DESCRIPTION
- Add an OSD timer
Shown 1 second by key press or continuously if the key is kept pressed
- Change the default key shortcut for Controls in Fullscreen to C