### PR TITLE
Don't show aspect ratio OSD message when opening a new file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -776,8 +776,8 @@ void Flow::setupFlowConnections()
             this, &Flow::manager_stoppedPlaying);
     connect(playbackManager, &PlaybackManager::stateChanged,
             this, &Flow::manager_stateChanged);
-    connect(playbackManager, &PlaybackManager::fileOpenedOrClosed,
-            this, &Flow::manager_fileOpenedOrClosed);
+    connect(playbackManager, &PlaybackManager::fileClosed,
+            this, &Flow::manager_fileClosed);
     connect(playbackManager, &PlaybackManager::instanceShouldClose,
             this, &Flow::mainwindow_instanceShouldQuit);
     connect(playbackManager, &PlaybackManager::subtitlesVisible,
@@ -1288,7 +1288,7 @@ void Flow::manager_stateChanged(PlaybackManager::PlaybackState state)
     screenSaver->inhibitSaver(tr("Playing Media"));
 }
 
-void Flow::manager_fileOpenedOrClosed()
+void Flow::manager_fileClosed()
 {
     mainWindow->disableChaptersMenus();
 }

--- a/main.h
+++ b/main.h
@@ -74,7 +74,7 @@ private slots:
     void mainwindow_optionsOpenRequested();
     void manager_playLengthChanged();
     void manager_stateChanged(PlaybackManager::PlaybackState state);
-    void manager_fileOpenedOrClosed();
+    void manager_fileClosed();
     void manager_subtitlesVisible(bool visible);
     void manager_hasNoSubtitles(bool none);
     void manager_openingNewFile();

--- a/manager.cpp
+++ b/manager.cpp
@@ -828,6 +828,7 @@ void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
         return;
     else if (eof.isEmpty()) {
         emit fileOpenedOrClosed();
+        showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;
         return;
     }
 
@@ -939,9 +940,17 @@ void PlaybackManager::mpvw_videoBitrateChanged(double bitrate)
 
 void PlaybackManager::mpvw_aspectNameChanged(QString newAspectName)
 {
-    if (!newAspectName.isEmpty()) {
-        mpvObject_->showMessage(tr("Aspect ratio: %1").arg(newAspectName));
+    // If it's the first file opened with mpc-qt, OnFirstPlay gets skipped
+    if (showAspectOsdTriggeredBy == AspectNameChanged::OnOpen) {
+        if (newAspectName.isEmpty())
+            showAspectOsdTriggeredBy = AspectNameChanged::OnFirstPlay;
+        else
+            showAspectOsdTriggeredBy = AspectNameChanged::Manually;
     }
+    else if (showAspectOsdTriggeredBy == AspectNameChanged::OnFirstPlay)
+        showAspectOsdTriggeredBy = AspectNameChanged::Manually;
+    else if (!newAspectName.isEmpty())
+        mpvObject_->showMessage(tr("Aspect ratio: %1").arg(newAspectName));
 }
 
 void PlaybackManager::mpvw_metadataChanged(QVariantMap metadata)

--- a/manager.cpp
+++ b/manager.cpp
@@ -827,7 +827,7 @@ void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
     if (eof == strFalse)
         return;
     else if (eof.isEmpty()) {
-        emit fileOpenedOrClosed();
+        emit fileClosed();
         showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;
         return;
     }

--- a/manager.cpp
+++ b/manager.cpp
@@ -6,6 +6,8 @@
 #include "logger.h"
 
 using namespace Helpers;
+static const char strTrue[] =  "true";
+static const char strFalse[] =  "false";
 
 Q_GLOBAL_STATIC_WITH_ARGS(QRegularExpression, wordSplitter, ("\\W+"));
 
@@ -816,13 +818,15 @@ void PlaybackManager::mpvw_playbackFinished() {
     if (playbackState_ == BufferingState || playbackState_ == WaitingState) {
         playbackState_ = StoppedState;
         emit stateChanged(playbackState_);
-        mpvw_eofReachedChanged(true);
+        mpvw_eofReachedChanged(strTrue);
     }
 }
 
-void PlaybackManager::mpvw_eofReachedChanged(bool eof) {
-    LogStream("manager") << "mpvw_eofReachedChanged";
-    if (!eof) {
+void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
+    LogStream("manager") << "mpvw_eofReachedChanged eof: " << eof;
+    if (eof == strFalse)
+        return;
+    else if (eof.isEmpty()) {
         emit fileOpenedOrClosed();
         return;
     }

--- a/manager.h
+++ b/manager.h
@@ -54,7 +54,7 @@ signals:
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
     void stateChanged(PlaybackManager::PlaybackState state);
-    void fileOpenedOrClosed();
+    void fileClosed();
     void typeChanged(PlaybackManager::PlaybackType type);
     // Transmit a map of chapter index to time,description pairs
     void chaptersAvailable(QList<QPair<double,QString>> chapters);

--- a/manager.h
+++ b/manager.h
@@ -179,7 +179,7 @@ private slots:
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling();
     void mpvw_playbackFinished();
-    void mpvw_eofReachedChanged(bool eof);
+    void mpvw_eofReachedChanged(QString eof);
     void mpvw_mediaTitleChanged(QString title);
     void mpvw_chapterDataChanged(QVariantMap metadata);
     void mpvw_chaptersChanged(QVariantList chapters);

--- a/manager.h
+++ b/manager.h
@@ -157,6 +157,7 @@ public slots:
                              int64_t &audioTrack, int64_t &subtitleTrack);
 
 private:
+    enum AspectNameChanged { OnOpen, OnFirstPlay, Manually };
     void startPlayWithUuid(QUrl what, QUuid playlistUuid, QUuid itemUuid,
                            bool isRepeating, QUrl with = QUrl());
     void selectDesiredTracks();
@@ -239,6 +240,8 @@ private:
     bool folderFallback = false;
 
     bool timeShortMode = false;
+
+    PlaybackManager::AspectNameChanged showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;
 
     Helpers::AfterPlayback afterPlaybackOnce = Helpers::DoNothingAfter;
     Helpers::AfterPlayback afterPlaybackAlways = Helpers::DoNothingAfter;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -46,7 +46,7 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("duration", self_playLengthChanged, toDouble, -1.0),
     HANDLE_PROP("seekable", seekableChanged, toBool, false),
     HANDLE_PROP("pause", pausedChanged, toBool, true),
-    HANDLE_PROP("eof-reached", eofReachedChanged, toBool, false),
+    HANDLE_PROP("eof-reached", eofReachedChanged, toString, QString()),
     HANDLE_PROP("media-title", mediaTitleChanged, toString, QString()),
     HANDLE_PROP("chapter-metadata", chapterDataChanged, toMap, QVariantMap()),
     HANDLE_PROP("chapter-list", chaptersChanged, toList, QVariantList()),

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -113,7 +113,7 @@ signals:
     void playbackLoading();
     void playbackStarted();
     void pausedChanged(bool yes);
-    void eofReachedChanged(bool eof);
+    void eofReachedChanged(QString eof);
     void playbackFinished();
     void playbackIdling();
     void mediaTitleChanged(QString title);


### PR DESCRIPTION
- Don't convert eof-reached to bool
eof-reached is the first watched property notification that a new file is being opened.
On file change, eof-reached, which is then an empty string, can't be converted to bool, so it's set to default (false). Thus we can't know if it's a new file or a file being played again after reaching the end.
- Don't show aspect ratio OSD message when opening a new file
With the first file opened with mpc-qt, aspect-name isn't first set to empty, so OnFirstPlay gets skipped.
- Rename fileOpenedOrClosed to fileClosed now that it's more precise