### PR TITLE
Restrict next/previous file feature to audio/video files

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -17,7 +17,7 @@
 #include "helpers.h"
 #include "platform/unify.h"
 
-QSet<QString> Helpers::fileExtensions {
+QSet<QString> Helpers::audioVideoFileExtensions {
     // DVD/Blu-ray audio formats
     "ac3", "a52",
     "eac3",
@@ -118,6 +118,11 @@ QSet<QString> Helpers::fileExtensions {
     "m3u", "m3u8",
     "pls",
     "cue",
+    // Modfiles
+    "mod"
+};
+
+QSet<QString> Helpers::imagesFileExtensions {
     // Image formats
     "bmp",
     "dds",
@@ -142,18 +147,26 @@ QSet<QString> Helpers::fileExtensions {
     "sunrast",
     "tiff",
     "webp",
-    "xpm",
-    // Modfiles
-    "mod",
+    "xpm"
+};
+
+QSet<QString> Helpers::archivesFileExtensions {
     // Archives
     "rar",
     "zip",
     "cbz",
-    "cbr",
+    "cbr"
+};
+QSet<QString> Helpers::othersFileExtensions {
     // Other formats
     "at9",
     "mpc"
 };
+
+QSet<QString> Helpers::allMediaExtensions = Helpers::audioVideoFileExtensions |
+                                            Helpers::imagesFileExtensions |
+                                            Helpers::archivesFileExtensions |
+                                            Helpers::othersFileExtensions;
 
 QSet<QString> Helpers::subsExtensions {
     "aqtitle", "aqt",
@@ -479,7 +492,7 @@ QString Helpers::parseFormatEx(QString fmt, QUrl sourceUrl, QString filePath,
 
 QString Helpers::fileOpenFilter()
 {
-    const QString ext = QStringList(Helpers::fileExtensions.values()).join(" *.");
+    const QString ext = QStringList(Helpers::allMediaExtensions.values()).join(" *.");
     return QString(QObject::tr("All Media (*.%1);;All Files (*.*)")).arg(ext);
 }
 
@@ -496,7 +509,7 @@ bool Helpers::urlSurvivesFilter(const QUrl &url)
     QFileInfo info(url.toLocalFile());
     if (info.isDir())
         return true;
-    return fileExtensions.contains(info.suffix().toLower());
+    return audioVideoFileExtensions.contains(info.suffix().toLower());
 }
 
 QList<QUrl> Helpers::filterUrls(const QList<QUrl> &urls)
@@ -518,7 +531,7 @@ QList<QUrl> Helpers::filterUrls(const QList<QUrl> &urls)
             filtered.append(filterUrls(children));
             continue;
         }
-        if (fileExtensions.contains(info.suffix().toLower())) {
+        if (Helpers::allMediaExtensions.contains(info.suffix().toLower())) {
             filtered << u;
             continue;
         }

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -509,7 +509,7 @@ bool Helpers::urlSurvivesFilter(const QUrl &url)
     QFileInfo info(url.toLocalFile());
     if (info.isDir())
         return true;
-    return audioVideoFileExtensions.contains(info.suffix().toLower());
+    return audioVideoFileExtensions.contains(info.suffix().toLower().split(" ")[0]);
 }
 
 QList<QUrl> Helpers::filterUrls(const QList<QUrl> &urls)
@@ -531,7 +531,7 @@ QList<QUrl> Helpers::filterUrls(const QList<QUrl> &urls)
             filtered.append(filterUrls(children));
             continue;
         }
-        if (Helpers::allMediaExtensions.contains(info.suffix().toLower())) {
+        if (Helpers::allMediaExtensions.contains(info.suffix().toLower().split(" ")[0])) {
             filtered << u;
             continue;
         }

--- a/helpers.h
+++ b/helpers.h
@@ -36,7 +36,11 @@ namespace Helpers {
     enum TimeFormat { LongFormat, ShortFormat,
                       LongHourFormat, ShortHourFormat };
 
-    extern QSet<QString> fileExtensions;
+    extern QSet<QString> audioVideoFileExtensions;
+    extern QSet<QString> imagesFileExtensions;
+    extern QSet<QString> archivesFileExtensions;
+    extern QSet<QString> othersFileExtensions;
+    extern QSet<QString> allMediaExtensions;
     extern QSet<QString> subsExtensions;
 
     QString fileSizeToString(int64_t bytes);


### PR DESCRIPTION
- Restrict next/previous file feature to audio/video files
This prevents archives or pictures in the folder from getting opened. This still allows manually opening non audio/video files or playing them if they're in a playlist.
- Cleanup file extension before filtering
This makes it possible to play incorrectly named files with a name like "video.mkv (1)".

Fixes #158