### PR TITLE
Increase OSD messages timeout to 2000 ms

### DIFF
--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -292,7 +292,7 @@ QStringList MpvObject::supportedProtocols()
 void MpvObject::showMessage(QString message)
 {
     if (shownStatsPage == 0)
-        emit ctrlCommand(QVariantList({"show_text", message, "1000"}));
+        emit ctrlCommand(QVariantList({"show_text", message, "2000"}));
 }
 
 void MpvObject::showStatsPage(int page)


### PR DESCRIPTION
It was 1000 ms, which is very short especially for showing the OSD timer.
A setting could also be added to change this timeout.