### PR TITLE
Only remember history for videos by default

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1386,10 +1386,11 @@ void Flow::settingswindow_inhibitScreensaver(bool yes)
     manager_stateChanged(playbackManager->playbackState());
 }
 
-void Flow::settingswindow_rememberHistory(bool yes)
+void Flow::settingswindow_rememberHistory(bool yes, bool onlyVideos)
 {
     // Remember our preference to the list of recent files
     this->rememberHistory = yes;
+    this->rememberHistoryOnlyForVideos = onlyVideos;
 }
 
 void Flow::settingswindow_rememberFilePosition(bool yes)
@@ -1510,7 +1511,7 @@ void Flow::updateRecentPosition(bool resetPosition)
         resetPosition = true;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
                                          videoTrack, audioTrack, subtitleTrack, hasVideo);
-    if (!itemUuid.isNull() && hasVideo)
+    if (!itemUuid.isNull() && (hasVideo || !rememberHistoryOnlyForVideos))
         updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position,
                       videoTrack, audioTrack, subtitleTrack);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -1505,11 +1505,12 @@ void Flow::updateRecentPosition(bool resetPosition)
     int64_t videoTrack;
     int64_t audioTrack;
     int64_t subtitleTrack;
+    bool hasVideo;
     if (playbackManager->eofReached())
         resetPosition = true;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
-                                         videoTrack, audioTrack, subtitleTrack);
-    if (!itemUuid.isNull())
+                                         videoTrack, audioTrack, subtitleTrack, hasVideo);
+    if (!itemUuid.isNull() && hasVideo)
         updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position,
                       videoTrack, audioTrack, subtitleTrack);
 }

--- a/main.h
+++ b/main.h
@@ -82,7 +82,7 @@ private slots:
     void mpcHcServer_fileSelected(QString fileName);
     void settingswindow_settingsData(const QVariantMap &settings);
     void settingswindow_inhibitScreensaver(bool yes);
-    void settingswindow_rememberHistory(bool yes);
+    void settingswindow_rememberHistory(bool yes, bool onlyVideos);
     void settingswindow_rememberFilePosition(bool yes);
     void settingswindow_rememberWindowGeometry(bool yes);
     void settingswindow_keymapData(const QVariantMap &keyMap);
@@ -138,6 +138,7 @@ private:
     bool inhibitScreensaver = false;
     bool manipulateScreensaver = false;
     bool rememberHistory = true;
+    bool rememberHistoryOnlyForVideos = true;
     bool rememberFilePosition = false;
     bool rememberWindowGeometry = false;
     bool nowPlayingDisplayingSubtitles = true;

--- a/manager.cpp
+++ b/manager.cpp
@@ -30,6 +30,8 @@ TrackData TrackData::fromMap(const QVariantMap &map)
         td.isExternal = map["external"].toBool();
     if (map.contains("default"))
         td.isDefault = map["default"].toBool();
+    if (map.contains("image"))
+        td.isImage = map["image"].toBool();
     return td;
 }
 
@@ -535,7 +537,7 @@ void PlaybackManager::sendCurrentTrackInfo()
 
 void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString title,
                                           double& length, double& position, int64_t& videoTrack,
-                                          int64_t& audioTrack, int64_t& subtitleTrack)
+                                          int64_t& audioTrack, int64_t& subtitleTrack, bool& hasVideo)
 {
     url = playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem);
     listUuid = nowPlayingList;
@@ -546,6 +548,7 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
     videoTrack = videoTrackSelected;
     audioTrack = audioTrackSelected;
     subtitleTrack = subtitleTrackSelected;
+    hasVideo = !videoList.isEmpty() && !videoListData[1].isImage;
 }
 
 void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
@@ -860,6 +863,7 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
     LogStream("manager") << "mpvw_tracksChanged";
     videoList.clear();
     audioList.clear();
+    videoListData.clear();
     audioListData.clear();
     subtitleList.clear();
     subtitleListData.clear();
@@ -872,6 +876,7 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
         item.second = td.formatted();
         if (td.type == "video") {
             videoList.append(item);
+            videoListData.insert(td.trackId, td);
         } else if (td.type == "audio") {
             audioList.append(item);
             audioListData.insert(td.trackId, td);

--- a/manager.h
+++ b/manager.h
@@ -27,6 +27,7 @@ public:
     bool isExternal = false;
     bool isForced = false;
     bool isDefault = false;
+    bool isImage = false;
     QString formatted();
 };
 
@@ -153,7 +154,7 @@ public slots:
     void sendCurrentTrackInfo();
     void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString title,
                              double &length, double &position, int64_t &videoTrack,
-                             int64_t &audioTrack, int64_t &subtitleTrack);
+                             int64_t &audioTrack, int64_t &subtitleTrack, bool &hasVideo);
 
 private:
     enum AspectNameChanged { OnOpen, OnFirstPlay, Manually };
@@ -217,6 +218,7 @@ private:
     QList<QPair<int64_t,QString>> videoList;
     QList<QPair<int64_t,QString>> audioList;
     QList<QPair<int64_t,QString>> subtitleList;
+    QMap<int64_t,TrackData> videoListData;
     QMap<int64_t,TrackData> audioListData;
     QMap<int64_t,TrackData> subtitleListData;
     QVariantList chapters = QVariantList();

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -713,7 +713,8 @@ void SettingsWindow::sendSignals()
     emit titleBarFormat(WIDGET_LOOKUP(ui->playerTitleDisplayFullPath).toBool() ? Helpers::PrefixFullPath
                         : WIDGET_LOOKUP(ui->playerTitleFileNameOnly).toBool() ? Helpers::PrefixFileName : Helpers::NoPrefix);
     emit titleUseMediaTitle(WIDGET_LOOKUP(ui->playerTitleReplaceName).toBool());
-    emit rememberHistory(WIDGET_LOOKUP(ui->playerKeepHistory).toBool());
+    emit rememberHistory(WIDGET_LOOKUP(ui->playerKeepHistory).toBool(),
+                         WIDGET_LOOKUP(ui->playerKeepHistoryOnlyForVideos).toBool());
     emit rememberFilePosition(WIDGET_LOOKUP(ui->playerRememberFilePosition).toBool());
     emit rememberSelectedPlaylist(WIDGET_LOOKUP(ui->playerRememberLastPlaylist).toBool());
     emit rememberWindowGeometry(WIDGET_LOOKUP(ui->playerRememberWindowGeometry).toBool());
@@ -1091,6 +1092,7 @@ void SettingsWindow::setFreestanding(bool freestanding)
     ui->playerOpenNew->setVisible(yes);
     ui->playerOpenBox->setEnabled(yes);
     ui->playerKeepHistory->setVisible(yes);
+    ui->playerKeepHistoryOnlyForVideos->setVisible(yes);
     ui->playerRememberFilePosition->setVisible(yes);
     ui->playerRememberLastPlaylist->setVisible(false /*yes*/);
     ui->playerRememberWindowGeometry->setVisible(yes);
@@ -1206,6 +1208,7 @@ void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state
     bool playerKeepHistoryEnabled = state == Qt::Checked;
     if (!playerKeepHistoryEnabled)
         ui->playerRememberFilePosition->setChecked(false);
+    ui->playerKeepHistoryOnlyForVideos->setEnabled(playerKeepHistoryEnabled);
     ui->playerRememberFilePosition->setEnabled(playerKeepHistoryEnabled);
 }
 

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -86,7 +86,7 @@ signals:
     void inhibitScreensaver(bool yes);
     void titleBarFormat(Helpers::TitlePrefix format);
     void titleUseMediaTitle(bool yes);
-    void rememberHistory(bool yes);
+    void rememberHistory(bool yes, bool onlyVideos);
     void rememberFilePosition(bool yes);
     void rememberSelectedPlaylist(bool yes);
     void rememberWindowGeometry(bool yes);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -198,6 +198,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="playerKeepHistoryOnlyForVideos">
+                <property name="text">
+                 <string>Only keep history for videos</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="playerRememberFilePosition">
                 <property name="text">
                  <string>Remember file position</string>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3931,6 +3931,10 @@ media file played</translation>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3891,6 +3891,10 @@ archivo multimedia reproducido</translation>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3845,6 +3845,10 @@ media file played</source>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3871,6 +3871,10 @@ media file played</source>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3851,6 +3851,10 @@ ogni file multimediale riprodotto</translation>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3903,6 +3903,10 @@ media file played</source>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3849,6 +3849,10 @@ media file played</source>
         <source>Change OSD font:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Only keep history for videos</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
- Only remember history for videos
This prevents flooding the recents with audio and images files when using mpc-qt for both video and audio/image content.
- Add an option to remember history for all files
It's actually worded as a setting to remember history only for videos, enabled by default.
- Update strings