### PR TITLE
Replace Fine (seek) step by Large step, Time step by Normal step

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -640,10 +640,10 @@ void Flow::setupSettingsConnections()
             playbackManager, &PlaybackManager::setSpeedStep);
     connect(settingsWindow, &SettingsWindow::speedStepAdditive,
             playbackManager, &PlaybackManager::setSpeedStepAdditive);
+    connect(settingsWindow, &SettingsWindow::stepTimeNormal,
+            playbackManager, &PlaybackManager::setStepTimeNormal);
     connect(settingsWindow, &SettingsWindow::stepTimeLarge,
             playbackManager, &PlaybackManager::setStepTimeLarge);
-    connect(settingsWindow, &SettingsWindow::stepTimeSmall,
-            playbackManager, &PlaybackManager::setStepTimeSmall);
     connect(settingsWindow, &SettingsWindow::trackSubtitlePreference,
             playbackManager, &PlaybackManager::setSubtitleTrackPreference);
     connect(settingsWindow, &SettingsWindow::trackAudioPreference,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1994,8 +1994,8 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     ui->menuPlaySubtitles->setEnabled(true);
     subtitleTracksGroup = new QActionGroup(this);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesEnabled);
-    ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesNext);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesPrevious);
+    ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesNext);
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesCopy);
     ui->menuPlaySubtitles->addAction(ui->actionDecreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addAction(ui->actionIncreaseSubtitlesDelay);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -883,10 +883,10 @@ void MainWindow::globalizeAllActions()
     for (QAction *a : ui->menubar->actions()) {
         addAction(a);
     }
-    addAction(ui->actionPlaySeekForwards);
-    addAction(ui->actionPlaySeekForwardsFine);
-    addAction(ui->actionPlaySeekBackwards);
-    addAction(ui->actionPlaySeekBackwardsFine);
+    addAction(ui->actionPlaySeekForwardsNormal);
+    addAction(ui->actionPlaySeekForwardsLarge);
+    addAction(ui->actionPlaySeekBackwardsNormal);
+    addAction(ui->actionPlaySeekBackwardsLarge);
 }
 
 void MainWindow::setUiDecorationState(DecorationState state)
@@ -2674,25 +2674,25 @@ void MainWindow::on_actionPlayRateReset_triggered()
     emit speedReset();
 }
 
-void MainWindow::on_actionPlaySeekForwards_triggered()
+void MainWindow::on_actionPlaySeekForwardsNormal_triggered()
 {
     emit relativeSeek(true, false);
     showOsdTimer(true);
 }
 
-void MainWindow::on_actionPlaySeekBackwards_triggered()
+void MainWindow::on_actionPlaySeekBackwardsNormal_triggered()
 {
     emit relativeSeek(false, false);
     showOsdTimer(true);
 }
 
-void MainWindow::on_actionPlaySeekForwardsFine_triggered()
+void MainWindow::on_actionPlaySeekForwardsLarge_triggered()
 {
     emit relativeSeek(true, true);
     showOsdTimer(true);
 }
 
-void MainWindow::on_actionPlaySeekBackwardsFine_triggered()
+void MainWindow::on_actionPlaySeekBackwardsLarge_triggered()
 {
     emit relativeSeek(false, true);
     showOsdTimer(true);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -115,6 +115,18 @@ QList<QAction *> MainWindow::editableActions()
 {
     QList<QAction*> actionList;
     actionsToList(actionList, actions());
+
+    // Reorder actions so that seek keys aren't at the bottom
+    qsizetype indexOfActionPlayFrameForward = actionList.indexOf(ui->actionPlayFrameForward);
+    actionList.move(actionList.indexOf(ui->actionPlaySeekForwardsLarge),
+        indexOfActionPlayFrameForward + 1);
+    actionList.move(actionList.indexOf(ui->actionPlaySeekBackwardsLarge),
+        indexOfActionPlayFrameForward + 1);
+    actionList.move(actionList.indexOf(ui->actionPlaySeekForwardsNormal),
+        indexOfActionPlayFrameForward + 1);
+    actionList.move(actionList.indexOf(ui->actionPlaySeekBackwardsNormal),
+        indexOfActionPlayFrameForward + 1);
+
     return actionList;
 }
 
@@ -883,10 +895,10 @@ void MainWindow::globalizeAllActions()
     for (QAction *a : ui->menubar->actions()) {
         addAction(a);
     }
-    addAction(ui->actionPlaySeekForwardsNormal);
-    addAction(ui->actionPlaySeekForwardsLarge);
     addAction(ui->actionPlaySeekBackwardsNormal);
+    addAction(ui->actionPlaySeekForwardsNormal);
     addAction(ui->actionPlaySeekBackwardsLarge);
+    addAction(ui->actionPlaySeekForwardsLarge);
 }
 
 void MainWindow::setUiDecorationState(DecorationState state)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -138,7 +138,7 @@ signals:
     void speedDown();
     void speedUp();
     void speedReset();
-    void relativeSeek(bool forwards, bool isSmall);
+    void relativeSeek(bool forwards, bool isLarge);
     void audioTrackSelected(int64_t id, bool userSelected);
     void subtitleTrackSelected(int64_t id, bool userSelected);
     void videoTrackSelected(int64_t id, bool userSelected);
@@ -351,10 +351,10 @@ private slots:
     void on_actionPlayRateDecrease_triggered();
     void on_actionPlayRateIncrease_triggered();
     void on_actionPlayRateReset_triggered();
-    void on_actionPlaySeekForwards_triggered();
-    void on_actionPlaySeekBackwards_triggered();
-    void on_actionPlaySeekForwardsFine_triggered();
-    void on_actionPlaySeekBackwardsFine_triggered();
+    void on_actionPlaySeekForwardsNormal_triggered();
+    void on_actionPlaySeekBackwardsNormal_triggered();
+    void on_actionPlaySeekForwardsLarge_triggered();
+    void on_actionPlaySeekBackwardsLarge_triggered();
 
     void on_actionPlaySubtitlesEnabled_triggered(bool checked);
     void on_actionPlaySubtitlesNext_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1607,33 +1607,33 @@
     <string>Return</string>
    </property>
   </action>
-  <action name="actionPlaySeekForwards">
+  <action name="actionPlaySeekForwardsNormal">
    <property name="text">
-    <string>Seek Forwards</string>
+    <string>Seek Forwards (normal step)</string>
    </property>
    <property name="shortcut">
     <string>Right</string>
    </property>
   </action>
-  <action name="actionPlaySeekBackwards">
+  <action name="actionPlaySeekBackwardsNormal">
    <property name="text">
-    <string>Seek Backwards</string>
+    <string>Seek Backwards (normal step)</string>
    </property>
    <property name="shortcut">
     <string>Left</string>
    </property>
   </action>
-  <action name="actionPlaySeekForwardsFine">
+  <action name="actionPlaySeekForwardsLarge">
    <property name="text">
-    <string>Seek Forwards Finely</string>
+    <string>Seek Forwards (large step)</string>
    </property>
    <property name="shortcut">
     <string>Shift+Right</string>
    </property>
   </action>
-  <action name="actionPlaySeekBackwardsFine">
+  <action name="actionPlaySeekBackwardsLarge">
    <property name="text">
-    <string>Seek Backwards Finely</string>
+    <string>Seek Backwards (large step)</string>
    </property>
    <property name="shortcut">
     <string>Shift+Left</string>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -812,8 +812,8 @@
     </widget>
     <addaction name="actionPlayPause"/>
     <addaction name="actionPlayStop"/>
-    <addaction name="actionPlayFrameForward"/>
     <addaction name="actionPlayFrameBackward"/>
+    <addaction name="actionPlayFrameForward"/>
     <addaction name="separator"/>
     <addaction name="actionPlayRateDecrease"/>
     <addaction name="actionPlayRateIncrease"/>
@@ -1316,20 +1316,20 @@
     <string>.</string>
    </property>
   </action>
-  <action name="actionPlayFrameForward">
-   <property name="text">
-    <string>F&amp;rame Step Forward</string>
-   </property>
-   <property name="shortcut">
-    <string>Ctrl+Right</string>
-   </property>
-  </action>
   <action name="actionPlayFrameBackward">
    <property name="text">
     <string>Fra&amp;me Step Backward</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+Left</string>
+   </property>
+  </action>
+  <action name="actionPlayFrameForward">
+   <property name="text">
+    <string>F&amp;rame Step Forward</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Right</string>
    </property>
   </action>
   <action name="actionPlayRateDecrease">

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -758,8 +758,8 @@
       <string>Su&amp;btitles</string>
      </property>
      <addaction name="actionPlaySubtitlesEnabled"/>
-     <addaction name="actionPlaySubtitlesNext"/>
      <addaction name="actionPlaySubtitlesPrevious"/>
+     <addaction name="actionPlaySubtitlesNext"/>
      <addaction name="actionPlaySubtitlesCopy"/>
      <addaction name="actionDecreaseSubtitlesDelay"/>
      <addaction name="actionIncreaseSubtitlesDelay"/>
@@ -2007,20 +2007,20 @@
     <string notr="true"/>
    </property>
   </action>
-  <action name="actionPlaySubtitlesNext">
-   <property name="text">
-    <string>&amp;Next Subtitle</string>
-   </property>
-   <property name="shortcut">
-    <string notr="true">S</string>
-   </property>
-  </action>
   <action name="actionPlaySubtitlesPrevious">
    <property name="text">
     <string>&amp;Previous Subtitle</string>
    </property>
    <property name="shortcut">
     <string notr="true">Shift+S</string>
+   </property>
+  </action>
+  <action name="actionPlaySubtitlesNext">
+   <property name="text">
+    <string>&amp;Next Subtitle</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">S</string>
    </property>
   </action>
   <action name="actionDecreaseSubtitlesDelay">

--- a/manager.cpp
+++ b/manager.cpp
@@ -355,10 +355,10 @@ void PlaybackManager::speedReset()
     setPlaybackSpeed(1.0);
 }
 
-void PlaybackManager::relativeSeek(bool forwards, bool isSmall)
+void PlaybackManager::relativeSeek(bool forwards, bool isLarge)
 {
     mpvObject_->seek((forwards ? 1.0 : -1.0) *
-                     (isSmall ? stepTimeSmall : stepTimeLarge), isSmall);
+                     (isLarge ? stepTimeLarge : stepTimeNormal), !isLarge);
 }
 
 void PlaybackManager::setPlaybackSpeed(double speed)
@@ -379,14 +379,14 @@ void PlaybackManager::setSpeedStepAdditive(bool isAdditive)
     speedStepAdditive = isAdditive;
 }
 
+void PlaybackManager::setStepTimeNormal(int normalMsec)
+{
+    stepTimeNormal = normalMsec / 1000.0;
+}
+
 void PlaybackManager::setStepTimeLarge(int largeMsec)
 {
     stepTimeLarge = largeMsec / 1000.0;
-}
-
-void PlaybackManager::setStepTimeSmall(int smallMsec)
-{
-    stepTimeSmall = smallMsec / 1000.0;
 }
 
 void PlaybackManager::setSubtitleTrackPreference(QString langs)

--- a/manager.h
+++ b/manager.h
@@ -119,14 +119,14 @@ public slots:
     void speedUp();
     void speedDown();
     void speedReset();
-    void relativeSeek(bool forwards, bool isSmall);
+    void relativeSeek(bool forwards, bool isLarge);
 
     // output functions
     void setPlaybackSpeed(double speed);
     void setSpeedStep(double step);
     void setSpeedStepAdditive(bool isAdditive);
+    void setStepTimeNormal(int normalMsec);
     void setStepTimeLarge(int largeMsec);
-    void setStepTimeSmall(int smallMsec);
     void setSubtitleTrackPreference(QString langs);
     void setAudioTrackPreference(QString langs);
     void setAudioTrack(int64_t id, bool userSelected);
@@ -210,8 +210,8 @@ private:
     double mpvSpeed = 1.0;
     double speedStep = 2.0;
     bool speedStepAdditive = true;
-    double stepTimeLarge = 5.0;
-    double stepTimeSmall = 1.0;
+    double stepTimeNormal = 5.0;
+    double stepTimeLarge = 20.0;
     PlaybackState playbackState_ = StoppedState;
     PlaybackState playbackStartState = PlayingState;
 

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -764,8 +764,8 @@ void SettingsWindow::sendSignals()
         emit speedStep(i > 0 ? 1.0 + i/100.0 : 2.0);
         emit speedStepAdditive(WIDGET_LOOKUP(ui->playbackSpeedStepAdditive).toBool());
     }
-    emit stepTimeLarge(WIDGET_LOOKUP(ui->playbackTimeStep).toInt());
-    emit stepTimeSmall(WIDGET_LOOKUP(ui->playbackFineStep).toInt());
+    emit stepTimeNormal(WIDGET_LOOKUP(ui->playbackNormalStep).toInt());
+    emit stepTimeLarge(WIDGET_LOOKUP(ui->playbackLargeStep).toInt());
 
     emit playbackPlayTimes(WIDGET_LOOKUP(ui->playbackPlayAmount).toInt());
     emit playbackForever(WIDGET_LOOKUP(ui->playbackRepeatForever).toBool());

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -115,8 +115,8 @@ signals:
     void volumeStep(int amount);
     void speedStep(double amount);
     void speedStepAdditive(bool isAdditive);
+    void stepTimeNormal(int msec);
     void stepTimeLarge(int msec);
-    void stepTimeSmall(int msec);
     void zoomPreset(int which, double fitFactor);
     void zoomCenter(bool yes);
     void mouseHideTimeFullscreen(int msec);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1109,14 +1109,14 @@ media file played</string>
                </layout>
               </item>
               <item row="2" column="0">
-               <widget class="QLabel" name="playbackTimeStepLabel">
+               <widget class="QLabel" name="playbackNormalStepLabel">
                 <property name="text">
-                 <string>Time step</string>
+                 <string>Normal step</string>
                 </property>
                </widget>
               </item>
               <item row="2" column="1">
-               <widget class="QSpinBox" name="playbackTimeStep">
+               <widget class="QSpinBox" name="playbackNormalStep">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -1124,7 +1124,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string notr="true">ms</string>
+                 <string notr="true"> ms</string>
                 </property>
                 <property name="minimum">
                  <number>1</number>
@@ -1138,14 +1138,14 @@ media file played</string>
                </widget>
               </item>
               <item row="3" column="0">
-               <widget class="QLabel" name="playbackFineStepLabel">
+               <widget class="QLabel" name="playbackLargeStepLabel">
                 <property name="text">
-                 <string>Fine step</string>
+                 <string>Large step</string>
                 </property>
                </widget>
               </item>
               <item row="3" column="1">
-               <widget class="QSpinBox" name="playbackFineStep">
+               <widget class="QSpinBox" name="playbackLargeStep">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -1153,7 +1153,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string notr="true">ms</string>
+                 <string notr="true"> ms</string>
                 </property>
                 <property name="minimum">
                  <number>1</number>
@@ -1162,7 +1162,7 @@ media file played</string>
                  <number>60000</number>
                 </property>
                 <property name="value">
-                 <number>1000</number>
+                 <number>20000</number>
                 </property>
                </widget>
               </item>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Seek Forwards</translation>
+        <translation type="vanished">Seek Forwards</translation>
     </message>
     <message>
         <source>Right</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Seek Backwards</translation>
+        <translation type="vanished">Seek Backwards</translation>
     </message>
     <message>
         <source>Left</source>
@@ -823,7 +823,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Seek Forwards Finely</translation>
+        <translation type="vanished">Seek Forwards Finely</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -831,7 +831,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Seek Backwards Finely</translation>
+        <translation type="vanished">Seek Backwards Finely</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1340,6 +1340,22 @@
     <message>
         <source>%1 / %2</source>
         <translation>%1 / %2</translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2236,11 +2252,11 @@ media file played</translation>
     </message>
     <message>
         <source>Time step</source>
-        <translation>Time step</translation>
+        <translation type="vanished">Time step</translation>
     </message>
     <message>
         <source>Fine step</source>
-        <translation>Fine step</translation>
+        <translation type="vanished">Fine step</translation>
     </message>
     <message>
         <source>Center window when zooming</source>
@@ -3894,6 +3910,14 @@ media file played</translation>
     <message>
         <source>Show OSD timer on seek</source>
         <translation>Show OSD timer on seek</translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -147,7 +147,7 @@
     <name>MainWindow</name>
     <message>
         <source>Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Reproductor multimedia clásico Qute Theater</translation>
     </message>
     <message>
         <source>Play</source>
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Buscar hacia delante</translation>
+        <translation type="vanished">Buscar hacia delante</translation>
     </message>
     <message>
         <source>Right</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Buscar hacia atrás</translation>
+        <translation type="vanished">Buscar hacia atrás</translation>
     </message>
     <message>
         <source>Left</source>
@@ -823,7 +823,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Búsqueda hacia delante precisa</translation>
+        <translation type="vanished">Búsqueda hacia delante precisa</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -831,7 +831,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Búsqueda hacia atrás precisa</translation>
+        <translation type="vanished">Búsqueda hacia atrás precisa</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1311,6 +1311,22 @@
     </message>
     <message>
         <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2208,11 +2224,11 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Time step</source>
-        <translation>Paso de tiempo</translation>
+        <translation type="vanished">Paso de tiempo</translation>
     </message>
     <message>
         <source>Fine step</source>
-        <translation>Paso preciso</translation>
+        <translation type="vanished">Paso preciso</translation>
     </message>
     <message>
         <source>Center window when zooming</source>
@@ -3853,6 +3869,14 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -791,7 +791,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Etsi Eteenpäin</translation>
+        <translation type="vanished">Etsi Eteenpäin</translation>
     </message>
     <message>
         <source>Right</source>
@@ -799,7 +799,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Etsi Taaksepäin</translation>
+        <translation type="vanished">Etsi Taaksepäin</translation>
     </message>
     <message>
         <source>Left</source>
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Etsi Hienosti Eteenpäin</translation>
+        <translation type="vanished">Etsi Hienosti Eteenpäin</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Etsi Hienosti Taaksepäin</translation>
+        <translation type="vanished">Etsi Hienosti Taaksepäin</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1307,6 +1307,22 @@
     </message>
     <message>
         <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2198,14 +2214,6 @@ media file played</source>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Time step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fine step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3823,6 +3831,14 @@ media file played</source>
     </message>
     <message>
         <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -803,7 +803,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Pindah Maju</translation>
+        <translation type="vanished">Pindah Maju</translation>
     </message>
     <message>
         <source>Right</source>
@@ -811,7 +811,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Pindah Mundur</translation>
+        <translation type="vanished">Pindah Mundur</translation>
     </message>
     <message>
         <source>Left</source>
@@ -819,7 +819,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Pindah Maju Perlahan</translation>
+        <translation type="vanished">Pindah Maju Perlahan</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -827,7 +827,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Pindah Mundur Perlahan</translation>
+        <translation type="vanished">Pindah Mundur Perlahan</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1311,6 +1311,22 @@
     </message>
     <message>
         <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2200,14 +2216,6 @@ media file played</source>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Time step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fine step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3849,6 +3857,14 @@ media file played</source>
     </message>
     <message>
         <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -799,7 +799,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Cerca in avanti</translation>
+        <translation type="vanished">Cerca in avanti</translation>
     </message>
     <message>
         <source>Right</source>
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Cerca all&apos;indietro</translation>
+        <translation type="vanished">Cerca all&apos;indietro</translation>
     </message>
     <message>
         <source>Left</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Cerca in avanti con precisione</translation>
+        <translation type="vanished">Cerca in avanti con precisione</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -823,7 +823,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Cerca all&apos;indietro con precisione</translation>
+        <translation type="vanished">Cerca all&apos;indietro con precisione</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1303,6 +1303,22 @@
     </message>
     <message>
         <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2197,14 +2213,6 @@ ogni file multimediale riprodotto</translation>
     <message>
         <source>Auto</source>
         <translation>Auto</translation>
-    </message>
-    <message>
-        <source>Time step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fine step</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Center window when zooming</source>
@@ -3829,6 +3837,14 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>Искать вперёд</translation>
+        <translation type="vanished">Искать вперёд</translation>
     </message>
     <message>
         <source>Right</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>Искать назад</translation>
+        <translation type="vanished">Искать назад</translation>
     </message>
     <message>
         <source>Left</source>
@@ -823,7 +823,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>Тонкий поиск вперёд</translation>
+        <translation type="vanished">Тонкий поиск вперёд</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -831,7 +831,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>Тонкий поиск назад</translation>
+        <translation type="vanished">Тонкий поиск назад</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1320,6 +1320,22 @@
     <message>
         <source>%1 / %2</source>
         <translation>%1 / %2</translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2216,11 +2232,11 @@ media file played</source>
     </message>
     <message>
         <source>Time step</source>
-        <translation>Шаг изменения времени</translation>
+        <translation type="vanished">Шаг изменения времени</translation>
     </message>
     <message>
         <source>Fine step</source>
-        <translation>Нормальный шаг</translation>
+        <translation type="vanished">Нормальный шаг</translation>
     </message>
     <message>
         <source>Center window when zooming</source>
@@ -3866,6 +3882,14 @@ media file played</source>
     <message>
         <source>Show OSD timer on seek</source>
         <translation>Показывать таймер экранного уведомления при поиске</translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -807,7 +807,7 @@
     </message>
     <message>
         <source>Seek Forwards</source>
-        <translation>向后跳转</translation>
+        <translation type="vanished">向后跳转</translation>
     </message>
     <message>
         <source>Right</source>
@@ -815,7 +815,7 @@
     </message>
     <message>
         <source>Seek Backwards</source>
-        <translation>向前跳转</translation>
+        <translation type="vanished">向前跳转</translation>
     </message>
     <message>
         <source>Left</source>
@@ -823,7 +823,7 @@
     </message>
     <message>
         <source>Seek Forwards Finely</source>
-        <translation>向前跳转(小)</translation>
+        <translation type="vanished">向前跳转(小)</translation>
     </message>
     <message>
         <source>Shift+Right</source>
@@ -831,7 +831,7 @@
     </message>
     <message>
         <source>Seek Backwards Finely</source>
-        <translation>向前跳转(小)</translation>
+        <translation type="vanished">向前跳转(小)</translation>
     </message>
     <message>
         <source>Shift+Left</source>
@@ -1311,6 +1311,22 @@
     </message>
     <message>
         <source>%1 / %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (normal step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Forwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek Backwards (large step)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -2202,14 +2218,6 @@ media file played</source>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Time step</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fine step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3827,6 +3835,14 @@ media file played</source>
     </message>
     <message>
         <source>Show OSD timer on seek</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Normal step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Large step</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- Replace Fine (seek) step by Large step, Time step by Normal step
Users probably need a large seek step more than a finer seek step (than normal).
If users really want a finer seek step and we can find a way to fit a third option, we could add it later.
Fixes #117
- Reorder seek commands in options and frame step commands
Reorder actions so that seek actions aren't at the bottom in keys
settings.
Reorder seek and frame step commands so that back comes before next
(like for most other commands).
- Reorder Previous and Next subtitle commands
Reorder previous and next subtitle commands so that their order matches
the order of all other commands (previous at the top, next at the
bottom).