### PR TITLE
Make aspect ratio changes smoother

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2583,12 +2583,12 @@ void MainWindow::on_actionViewZoomDisable_triggered()
 
 void MainWindow::on_actionDecreaseVideoAspect_triggered()
 {
-    mpvObject_->setVideoAspect(-0.05);
+    mpvObject_->setVideoAspect(-0.02);
 }
 
 void MainWindow::on_actionIncreaseVideoAspect_triggered()
 {
-    mpvObject_->setVideoAspect(0.05);
+    mpvObject_->setVideoAspect(0.02);
 }
 
 void MainWindow::on_actionResetVideoAspect_triggered()

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -57,6 +57,7 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("decoder-frame-drop-count", decoderFramedropsChanged, toLongLong, 0ll),
     HANDLE_PROP("audio-bitrate", audioBitrateChanged, toDouble, 0.0),
     HANDLE_PROP("video-bitrate", videoBitrateChanged, toDouble, 0.0),
+    HANDLE_PROP("video-params/aspect", self_aspectChanged, toDouble, 0.0),
     HANDLE_PROP("video-params/aspect-name", aspectNameChanged, toString, QString()),
     HANDLE_PROP("metadata", self_metadata, toMap, QVariantMap()),
     HANDLE_PROP("audio-device-list", self_audioDeviceList, toList, QVariantList()),
@@ -150,6 +151,7 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "time-pos", 0, MPV_FORMAT_DOUBLE },
         { "pause", 0, MPV_FORMAT_FLAG },
         { "eof-reached", 0, MPV_FORMAT_FLAG },
+        { "video-params/aspect", 0, MPV_FORMAT_DOUBLE },
         { "video-params/aspect-name", 0, MPV_FORMAT_STRING },
         { "media-title", 0, MPV_FORMAT_STRING },
         { "chapter-metadata", 0, MPV_FORMAT_NODE },
@@ -423,8 +425,7 @@ void MpvObject::setSubtitlesDelay(int subDelayStep)
 
 void MpvObject::setVideoAspect(double aspectDiff)
 {
-    double currAspect = getMpvPropertyVariant("video-params/aspect").toDouble();
-    setMpvPropertyVariant("video-aspect-override", currAspect + aspectDiff);
+    setMpvPropertyVariant("video-aspect-override", aspect + aspectDiff);
 }
 
 void MpvObject::setVideoAspectPreset(double aspect)
@@ -654,6 +655,11 @@ void MpvObject::hideCursor()
             return;
         w->setCursor(Qt::BlankCursor);
     }
+}
+
+void MpvObject::self_aspectChanged(double newAspect)
+{
+    aspect = newAspect;
 }
 
 void MpvObject::ctrl_mpvPropertyChanged(QString name, QVariant v)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -165,6 +165,7 @@ private slots:
     void self_metadata(QVariantMap metadata);
     void self_audioDeviceList(const QVariantList &list);
     void hideTimer_timeout();
+    void self_aspectChanged(double newAspect);
 
     void self_mouseMoved(int x, int y);
     void self_mousePress(int x, int y, int btn);
@@ -187,6 +188,7 @@ private:
     QSize videoSize_;
     double playTime_ = 0.0;
     double playLength_ = 0.0;
+    double aspect = 0.0;
 
     int shownStatsPage = 0;
     bool loopImages = true;


### PR DESCRIPTION
- Cache aspect ratio instead of blocking the mpv thread to check it
This makes aspect ratio changes much smoother even during playback.
- Decrease aspect ratio change step size
Now that it's smooth even during playback, a smaller step size makes it even smoother visually. An even smaller step size would be smoother but also slower.