### PR TITLE
Don't add the current directory to external subtitles search

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6807,7 +6807,7 @@ media file played</string>
                 <item>
                  <widget class="QLineEdit" name="subtitlesAutoloadPath">
                   <property name="placeholderText">
-                   <string notr="true">.;./subtitles;./subs</string>
+                   <string notr="true">./subtitles;./subs</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
mpv already searches in it, so it just adds a duplicate subtitle.