### PR TITLE
Add vertical dividers between control buttons

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -202,7 +202,36 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>8</width>
+                 <width>3</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="Line" name="verticalLine1">
+               <property name="maximumSize">
+                <size>
+                 <width>1</width>
+                 <height>40</height>
+                </size>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="controlbarSpacer1b">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Policy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>4</width>
                  <height>20</height>
                 </size>
                </property>
@@ -290,7 +319,36 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>8</width>
+                 <width>3</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="Line" name="verticalLine2">
+               <property name="maximumSize">
+                <size>
+                 <width>1</width>
+                 <height>40</height>
+                </size>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="controlbarSpacer2b">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Policy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>4</width>
                  <height>20</height>
                 </size>
                </property>
@@ -316,6 +374,12 @@
              </item>
              <item>
               <widget class="QPushButton" name="stepForward">
+               <property name="maximumSize">
+                <size>
+                 <width>31</width>
+                 <height>40</height>
+                </size>
+               </property>
                <property name="enabled">
                 <bool>false</bool>
                </property>
@@ -342,7 +406,36 @@
                </property>
                <property name="sizeHint" stdset="0">
                 <size>
-                 <width>8</width>
+                 <width>3</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="Line" name="verticalLine3">
+               <property name="maximumSize">
+                <size>
+                 <width>1</width>
+                 <height>40</height>
+                </size>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="controlbarSpacer3b">
+               <property name="orientation">
+                <enum>Qt::Orientation::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Policy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>4</width>
                  <height>20</height>
                 </size>
                </property>


### PR DESCRIPTION
The maximumSize properties are needed to prevent several bugs:
- the stepForward would take all the width
- the vertical dividers would have a 2 pixels width

Fixes #21