### PR TITLE
Fix single instance mode

### DIFF
--- a/main.h
+++ b/main.h
@@ -18,6 +18,7 @@
 #include "platform/windowmanager.h"
 
 class MprisInstance;
+class QLockFile;
 class QThread;
 
 // a simple class to control program exection and own application objects
@@ -101,6 +102,7 @@ private slots:
     void exportPlaylist(QString fname, QStringList items);
 
 private:
+    std::unique_ptr<QLockFile> lockFile_;
     MpcQtServer *server = nullptr;
     MpvServer *mpvServer = nullptr;
     MpcHcServer *mpcHcServer = nullptr;

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1091,6 +1091,9 @@ void SettingsWindow::setFreestanding(bool freestanding)
     bool yes = !freestanding;
     ui->ipcNotice->setVisible(yes);
     ui->ipcMpris->setVisible(yes);
+    ui->playerOpenSame->setVisible(yes);
+    ui->playerOpenNew->setVisible(yes);
+    ui->playerOpenBox->setEnabled(yes);
     ui->playerKeepHistory->setVisible(yes);
     ui->playerRememberFilePosition->setVisible(yes);
     ui->playerRememberLastPlaylist->setVisible(false /*yes*/);


### PR DESCRIPTION
- Use a lock file to ensure single instance mode works correctly
In certain circumstances (like clicking too many times on a file), two or more players could still be opened.
- Hide single instance options for freestanding windows
These can't change that setting.