### PR TITLE
Tweaks settings

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1057,8 +1057,8 @@ void SettingsWindow::sendSignals()
     emit timeTooltip(WIDGET_LOOKUP(ui->tweaksTimeTooltip).toBool(),
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);
     emit osdTimerOnSeek(WIDGET_LOOKUP(ui->tweaksOsdTimerOnSeek).toBool());
-    emit option("osd-font", WIDGET_LOOKUP(ui->tweaksOsdFont).toString());
-    emit option("osd-font-size", WIDGET_LOOKUP(ui->tweaksOsdSize).toInt());
+    emit option("osd-font", WIDGET_LOOKUP(ui->tweaksOsdFontChkBox).toBool() ? WIDGET_LOOKUP(ui->tweaksOsdFont).toString() : "");
+    emit option("osd-font-size", WIDGET_LOOKUP(ui->tweaksOsdFontChkBox).toBool() ? WIDGET_LOOKUP(ui->tweaksOsdSize).toInt() : 55);
     emit option("brightness", WIDGET_LOOKUP(ui->miscBrightness).toInt());
     emit option("contrast", WIDGET_LOOKUP(ui->miscContrast).toInt());
     emit option("gamma", WIDGET_LOOKUP(ui->miscGamma).toInt());
@@ -1365,6 +1365,17 @@ void SettingsWindow::on_playbackMouseHideFullscreen_toggled(bool checked)
 void SettingsWindow::on_playbackMouseHideWindowed_toggled(bool checked)
 {
     ui->playbackMouseHideWindowedDuration->setEnabled(checked);
+}
+
+void SettingsWindow::on_tweaksTimeTooltip_toggled(bool checked)
+{
+    ui->tweaksTimeTooltipLocation->setEnabled(checked);
+}
+
+void SettingsWindow::on_tweaksOsdFontChkBox_toggled(bool checked)
+{
+    ui->tweaksOsdFont->setEnabled(checked);
+    ui->tweaksOsdSize->setEnabled(checked);
 }
 
 void SettingsWindow::on_miscBrightness_valueChanged(int value)

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -496,9 +496,6 @@ void SettingsWindow::setupUnimplementedWidgets()
 
     ui->tweaksShowChapterMarks->setVisible(false);
     ui->tweaksPreferWayland->setVisible(Platform::isUnix);
-    // Remove the trailing : (looks odd with the rest of the tooltip options hidden)
-    ui->tweaksTimeTooltip->setText(ui->tweaksTimeTooltip->text().replace(":",""));
-    ui->tweaksTimeTooltipLocation->setVisible(false);
 
     ui->miscExportKeys->setVisible(false);
     ui->miscExportSettings->setVisible(false);

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -271,6 +271,10 @@ private slots:
 
     void on_playbackMouseHideWindowed_toggled(bool checked);
 
+    void on_tweaksTimeTooltip_toggled(bool checked);
+
+    void on_tweaksOsdFontChkBox_toggled(bool checked);
+
     void on_miscBrightness_valueChanged(int value);
 
     void on_miscContrast_valueChanged(int value);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7671,6 +7671,9 @@ media file played</string>
            </item>
            <item row="9" column="1">
             <widget class="QComboBox" name="tweaksTimeTooltipLocation">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
                <horstretch>0</horstretch>
@@ -7716,10 +7719,17 @@ media file played</string>
            <item row="11" column="1">
             <layout class="QHBoxLayout" name="tweaksOsdLayout" stretch="1,0">
              <item>
-              <widget class="QFontComboBox" name="tweaksOsdFont"/>
+              <widget class="QFontComboBox" name="tweaksOsdFont">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+              </widget>
              </item>
              <item>
               <widget class="QSpinBox" name="tweaksOsdSize">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="minimum">
                 <number>1</number>
                </property>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7653,17 +7653,21 @@ media file played</string>
             </widget>
            </item>
            <item row="9" column="0">
-            <widget class="QCheckBox" name="tweaksTimeTooltip">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Use time tooltip:</string>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="1">
+             <item>
+              <widget class="QCheckBox" name="tweaksTimeTooltip">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Show time tooltip:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="9" column="1">
             <widget class="QComboBox" name="tweaksTimeTooltipLocation">
@@ -7693,11 +7697,21 @@ media file played</string>
             </widget>
            </item>
            <item row="11" column="0">
-            <widget class="QLabel" name="tweaksOsdFontLabel">
-             <property name="text">
-              <string>OSD font:</string>
-             </property>
-            </widget>
+            <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="1">
+             <item>
+              <widget class="QCheckBox" name="tweaksOsdFontChkBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Change OSD font:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="11" column="1">
             <layout class="QHBoxLayout" name="tweaksOsdLayout" stretch="1,0">

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1063,7 +1063,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>Repe&amp;at</translation>
+        <translation type="vanished">Repe&amp;at</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1356,6 +1356,10 @@
     <message>
         <source>Seek Backwards (large step)</source>
         <translation>Seek Backwards (large step)</translation>
+    </message>
+    <message>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3489,7 +3493,7 @@ media file played</translation>
     </message>
     <message>
         <source>OSD font:</source>
-        <translation>OSD font:</translation>
+        <translation type="vanished">OSD font:</translation>
     </message>
     <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
@@ -3781,7 +3785,7 @@ media file played</translation>
     </message>
     <message>
         <source>Use time tooltip:</source>
-        <translation>Use time tooltip:</translation>
+        <translation type="vanished">Use time tooltip:</translation>
     </message>
     <message>
         <source>Language Override</source>
@@ -3918,6 +3922,14 @@ media file played</translation>
     <message>
         <source>Large step</source>
         <translation>Large step</translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1063,7 +1063,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>Repetir</translation>
+        <translation type="vanished">Repetir</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1327,6 +1327,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3453,7 +3457,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>OSD font:</source>
-        <translation>Fuente del OSD:</translation>
+        <translation type="vanished">Fuente del OSD:</translation>
     </message>
     <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
@@ -3741,7 +3745,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Use time tooltip:</source>
-        <translation>Usar descripciones de tiempo:</translation>
+        <translation type="vanished">Usar descripciones de tiempo:</translation>
     </message>
     <message>
         <source>Language Override</source>
@@ -3877,6 +3881,14 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1043,7 +1043,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>Toi&amp;staa</translation>
+        <translation type="vanished">Toi&amp;staa</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1323,6 +1323,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3414,10 +3418,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OSD font:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3702,10 +3702,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use time tooltip:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Language Override</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3839,6 +3835,14 @@ media file played</source>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1055,7 +1055,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>Ul&amp;ang</translation>
+        <translation type="vanished">Ul&amp;ang</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1327,6 +1327,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3436,10 +3440,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OSD font:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3728,10 +3728,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use time tooltip:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Language Override</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3865,6 +3861,14 @@ media file played</source>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1050,10 +1050,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Repe&amp;at</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Repeat</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1315,6 +1311,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3417,7 +3417,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>OSD font:</source>
-        <translation>Font OSD:</translation>
+        <translation type="vanished">Font OSD:</translation>
     </message>
     <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
@@ -3705,7 +3705,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Use time tooltip:</source>
-        <translation>Mostra tempo in un suggerimento:</translation>
+        <translation type="vanished">Mostra tempo in un suggerimento:</translation>
     </message>
     <message>
         <source>Language Override</source>
@@ -3841,6 +3841,14 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1063,7 +1063,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>Повтор&amp;ить</translation>
+        <translation type="vanished">Повтор&amp;ить</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1335,6 +1335,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3461,7 +3465,7 @@ media file played</source>
     </message>
     <message>
         <source>OSD font:</source>
-        <translation>Шрифт экранного уведомления:</translation>
+        <translation type="vanished">Шрифт экранного уведомления:</translation>
     </message>
     <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
@@ -3749,7 +3753,7 @@ media file played</source>
     </message>
     <message>
         <source>Use time tooltip:</source>
-        <translation>Использовать подсказку времени:</translation>
+        <translation type="vanished">Использовать подсказку времени:</translation>
     </message>
     <message>
         <source>Language Override</source>
@@ -3889,6 +3893,14 @@ media file played</source>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1063,7 +1063,7 @@
     </message>
     <message>
         <source>Repe&amp;at</source>
-        <translation>重复播放(&amp;A)</translation>
+        <translation type="vanished">重复播放(&amp;A)</translation>
     </message>
     <message>
         <source>&amp;Repeat</source>
@@ -1327,6 +1327,10 @@
     </message>
     <message>
         <source>Seek Backwards (large step)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3418,10 +3422,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>OSD font:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Prefer Wayland over XWayland (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3706,10 +3706,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Use time tooltip:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Language Override</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3843,6 +3839,14 @@ media file played</source>
     </message>
     <message>
         <source>Large step</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show time tooltip:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
- Don't hide time tooltip position setting
It was already mostly implemented, but hidden.
- Add a checkbox for OSD font setting, try to fix layout
It looks better with checkboxes for both OSD font and time tooltip, though OSD font checkbox is still not aligned on the left.
- Implement time tooltip and OSD font checkboxes
- Update strings