### PR TITLE
Don't show "Mute:" and "Volume:" OSD messages when opening mpc-qt

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2028,10 +2028,10 @@ void MainWindow::setSubtitleText(QString subText)
     subtitleText = subText;
 }
 
-void MainWindow::setVolume(int level)
+void MainWindow::setVolume(int level, bool onInit)
 {
     volumeSlider_->setValue(level);
-    emit volumeChanged(level);
+    emit volumeChanged(level, onInit);
 }
 
 void MainWindow::setVolumeDouble(double level)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -202,7 +202,7 @@ void MainWindow::setState(const QVariantMap &map)
     UNWRAP(ui->actionPlayVolumeMute, false);
 
     on_actionPlaySubtitlesEnabled_triggered(ui->actionPlaySubtitlesEnabled->isChecked());
-    on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked());
+    on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked(), true);
     setOSDPage(map.value("shownStatsPage",0).toInt());
     updateOnTop();
 
@@ -2784,9 +2784,9 @@ void MainWindow::on_actionPlayVolumeDown_triggered()
     volumeSlider_->setValue(newvol);
 }
 
-void MainWindow::on_actionPlayVolumeMute_toggled(bool checked)
+void MainWindow::on_actionPlayVolumeMute_toggled(bool checked, bool onInit)
 {
-    emit volumeMuteChanged(checked);
+    emit volumeMuteChanged(checked, onInit);
     ui->actionPlayVolumeMute->setChecked(checked);
     ui->mute->setChecked(checked);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -145,7 +145,7 @@ signals:
     void subtitlesEnabled(bool enabled);
     void nextSubtitleSelected();
     void previousSubtitleSelected();
-    void volumeChanged(int64_t volume);
+    void volumeChanged(int64_t volume, bool onInit = false);
     void volumeMuteChanged(bool muted, bool onInit);
     void afterPlaybackOnce(Helpers::AfterPlayback action);
     void afterPlaybackAlways(Helpers::AfterPlayback action);
@@ -256,7 +256,7 @@ public slots:
     void videoTrackSet(int64_t id);
     void subtitleTrackSet(int64_t id);
     void setSubtitleText(QString subText);
-    void setVolume(int level);
+    void setVolume(int level, bool onInit = false);
     void setVolumeDouble(double level);
     void setVolumeMax(int level);
     void setSubtitlesDelayStep(int subtitlesDelayStep);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -146,7 +146,7 @@ signals:
     void nextSubtitleSelected();
     void previousSubtitleSelected();
     void volumeChanged(int64_t volume);
-    void volumeMuteChanged(bool muted);
+    void volumeMuteChanged(bool muted, bool onInit);
     void afterPlaybackOnce(Helpers::AfterPlayback action);
     void afterPlaybackAlways(Helpers::AfterPlayback action);
     void chapterPrevious();
@@ -370,7 +370,7 @@ private slots:
 
     void on_actionPlayVolumeUp_triggered();
     void on_actionPlayVolumeDown_triggered();
-    void on_actionPlayVolumeMute_toggled(bool checked);
+    void on_actionPlayVolumeMute_toggled(bool checked, bool onInit = false);
 
     void on_actionPlayAfterOnceExit_triggered();
     void on_actionPlayAfterOnceStandby_triggered();

--- a/manager.cpp
+++ b/manager.cpp
@@ -451,14 +451,15 @@ void PlaybackManager::selectPrevSubtitle()
     setSubtitleTrack(previousSubs, true);
 }
 
-void PlaybackManager::setVolume(int64_t volume)
+void PlaybackManager::setVolume(int64_t volume, bool onInit)
 {
     static int64_t lastVol = -1;
     if (lastVol == volume)
         return;
     lastVol = volume;
     mpvObject_->setVolume(volume);
-    mpvObject_->showMessage(tr("Volume: %1%").arg(volume));
+    if (!onInit)
+        mpvObject_->showMessage(tr("Volume: %1%").arg(volume));
 }
 
 void PlaybackManager::setMute(bool muted, bool onInit)

--- a/manager.cpp
+++ b/manager.cpp
@@ -461,10 +461,11 @@ void PlaybackManager::setVolume(int64_t volume)
     mpvObject_->showMessage(tr("Volume: %1%").arg(volume));
 }
 
-void PlaybackManager::setMute(bool muted)
+void PlaybackManager::setMute(bool muted, bool onInit)
 {
     mpvObject_->setMute(muted);
-    mpvObject_->showMessage(muted ? tr("Mute: on") : tr("Mute: off"));
+    if (!onInit)
+        mpvObject_->showMessage(muted ? tr("Mute: on") : tr("Mute: off"));
 }
 
 void PlaybackManager::setAfterPlaybackOnce(AfterPlayback mode)

--- a/manager.h
+++ b/manager.h
@@ -136,7 +136,7 @@ public slots:
     void selectNextSubtitle();
     void selectPrevSubtitle();
     void setVolume(int64_t volume);
-    void setMute(bool muted);
+    void setMute(bool muted, bool onInit);
     void setAfterPlaybackOnce(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlways(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlwaysDefault(Helpers::AfterPlayback mode);

--- a/manager.h
+++ b/manager.h
@@ -135,7 +135,7 @@ public slots:
     void setSubtitleEnabled(bool enabled);
     void selectNextSubtitle();
     void selectPrevSubtitle();
-    void setVolume(int64_t volume);
+    void setVolume(int64_t volume, bool onInit = false);
     void setMute(bool muted, bool onInit);
     void setAfterPlaybackOnce(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlways(Helpers::AfterPlayback mode);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -757,7 +757,7 @@ void SettingsWindow::sendSignals()
     int vol = WIDGET_LOOKUP(ui->playbackVolume).toInt();
     int volmax = WIDGET_LOOKUP(ui->tweaksVolumeLimit).toBool() ? 100 : 130;
     emit volumeMax(volmax);
-    emit volume(std::min(vol, volmax));
+    emit volume(std::min(vol, volmax), true);
     emit volumeStep(WIDGET_LOOKUP(ui->playbackVolumeStep).toInt());
     {
         int i = WIDGET_LOOKUP(ui->playbackSpeedStep).toInt();

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -110,7 +110,7 @@ signals:
     void webserverRoot(QString root);
     void webserverDefaultPage(QString page);
 
-    void volume(int level);
+    void volume(int level, bool onInit);
     void balance(double pan);
     void volumeStep(int amount);
     void speedStep(double amount);


### PR DESCRIPTION
- Don't show "Mute: off" OSD message when opening mpc-qt
(or "Mute: on").
- Don't show "Volume:" OSD message when opening mpc-qt