### PR TITLE
Simplify the "After Playback" actions

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -535,13 +535,6 @@ void MainWindow::setupMenu()
     ui->actionViewHideCapture->setVisible(false);
     ui->actionViewHideNavigation->setVisible(false);
 
-    // Work around separators with text in the designer not showing as
-    // sections
-    ui->menuPlayAfter->insertSection(ui->actionPlayAfterOnceExit,
-                                       tr("Once"));
-    ui->menuPlayAfter->insertSection(ui->actionPlayAfterAlwaysExit,
-                                      tr("Every time"));
-
     ui->infoStats->setVisible(false);
 
     connect(Platform::deviceManager(), &DeviceManager::deviceListChanged,
@@ -661,15 +654,10 @@ void MainWindow::setupActionGroups()
     ag->addAction(ui->actionPlayAfterOnceLock);
     ag->addAction(ui->actionPlayAfterOnceLogoff);
     ag->addAction(ui->actionPlayAfterOnceNothing);
-    ag->addAction(ui->actionPlayAfterOnceRepeat);
+    ag->addAction(ui->actionPlayAfterAlwaysRepeat);
     ag->addAction(ui->actionPlayAfterOnceShutdown);
     ag->addAction(ui->actionPlayAfterOnceStandby);
-
-    ag = new QActionGroup(this);
-    ag->addAction(ui->actionPlayAfterAlwaysExit);
     ag->addAction(ui->actionPlayAfterAlwaysNext);
-    ag->addAction(ui->actionPlayAfterAlwaysNothing);
-    ag->addAction(ui->actionPlayAfterAlwaysRepeat);
 }
 
 void MainWindow::setupPositionSlider()
@@ -1520,10 +1508,6 @@ void MainWindow::httpAfterPlaybackNothing()
         ui->actionPlayAfterOnceNothing->setChecked(true);
         ui->actionPlayAfterOnceNothing->trigger();
     }
-    if (ui->actionPlayAfterAlwaysNothing->isEnabled()) {
-        ui->actionPlayAfterAlwaysNothing->setChecked(true);
-        ui->actionPlayAfterAlwaysNothing->trigger();
-    }
 }
 
 void MainWindow::httpAfterPlaybackPlayNext()
@@ -2081,10 +2065,8 @@ void MainWindow::resetPlayAfterOnce()
 void MainWindow::setPlayAfterAlways(AfterPlayback action)
 {
     QMap<Helpers::AfterPlayback, QAction*> map {
-        { Helpers::DoNothingAfter, ui->actionPlayAfterAlwaysNothing },
         { Helpers::RepeatAfter, ui->actionPlayAfterAlwaysRepeat },
-        { Helpers::PlayNextAfter, ui->actionPlayAfterAlwaysNext },
-        { Helpers::ExitAfter, ui->actionPlayAfterAlwaysExit }
+        { Helpers::PlayNextAfter, ui->actionPlayAfterAlwaysNext }
     };
     if (map.contains(action))
         map[action]->setChecked(true);
@@ -2845,24 +2827,9 @@ void MainWindow::on_actionPlayAfterOnceNothing_triggered()
     emit afterPlaybackOnce(Helpers::DoNothingAfter);
 }
 
-void MainWindow::on_actionPlayAfterOnceRepeat_triggered()
-{
-    emit afterPlaybackOnce(Helpers::RepeatAfter);
-}
-
 void MainWindow::on_actionPlayAfterAlwaysRepeat_triggered()
 {
     emit afterPlaybackAlways(Helpers::RepeatAfter);
-}
-
-void MainWindow::on_actionPlayAfterAlwaysExit_triggered()
-{
-    emit afterPlaybackAlways(Helpers::ExitAfter);
-}
-
-void MainWindow::on_actionPlayAfterAlwaysNothing_triggered()
-{
-    emit afterPlaybackAlways(Helpers::DoNothingAfter);
 }
 
 void MainWindow::on_actionPlayAfterAlwaysNext_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -379,10 +379,7 @@ private slots:
     void on_actionPlayAfterOnceLogoff_triggered();
     void on_actionPlayAfterOnceLock_triggered();
     void on_actionPlayAfterOnceNothing_triggered();
-    void on_actionPlayAfterOnceRepeat_triggered();
     void on_actionPlayAfterAlwaysRepeat_triggered();
-    void on_actionPlayAfterAlwaysExit_triggered();
-    void on_actionPlayAfterAlwaysNothing_triggered();
     void on_actionPlayAfterAlwaysNext_triggered();
 
     void on_actionNavigateChaptersPrevious_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -886,12 +886,9 @@
      <addaction name="actionPlayAfterOnceShutdown"/>
      <addaction name="actionPlayAfterOnceLogoff"/>
      <addaction name="actionPlayAfterOnceLock"/>
-     <addaction name="actionPlayAfterOnceRepeat"/>
-     <addaction name="actionPlayAfterOnceNothing"/>
-     <addaction name="actionPlayAfterAlwaysExit"/>
      <addaction name="actionPlayAfterAlwaysNext"/>
      <addaction name="actionPlayAfterAlwaysRepeat"/>
-     <addaction name="actionPlayAfterAlwaysNothing"/>
+     <addaction name="actionPlayAfterOnceNothing"/>
     </widget>
     <widget class="QMenu" name="menuPlayLoop">
      <property name="title">
@@ -1524,25 +1521,6 @@
     <string>&amp;Lock</string>
    </property>
   </action>
-  <action name="actionPlayAfterAlwaysExit">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>E&amp;xit</string>
-   </property>
-  </action>
-  <action name="actionPlayAfterAlwaysNothing">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Do &amp;Nothing</string>
-   </property>
-  </action>
   <action name="actionPlayAfterAlwaysNext">
    <property name="checkable">
     <bool>true</bool>
@@ -2005,7 +1983,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Do No&amp;thing</string>
+    <string>Do &amp;Nothing</string>
    </property>
   </action>
   <action name="actionPlayAfterAlwaysRepeat">
@@ -2014,14 +1992,6 @@
    </property>
    <property name="text">
     <string>Repe&amp;at</string>
-   </property>
-  </action>
-  <action name="actionPlayAfterOnceRepeat">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Repeat</string>
    </property>
   </action>
   <action name="actionViewOSDMessages">

--- a/manager.cpp
+++ b/manager.cpp
@@ -647,7 +647,8 @@ void PlaybackManager::checkAfterPlayback()
         action = afterPlaybackAlways;
 
     afterPlaybackOnce = Helpers::DoNothingAfter;
-    emit afterPlaybackReset();
+    if (action != Helpers::RepeatAfter && action != Helpers::PlayNextAfter)
+        emit afterPlaybackReset();
 
     switch (action) {
     case Helpers::ExitAfter:

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1059,7 +1059,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>Do No&amp;thing</translation>
+        <translation type="vanished">Do No&amp;thing</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1115,11 +1115,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Once</translation>
+        <translation type="vanished">Once</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Every time</translation>
+        <translation type="vanished">Every time</translation>
     </message>
     <message>
         <source>View</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1059,7 +1059,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>No hacer nada</translation>
+        <translation type="vanished">No hacer nada</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1115,11 +1115,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Una vez</translation>
+        <translation type="vanished">Una vez</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Siempre</translation>
+        <translation type="vanished">Siempre</translation>
     </message>
     <message>
         <source>View</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1039,7 +1039,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>Älä Tee Mi&amp;tään</translation>
+        <translation type="vanished">Älä Tee Mi&amp;tään</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1095,11 +1095,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Kerran</translation>
+        <translation type="vanished">Kerran</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Joka kerta</translation>
+        <translation type="vanished">Joka kerta</translation>
     </message>
     <message>
         <source>View</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1051,7 +1051,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>&amp;Tidak melakukan apapun</translation>
+        <translation type="vanished">&amp;Tidak melakukan apapun</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1107,11 +1107,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Sekali</translation>
+        <translation type="vanished">Sekali</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Setiap kali</translation>
+        <translation type="vanished">Setiap kali</translation>
     </message>
     <message>
         <source>View</source>
@@ -3745,7 +3745,7 @@ media file played</source>
     </message>
     <message>
         <source>BT.470M</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470M</translation>
     </message>
     <message>
         <source>V-Gamut</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1050,10 +1050,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Do No&amp;thing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Repe&amp;at</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1107,11 +1103,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Una volta</translation>
+        <translation type="vanished">Una volta</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Ogni volta</translation>
+        <translation type="vanished">Ogni volta</translation>
     </message>
     <message>
         <source>View</source>
@@ -3725,7 +3721,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>BT.470M</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470M</translation>
     </message>
     <message>
         <source>V-Gamut</source>
@@ -3753,15 +3749,15 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Gamma 2.0</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Gamma 2.0</translation>
     </message>
     <message>
         <source>Gamma 2.4</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Gamma 2.4</translation>
     </message>
     <message>
         <source>Gamma 2.6</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Gamma 2.6</translation>
     </message>
     <message>
         <source>ST 428</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1059,7 +1059,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>&amp;Ничего не делать</translation>
+        <translation type="vanished">&amp;Ничего не делать</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1115,11 +1115,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>Один раз</translation>
+        <translation type="vanished">Один раз</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>Каждый раз</translation>
+        <translation type="vanished">Каждый раз</translation>
     </message>
     <message>
         <source>View</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1059,7 +1059,7 @@
     </message>
     <message>
         <source>Do No&amp;thing</source>
-        <translation>什么都不做(&amp;T)</translation>
+        <translation type="vanished">什么都不做(&amp;T)</translation>
     </message>
     <message>
         <source>Repe&amp;at</source>
@@ -1115,11 +1115,11 @@
     </message>
     <message>
         <source>Once</source>
-        <translation>此次播放</translation>
+        <translation type="vanished">此次播放</translation>
     </message>
     <message>
         <source>Every time</source>
-        <translation>每次播放</translation>
+        <translation type="vanished">每次播放</translation>
     </message>
     <message>
         <source>View</source>


### PR DESCRIPTION
Group all actions in one action group, remove the distinction between "Once" and "Always".
This distinction is more likely to confuse users into thinking that "Always" means the setting is saved accross restarts.
Repeat (Once): not very useful, it just repeats the file once.
Exit (Always): duplicate of Exit (Once) because the action isn't saved.
Do Nothing (Always): not needed anymore with just one action group.