### PR TITLE
Handle QEvent::ApplicationPaletteChange for DrawnSlider

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -329,6 +329,9 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     if (object == ui->bottomArea && event->type() == QEvent::Leave)
         this->leaveBottomArea();
 
+    if (event->type() == QEvent::ApplicationPaletteChange)
+        positionSlider_->applicationPaletteChanged();
+
     if (Platform::isWindows && event->type() == QEvent::KeyPress) {
         QKeyEvent *ke = static_cast<QKeyEvent*>(event);
         switch (ke->key()) {

--- a/widgets/drawnslider.cpp
+++ b/widgets/drawnslider.cpp
@@ -30,8 +30,6 @@ DrawnSlider::DrawnSlider(QWidget *parent, QSize handle, QSize margin, int paddin
     setSliderGeometry(handle.width(), handle.height(),
                       margin.width(), margin.height(),
                       paddingHeight);
-    connect(qApp, &QApplication::paletteChanged,
-            this, &DrawnSlider::applicationPaletteChanged);
 }
 
 void DrawnSlider::setValue(double v)

--- a/widgets/drawnslider.h
+++ b/widgets/drawnslider.h
@@ -28,9 +28,9 @@ signals:
 
 public slots:
     void setHighContrast(bool enabled);
+    void applicationPaletteChanged();
 
 private slots:
-    void applicationPaletteChanged();
 
 protected:
     void setSliderGeometry(int handleWidth, int handleHeight,


### PR DESCRIPTION
QApplication::paletteChanged is deprecated since 6.0