### PR TITLE
Default options

### DIFF
--- a/manager.h
+++ b/manager.h
@@ -209,7 +209,7 @@ private:
     double mpvLength = 0.0;
     double mpvSpeed = 1.0;
     double speedStep = 2.0;
-    bool speedStepAdditive = true;
+    bool speedStepAdditive = false;
     double stepTimeNormal = 5.0;
     double stepTimeLarge = 20.0;
     PlaybackState playbackState_ = StoppedState;

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7613,6 +7613,9 @@ media file played</string>
              <property name="text">
               <string>Limit volume to 100% like mpc-hc</string>
              </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="5" column="0" colspan="2">

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1102,7 +1102,7 @@ media file played</string>
                    <string>Use additive speed step</string>
                   </property>
                   <property name="checked">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
- Don't use additive speed step by default
Additive makes it harder to reset to normal speed: decreasing then increasing the speed doesn't make it come back to 100%.
- Limit the volume to 100% by default
Allows users to easily change the volume without risking clipping.