### PR TITLE
Cache eofReached instead of blocking the main thread to check it

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -126,7 +126,7 @@ QUrl PlaybackManager::nowPlaying()
 
 bool PlaybackManager::eofReached()
 {
-    return mpvObject_->eofReached();
+    return eofReached_;
 }
 
 PlaybackManager::PlaybackState PlaybackManager::playbackState()
@@ -244,7 +244,7 @@ void PlaybackManager::pausePlayer()
 void PlaybackManager::unpausePlayer()
 {
     if (playbackState_ == PausedState) {
-        if (mpvObject_->eofReached())
+        if (eofReached_)
             navigateToTime(0);
         mpvObject_->setPaused(false);
     }
@@ -822,13 +822,16 @@ void PlaybackManager::mpvw_playbackFinished() {
 
 void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
     LogStream("manager") << "mpvw_eofReachedChanged eof: " << eof;
-    if (eof == strFalse)
+    if (eof == strFalse) {
+        eofReached_ = false;
         return;
+    }
     else if (eof.isEmpty()) {
         emit fileClosed();
         showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;
         return;
     }
+    eofReached_ = true;
 
     emit stoppedPlaying();
 

--- a/manager.h
+++ b/manager.h
@@ -210,6 +210,7 @@ private:
     double mpvSpeed = 1.0;
     double speedStep = 2.0;
     bool speedStepAdditive = false;
+    bool eofReached_ = false;
     double stepTimeNormal = 5.0;
     double stepTimeLarge = 20.0;
     PlaybackState playbackState_ = StoppedState;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -548,11 +548,6 @@ void MpvObject::setSendMouseEvents(bool enabled)
     sendMouseEvents = enabled;
 }
 
-bool MpvObject::eofReached()
-{
-    return getMpvPropertyVariant("eof-reached").toBool();
-}
-
 double MpvObject::playLength()
 {
     return playLength_;

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -86,7 +86,6 @@ public:
     void setSendKeyEvents(bool enabled);
     void setSendMouseEvents(bool enabled);
 
-    bool eofReached();
     double playLength();
     double playTime();
     QSize videoSize();


### PR DESCRIPTION
In some conditions (very quickly opening different files), getMpvPropertyVariant("eof-reached") didn't return, thus hanging mpc-qt in Flow::updateRecentPosition.