### PR TITLE
Add an option to show OSD timer on seek

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -620,6 +620,8 @@ void Flow::setupSettingsConnections()
             mainWindow, &MainWindow::setTimeShortMode);
     connect(settingsWindow, &SettingsWindow::timeTooltip,
             mainWindow, &MainWindow::setTimeTooltip);
+    connect(settingsWindow, &SettingsWindow::osdTimerOnSeek,
+            mainWindow, &MainWindow::setOsdTimerOnSeek);
 
     // settings -> playlistWindow
     connect(settingsWindow, &SettingsWindow::iconTheme,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1217,6 +1217,18 @@ void MainWindow::updateDiscList()
     ui->menuFileOpenDisc->setEnabled(addedSomething);
 }
 
+void MainWindow::showOsdTimer(bool onSeek)
+{
+    if (!onSeek || osdTimerOnSeek) {
+        double time = mpvObject_->playTime();
+        double length = mpvObject_->playLength();
+        mpvObject_->showMessage(tr("%1 / %2").arg(Helpers::toDateFormatFixed(time,
+                                                         Helpers::ShortFormat),
+                                                  Helpers::toDateFormatFixed(length,
+                                                         Helpers::ShortFormat)));
+    }
+}
+
 QList<QUrl> MainWindow::doQuickOpenFileDialog()
 {
     static QFileDialog::Options options = QFileDialog::Options();
@@ -1815,6 +1827,11 @@ void MainWindow::setTimeTooltip(bool shown, bool above)
 {
     timeTooltipShown = shown;
     timeTooltipAbove = above;
+}
+
+void MainWindow::setOsdTimerOnSeek(bool enabled)
+{
+    osdTimerOnSeek = enabled;
 }
 
 void MainWindow::setFullscreenHidePanels(bool hidden)
@@ -2461,10 +2478,7 @@ void MainWindow::on_actionViewOSDCycle_triggered()
 
 void MainWindow::on_actionViewOSDTimer_triggered()
 {
-    double time = mpvObject_->playTime();
-    double length = mpvObject_->playLength();
-    mpvObject_->showMessage(tr("%1 / %2").arg(Helpers::toDateFormatFixed(time, Helpers::ShortFormat),
-                                              Helpers::toDateFormatFixed(length, Helpers::ShortFormat))); 
+    showOsdTimer(false);
 }
 
 void MainWindow::on_actionViewFullscreen_toggled(bool checked)
@@ -2663,21 +2677,25 @@ void MainWindow::on_actionPlayRateReset_triggered()
 void MainWindow::on_actionPlaySeekForwards_triggered()
 {
     emit relativeSeek(true, false);
+    showOsdTimer(true);
 }
 
 void MainWindow::on_actionPlaySeekBackwards_triggered()
 {
     emit relativeSeek(false, false);
+    showOsdTimer(true);
 }
 
 void MainWindow::on_actionPlaySeekForwardsFine_triggered()
 {
     emit relativeSeek(true, true);
+    showOsdTimer(true);
 }
 
 void MainWindow::on_actionPlaySeekBackwardsFine_triggered()
 {
     emit relativeSeek(false, true);
+    showOsdTimer(true);
 }
 
 void MainWindow::on_actionPlaySubtitlesEnabled_triggered(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -108,6 +108,7 @@ private:
     void updateWindowFlags();
     void updateMouseHideTime();
     void updateDiscList();
+    void showOsdTimer(bool onSeek);
     QList<QUrl> doQuickOpenFileDialog();
 
 signals:
@@ -242,6 +243,7 @@ public slots:
     void setBottomAreaBehavior(Helpers::ControlHiding method);
     void setBottomAreaHideTime(int milliseconds);
     void setTimeTooltip(bool show, bool above);
+    void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
     void setPlaybackState(PlaybackManager::PlaybackState state);
     void setPlaybackType(PlaybackManager::PlaybackType type);
@@ -442,6 +444,7 @@ private:
     int bottomAreaHideTime = 0;
     bool timeTooltipShown = true;
     bool timeTooltipAbove = true;
+    bool osdTimerOnSeek = false;
     bool timeShortMode = false;
 
     QString previousOpenDir;

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1066,6 +1066,7 @@ void SettingsWindow::sendSignals()
     emit timeShorten(WIDGET_LOOKUP(ui->tweaksTimeShort).toBool());
     emit timeTooltip(WIDGET_LOOKUP(ui->tweaksTimeTooltip).toBool(),
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);
+    emit osdTimerOnSeek(WIDGET_LOOKUP(ui->tweaksOsdTimerOnSeek).toBool());
 }
 
 void SettingsWindow::sendAcceptedSettings()

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -175,6 +175,7 @@ signals:
     void mpvMouseEvents(bool yes);
     void mpvKeyEvents(bool yes);
     void timeTooltip(bool yes, bool above);
+    void osdTimerOnSeek(bool yes);
     void osdFont(const QString &family, const QString &size);
 
     // bchs should be part of a filter module page, hence the funny name

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7635,6 +7635,44 @@ media file played</string>
              </property>
             </widget>
            </item>
+           <item row="4" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksVolumeLimit">
+             <property name="text">
+              <string>Limit volume to 100% like mpc-hc</string>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksTimeShort">
+             <property name="text">
+              <string>Shorten the playback time indicator like mpc-hc</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksPreferWayland">
+             <property name="text">
+              <string>Prefer Wayland over XWayland (restart required)</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksMpvMouseEvents">
+             <property name="text">
+              <string>Send mouse events to mpv</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksMpvKeyEvents">
+             <property name="text">
+              <string>Send key events to mpv</string>
+             </property>
+            </widget>
+           </item>
            <item row="9" column="0">
             <widget class="QCheckBox" name="tweaksTimeTooltip">
              <property name="sizePolicy">
@@ -7694,44 +7732,6 @@ media file played</string>
               </widget>
              </item>
             </layout>
-           </item>
-           <item row="4" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksVolumeLimit">
-             <property name="text">
-              <string>Limit volume to 100% like mpc-hc</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksTimeShort">
-             <property name="text">
-              <string>Shorten the playback time indicator like mpc-hc</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksPreferWayland">
-             <property name="text">
-              <string>Prefer Wayland over XWayland (restart required)</string>
-             </property>
-            </widget>
-           </item>
-           <item row="7" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksMpvMouseEvents">
-             <property name="text">
-              <string>Send mouse events to mpv</string>
-             </property>
-            </widget>
-           </item>
-           <item row="8" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksMpvKeyEvents">
-             <property name="text">
-              <string>Send key events to mpv</string>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7706,14 +7706,21 @@ media file played</string>
              </item>
             </widget>
            </item>
-           <item row="10" column="0">
+           <item row="10" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
+             <property name="text">
+              <string>Show OSD timer on seek</string>
+             </property>
+            </widget>
+           </item>
+           <item row="11" column="0">
             <widget class="QLabel" name="tweaksOsdFontLabel">
              <property name="text">
               <string>OSD font:</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="1">
+           <item row="11" column="1">
             <layout class="QHBoxLayout" name="tweaksOsdLayout" stretch="1,0">
              <item>
               <widget class="QFontComboBox" name="tweaksOsdFont"/>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1247,7 +1247,7 @@
     </message>
     <message>
         <source>i</source>
-        <translation>i</translation>
+        <translation type="vanished">i</translation>
     </message>
     <message>
         <source>&amp;Previous File</source>
@@ -1295,19 +1295,51 @@
     </message>
     <message>
         <source>&amp;Decrease Aspect</source>
-        <translation>&amp;Decrease Aspect</translation>
+        <translation type="vanished">&amp;Decrease Aspect</translation>
     </message>
     <message>
         <source>&amp;Increase Aspect</source>
-        <translation>&amp;Increase Aspect</translation>
+        <translation type="vanished">&amp;Increase Aspect</translation>
     </message>
     <message>
         <source>&amp;Reset Aspect</source>
-        <translation>&amp;Reset Aspect</translation>
+        <translation type="vanished">&amp;Reset Aspect</translation>
     </message>
     <message>
         <source>Disable &amp;aspect</source>
-        <translation>Disable &amp;aspect</translation>
+        <translation type="vanished">Disable &amp;aspect</translation>
+    </message>
+    <message>
+        <source>&amp;Show OSD Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3854,6 +3886,10 @@ media file played</translation>
     <message>
         <source>nVidia only (faster than CUDA)</source>
         <translation>nVidia only (faster than CUDA)</translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1238,10 +1238,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1286,19 +1282,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Decrease Aspect</source>
+        <source>&amp;Show OSD Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Increase Aspect</source>
+        <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Reset Aspect</source>
+        <source>&amp;Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable &amp;aspect</source>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3833,6 +3845,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -101,11 +101,11 @@
     </message>
     <message>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Palauta</translation>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Poista</translation>
     </message>
     <message>
         <source>Close</source>
@@ -128,7 +128,7 @@
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tyhjennä</translation>
     </message>
     <message>
         <source>Save File</source>
@@ -1218,10 +1218,6 @@
         <translation>Säätimet Koko Näytön Tilassa</translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation>&amp;Edellinen Tiedosto</translation>
     </message>
@@ -1267,19 +1263,51 @@
     </message>
     <message>
         <source>&amp;Decrease Aspect</source>
-        <translation>&amp;Pienennä Kuvasuhdetta</translation>
+        <translation type="vanished">&amp;Pienennä Kuvasuhdetta</translation>
     </message>
     <message>
         <source>&amp;Increase Aspect</source>
-        <translation>&amp;Kasvata Kuvasuhdetta</translation>
+        <translation type="vanished">&amp;Kasvata Kuvasuhdetta</translation>
     </message>
     <message>
         <source>&amp;Reset Aspect</source>
-        <translation>&amp;Palauta Kuvasuhde</translation>
+        <translation type="vanished">&amp;Palauta Kuvasuhde</translation>
     </message>
     <message>
         <source>Disable &amp;aspect</source>
-        <translation>Poista &amp;Kuvasuhde Käytöstä</translation>
+        <translation type="vanished">Poista &amp;Kuvasuhde Käytöstä</translation>
+    </message>
+    <message>
+        <source>&amp;Show OSD Timer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1908,7 +1936,7 @@
     </message>
     <message>
         <source>Playlist</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Soittolista</translation>
     </message>
     <message>
         <source>Subtitles</source>
@@ -2238,7 +2266,7 @@ media file played</source>
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Yleinen</translation>
     </message>
     <message>
         <source>Framebuffer</source>
@@ -2422,7 +2450,7 @@ media file played</source>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ikkuna</translation>
     </message>
     <message>
         <source>Box</source>
@@ -2726,7 +2754,7 @@ media file played</source>
     </message>
     <message>
         <source>Clip</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Leike</translation>
     </message>
     <message>
         <source>Mobius</source>
@@ -2886,7 +2914,7 @@ media file played</source>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Poista</translation>
     </message>
     <message>
         <source>Add to shaders</source>
@@ -2966,7 +2994,7 @@ media file played</source>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Ei Mitään</translation>
     </message>
     <message>
         <source>Default</source>
@@ -3102,11 +3130,11 @@ media file played</source>
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Vasen</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Oikea</translation>
     </message>
     <message>
         <source>Y</source>
@@ -3787,6 +3815,10 @@ media file played</source>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1238,10 +1238,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1286,19 +1282,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Decrease Aspect</source>
+        <source>&amp;Show OSD Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Increase Aspect</source>
+        <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Reset Aspect</source>
+        <source>&amp;Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable &amp;aspect</source>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3829,6 +3841,10 @@ media file played</source>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1230,10 +1230,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1278,19 +1274,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Decrease Aspect</source>
+        <source>&amp;Show OSD Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Increase Aspect</source>
+        <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Reset Aspect</source>
+        <source>&amp;Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable &amp;aspect</source>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3809,6 +3821,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1246,10 +1246,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1294,19 +1290,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Decrease Aspect</source>
+        <source>&amp;Show OSD Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Increase Aspect</source>
+        <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Reset Aspect</source>
+        <source>&amp;Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable &amp;aspect</source>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3845,6 +3857,10 @@ media file played</source>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1238,10 +1238,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>i</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Previous File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1286,19 +1282,35 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Decrease Aspect</source>
+        <source>&amp;Show OSD Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Increase Aspect</source>
+        <source>I</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Reset Aspect</source>
+        <source>&amp;Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Disable &amp;aspect</source>
+        <source>&amp;Increase Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Reset Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3807,6 +3819,10 @@ media file played</source>
     </message>
     <message>
         <source>nVidia only (faster than CUDA)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show OSD timer on seek</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- Add an option to show OSD timer on seek
In Tweaks, disabled by default.
- Reorder Tweaks section of settings (code style)