### PR TITLE
Revert "Remove remaining mac code"

### DIFF
--- a/logwindow.cpp
+++ b/logwindow.cpp
@@ -56,6 +56,9 @@ void LogWindow::on_copy_clicked()
 void LogWindow::on_save_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString textToSave = ui->messages->document()->toPlainText();
     static QString lastLog;
     QString file = QFileDialog::getSaveFileName(this, tr("Save File"), lastLog, "Text files (*.txt)",

--- a/main.cpp
+++ b/main.cpp
@@ -1214,6 +1214,9 @@ void Flow::mainwindow_recentClear()
 void Flow::mainwindow_takeImage(Helpers::ScreenshotRender render)
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     // Take a screenshot and save it to a temporary file
     QString fmt("%1/mpc-qt_%2.%3");
     QString tempDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1242,6 +1242,9 @@ void MainWindow::showOsdTimer(bool onSeek)
 QList<QUrl> MainWindow::doQuickOpenFileDialog()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QList<QUrl> urls;
     static QUrl lastDir;
     static QString filter;
@@ -2174,6 +2177,9 @@ void MainWindow::on_actionFileOpen_triggered()
 void MainWindow::on_actionFileOpenDvdbd_triggered()
 {
     static QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_MAC
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
     QUrl dir;
     static QUrl lastDir;
     dir = QFileDialog::getExistingDirectoryUrl(this, tr("Open Directory"),
@@ -2187,6 +2193,9 @@ void MainWindow::on_actionFileOpenDvdbd_triggered()
 void MainWindow::on_actionFileOpenDirectory_triggered()
 {
     static QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_MAC
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
     QUrl url;
     static QUrl lastDir;
     url = QFileDialog::getExistingDirectoryUrl(this, tr("Open Directory"),
@@ -2260,6 +2269,9 @@ void MainWindow::on_actionFileLoadSubtitle_triggered()
     QUrl url;
     static QUrl lastUrl;
     static QFileDialog::Options options;
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     url = QFileDialog::getOpenFileUrl(this, tr("Open Subtitle"), lastUrl, "", nullptr, options);
     if (url.isEmpty())
         return;

--- a/openfiledialog.cpp
+++ b/openfiledialog.cpp
@@ -30,6 +30,9 @@ void OpenFileDialog::on_fileBrowse_clicked()
 {
     static QString filter;
     static QFileDialog::Options options;
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     if (filter.isEmpty())
         filter = Helpers::fileOpenFilter();
     QUrl url = QFileDialog::getOpenFileUrl(this, tr("Select File"), QUrl(), filter,
@@ -42,6 +45,9 @@ void OpenFileDialog::on_subsBrowse_clicked()
 {
     static QString subsFilter;
     static QFileDialog::Options options;
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     if (subsFilter.isEmpty())
         subsFilter = Helpers::subsOpenFilter();
     QUrl url = QFileDialog::getOpenFileUrl(this, tr("Select File"), QUrl(), subsFilter,

--- a/platform/unify.cpp
+++ b/platform/unify.cpp
@@ -36,7 +36,7 @@ const bool Platform::isWindows =
 ;
 
 const bool Platform::isUnix =
-#if defined(Q_OS_UNIX)
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC)
     true
 #else
     false

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -492,6 +492,9 @@ void PlaylistWindow::duplicateTab()
 void PlaylistWindow::importTab()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString file;
     file = QFileDialog::getOpenFileName(this, tr("Import File"), QString(),
                                         tr("Playlist files (*.m3u *.m3u8)"), nullptr, options);
@@ -691,6 +694,9 @@ void PlaylistWindow::finishSearch()
 void PlaylistWindow::savePlaylist(const QUuid &playlistUuid)
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString file;
     file = QFileDialog::getSaveFileName(this, tr("Export File"), QString(),
                                         tr("Playlist files (*.m3u *.m3u8)"), nullptr, options);

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -218,6 +218,9 @@ QString PropertiesWindow::sectionText(const QString &header, const QVariantMap &
 void PropertiesWindow::on_save_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString docsFolder = QStandardPaths::writableLocation(QStandardPaths::DocumentsLocation);
     QFileInfo info(filename + ".MediaInfo.txt");
     QString filename = QString("%1/%2").arg(docsFolder, info.fileName());

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1225,6 +1225,9 @@ void SettingsWindow::on_videoDumbMode_toggled(bool checked)
 void SettingsWindow::on_logoExternalBrowse_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString file = WIDGET_LOOKUP(ui->logoExternalLocation).toString();
     file = QFileDialog::getOpenFileName(this, tr("Open Logo Image"), file, "", nullptr, options);
     if (file.isEmpty())
@@ -1291,6 +1294,9 @@ void SettingsWindow::on_keysReset_clicked()
 void SettingsWindow::on_shadersAddFile_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QStringList files = QFileDialog::getOpenFileNames(this, "", "", "", nullptr, options);
     if (files.isEmpty())
         return;
@@ -1448,6 +1454,9 @@ void SettingsWindow::on_webPortLink_linkActivated(const QString &link)
 void SettingsWindow::on_webRootBrowse_clicked()
 {
     static QFileDialog::Options options = QFileDialog::ShowDirsOnly;
+#ifdef Q_OS_MAC
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
     QString path = QFileDialog::getExistingDirectory(this, "", "", options);
     if (path.isEmpty())
         return;

--- a/thumbnailerwindow.cpp
+++ b/thumbnailerwindow.cpp
@@ -60,6 +60,9 @@ void ThumbnailerWindow::setScreenshotFormat(QString format)
 void ThumbnailerWindow::on_saveImageBrowse_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options = QFileDialog::DontUseNativeDialog;
+#endif
     QString filename = QFileDialog::getSaveFileName(this, "Save Thumbnails",
                                                     ui->saveImage->text(),
                                                     saveDialogFilter,


### PR DESCRIPTION
Reverts mpc-qt/mpc-qt#227
As mentioned, I didn't notice this was added recently.
If [face1es5](https://github.com/face1es5) can provide support for macOS, let's not prevent it.