### PR TITLE
Improve code readability

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1901,7 +1901,7 @@ void MainWindow::disableChaptersMenus()
     ui->menuNavigateChapters->setEnabled(false);
 }
 
-void MainWindow::setChapters(QList<QPair<double, QString>> chapters)
+void MainWindow::setChapters(QList<Chapter> chapters)
 {
     positionSlider_->clearTicks();
     ui->menuNavigateChapters->clear();
@@ -1910,10 +1910,10 @@ void MainWindow::setChapters(QList<QPair<double, QString>> chapters)
         return;
     ui->menuNavigateChapters->setEnabled(true);
     int64_t index = 0;
-    for (const QPair<double,QString> &chapter : chapters) {
-        positionSlider_->setTick(chapter.first, chapter.second);
+    for (const Chapter &chapter : chapters) {
+        positionSlider_->setTick(chapter.time, chapter.title);
         QAction *action = new QAction(this);
-        action->setText(chapter.second);
+        action->setText(chapter.title);
         connect (action, &QAction::triggered, this, [this,index]() {
            emit chapterSelected(index);
         });

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1922,7 +1922,7 @@ void MainWindow::setChapters(QList<Chapter> chapters)
     }
 }
 
-void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
+void MainWindow::setAudioTracks(QList<Track> tracks)
 {
     ui->menuPlayAudio->clear();
     ui->menuPlayAudio->setEnabled(false);
@@ -1932,12 +1932,12 @@ void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
         return;
     ui->menuPlayAudio->setEnabled(true);
     audioTracksGroup = new QActionGroup(this);
-    for (const QPair<int64_t, QString> &track : tracks) {
+    for (const Track &track : tracks) {
         QAction *action = new QAction(this);
-        action->setText(track.second);
+        action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(audioTracksGroup);
-        int64_t index = track.first;
+        int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index] {
             emit audioTrackSelected(index, true);
         });
@@ -1946,7 +1946,7 @@ void MainWindow::setAudioTracks(QList<QPair<int64_t, QString>> tracks)
     audioTracksGroup->actions()[0]->setChecked(true);
 }
 
-void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
+void MainWindow::setVideoTracks(QList<Track> tracks)
 {
     ui->menuPlayVideo->clear();
     ui->menuPlayVideo->setEnabled(false);
@@ -1961,12 +1961,12 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
     ui->menuPlayVideo->addAction(ui->actionResetVideoAspect);
     ui->menuPlayVideo->addAction(ui->actionDisableVideoAspect);
     ui->menuPlayVideo->addSeparator();
-    for (const QPair<int64_t, QString> &track : tracks) {
+    for (const Track &track : tracks) {
         QAction *action = new QAction(this);
-        action->setText(track.second);
+        action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(videoTracksGroup);
-        int64_t index = track.first;
+        int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit videoTrackSelected(index, true);
         });
@@ -1976,7 +1976,7 @@ void MainWindow::setVideoTracks(QList<QPair<int64_t, QString>> tracks)
     updateOnTop();
 }
 
-void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
+void MainWindow::setSubtitleTracks(QList<Track > tracks)
 {
     ui->menuPlaySubtitles->clear();
     ui->menuPlaySubtitles->setEnabled(false);
@@ -1997,12 +1997,12 @@ void MainWindow::setSubtitleTracks(QList<QPair<int64_t, QString> > tracks)
     ui->menuPlaySubtitles->addAction(ui->actionDecreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addAction(ui->actionIncreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addSeparator();
-    for (const QPair<int64_t, QString> &track : tracks) {
+    for (const Track &track : tracks) {
         QAction *action = new QAction(this);
-        action->setText(track.second);
+        action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(subtitleTracksGroup);
-        int64_t index = track.first;
+        int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit subtitleTrackSelected(index, true);
         });

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -250,7 +250,7 @@ public slots:
     void setPlaybackState(PlaybackManager::PlaybackState state);
     void setPlaybackType(PlaybackManager::PlaybackType type);
     void disableChaptersMenus();
-    void setChapters(QList<QPair<double,QString>> chapters);
+    void setChapters(QList<Chapter> chapters);
     void setAudioTracks(QList<QPair<int64_t,QString>> tracks);
     void setVideoTracks(QList<QPair<int64_t,QString>> tracks);
     void setSubtitleTracks(QList<QPair<int64_t,QString>> tracks);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -251,9 +251,9 @@ public slots:
     void setPlaybackType(PlaybackManager::PlaybackType type);
     void disableChaptersMenus();
     void setChapters(QList<Chapter> chapters);
-    void setAudioTracks(QList<QPair<int64_t,QString>> tracks);
-    void setVideoTracks(QList<QPair<int64_t,QString>> tracks);
-    void setSubtitleTracks(QList<QPair<int64_t,QString>> tracks);
+    void setAudioTracks(QList<Track> tracks);
+    void setVideoTracks(QList<Track> tracks);
+    void setSubtitleTracks(QList<Track> tracks);
     void audioTrackSet(int64_t id);
     void videoTrackSet(int64_t id);
     void subtitleTrackSet(int64_t id);

--- a/manager.cpp
+++ b/manager.cpp
@@ -869,22 +869,21 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
     audioListData.clear();
     subtitleList.clear();
     subtitleListData.clear();
-    QPair<int64_t,QString> item;
+    Track track;
 
-    for (QVariant &track : tracks) {
-        QVariantMap t = track.toMap();
-        TrackData td = TrackData::fromMap(t);
-        item.first = td.trackId;
-        item.second = td.formatted();
+    for (QVariant &trackItem : tracks) {
+        TrackData td = TrackData::fromMap(trackItem.toMap());
+        track.id = td.trackId;
+        track.title = td.formatted();
         if (td.type == "video") {
-            videoList.append(item);
+            videoList.append(track);
             videoListData.insert(td.trackId, td);
         } else if (td.type == "audio") {
-            audioList.append(item);
+            audioList.append(track);
             audioListData.insert(td.trackId, td);
         } else if (td.type == "sub") {
             if (!subtitlesIgnoreEmbedded || td.isExternal) {
-                subtitleList.append(item);
+                subtitleList.append(track);
                 subtitleListData.insert(td.trackId, td);
             }
         }

--- a/manager.cpp
+++ b/manager.cpp
@@ -146,10 +146,10 @@ void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
     bool playAfterAdd = (playlistWindow_->isCurrentPlaylistEmpty()
                          && (important || nowPlayingItem == QUuid()))
                         || !playlistWindow_->isVisible();
-    auto info = playlistWindow_->addToCurrentPlaylist(what);
-    if (playAfterAdd && !info.second.isNull()) {
-        QUrl urlToPlay = playlistWindow_->getUrlOf(info.first, info.second);
-        startPlayWithUuid(urlToPlay, info.first, info.second, false);
+    PlaylistItem playlistItem = playlistWindow_->addToCurrentPlaylist(what);
+    if (playAfterAdd && !playlistItem.item.isNull()) {
+        QUrl urlToPlay = playlistWindow_->getUrlOf(playlistItem.list, playlistItem.item);
+        startPlayWithUuid(urlToPlay, playlistItem.list, playlistItem.item, false);
     }
 }
 
@@ -158,10 +158,10 @@ void PlaybackManager::openFile(QUrl what, QUrl with)
     if (!nowPlayingItem.isNull())
         emit openingNewFile();
 
-    auto info = playlistWindow_->urlToQuickPlaylist(what);
-    if (!info.second.isNull()) {
-        QUrl urlToPlay = playlistWindow_->getUrlOf(info.first, info.second);
-        startPlayWithUuid(urlToPlay, info.first, info.second, false, with);
+    PlaylistItem playlistItem = playlistWindow_->urlToQuickPlaylist(what);
+    if (!playlistItem.item.isNull()) {
+        QUrl urlToPlay = playlistWindow_->getUrlOf(playlistItem.list, playlistItem.item);
+        startPlayWithUuid(urlToPlay, playlistItem.list, playlistItem.item, false, with);
     }
 }
 
@@ -183,9 +183,9 @@ void PlaybackManager::playDiscFiles(QUrl where)
 
 void PlaybackManager::playStream(QUrl stream)
 {
-    auto info = playlistWindow_->addToCurrentPlaylist({ stream });
-    QUrl urlToPlay = playlistWindow_->getUrlOf(info.first, info.second);
-    startPlayWithUuid(urlToPlay, info.first, info.second, false);
+    PlaylistItem playlistItem = playlistWindow_->addToCurrentPlaylist({ stream });
+    QUrl urlToPlay = playlistWindow_->getUrlOf(playlistItem.list, playlistItem.item);
+    startPlayWithUuid(urlToPlay, playlistItem.list, playlistItem.item, false);
 }
 
 void PlaybackManager::playItem(QUuid playlist, QUuid item)
@@ -702,11 +702,11 @@ void PlaybackManager::updateChapters()
 
 void PlaybackManager::playNextTrack()
 {
-    QPair<QUuid, QUuid> next;
+    PlaylistItem next;
     next = playlistWindow_->getItemAfter(nowPlayingList, nowPlayingItem);
-    QUrl url = playlistWindow_->getUrlOf(next.first, next.second);
+    QUrl url = playlistWindow_->getUrlOf(next.list, next.item);
     if (!url.isEmpty())
-        startPlayWithUuid(url, next.first, next.second, false);
+        startPlayWithUuid(url, next.list, next.item, false);
 }
 
 void PlaybackManager::playPrevTrack()

--- a/manager.cpp
+++ b/manager.cpp
@@ -711,10 +711,10 @@ void PlaybackManager::playNextTrack()
 
 void PlaybackManager::playPrevTrack()
 {
-    QUuid uuid = playlistWindow_->getItemBefore(nowPlayingList, nowPlayingItem);
-    QUrl url = playlistWindow_->getUrlOf(nowPlayingList, uuid);
+    QUuid itemUuid = playlistWindow_->getItemBefore(nowPlayingList, nowPlayingItem);
+    QUrl url = playlistWindow_->getUrlOf(nowPlayingList, itemUuid);
     if (!url.isEmpty())
-        startPlayWithUuid(url, nowPlayingList, uuid, false);
+        startPlayWithUuid(url, nowPlayingList, itemUuid, false);
 }
 
 bool PlaybackManager::playNextFileUrl(QUrl url, int delta)

--- a/manager.cpp
+++ b/manager.cpp
@@ -1,8 +1,6 @@
 #include <QRegularExpression>
 #include "manager.h"
-#include "mpvwidget.h"
 #include "playlistwindow.h"
-#include "helpers.h"
 #include "logger.h"
 
 using namespace Helpers;
@@ -683,7 +681,7 @@ void PlaybackManager::checkAfterPlayback()
 
 void PlaybackManager::updateChapters()
 {
-    QList<QPair<double,QString>> list;
+    QList<Chapter> list;
 
     if (!chapters.isEmpty()) {
         for (QVariant &v : chapters) {
@@ -692,7 +690,7 @@ void PlaybackManager::updateChapters()
                     toDateFormatFixed(node["time"].toDouble(),
                                     timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
                     node["title"].toString());
-            QPair<double,QString> item(node["time"].toDouble(), text);
+            Chapter item { node["time"].toDouble(), text };
             list.append(item);
         }
     }

--- a/manager.h
+++ b/manager.h
@@ -14,6 +14,11 @@
 #include "helpers.h"
 #include "mpvwidget.h"
 
+struct Track {
+    int64_t id;
+    QString title;
+};
+
 class MpvObject;
 class PlaylistWindow;
 
@@ -60,9 +65,9 @@ signals:
     // Transmit a map of chapter index to time,description pairs
     void chaptersAvailable(QList<Chapter> chapters);
     // These signals transmit a list of (id, description) pairs
-    void audioTracksAvailable(QList<QPair<int64_t,QString>> tracks);
-    void videoTracksAvailable(QList<QPair<int64_t,QString>> tracks);
-    void subtitleTracksAvailable(QList<QPair<int64_t,QString>> tracks);
+    void audioTracksAvailable(QList<Track> tracks);
+    void videoTracksAvailable(QList<Track> tracks);
+    void subtitleTracksAvailable(QList<Track> tracks);
     void playingNextFile();
     void hasNoVideo(bool empty);
     void hasNoAudio(bool empty);
@@ -217,9 +222,9 @@ private:
     PlaybackState playbackState_ = StoppedState;
     PlaybackState playbackStartState = PlayingState;
 
-    QList<QPair<int64_t,QString>> videoList;
-    QList<QPair<int64_t,QString>> audioList;
-    QList<QPair<int64_t,QString>> subtitleList;
+    QList<Track> videoList;
+    QList<Track> audioList;
+    QList<Track> subtitleList;
     QMap<int64_t,TrackData> videoListData;
     QMap<int64_t,TrackData> audioListData;
     QMap<int64_t,TrackData> subtitleListData;

--- a/manager.h
+++ b/manager.h
@@ -12,6 +12,7 @@
 #include <QSize>
 #include <QVariant>
 #include "helpers.h"
+#include "mpvwidget.h"
 
 class MpvObject;
 class PlaylistWindow;
@@ -57,7 +58,7 @@ signals:
     void fileClosed();
     void typeChanged(PlaybackManager::PlaybackType type);
     // Transmit a map of chapter index to time,description pairs
-    void chaptersAvailable(QList<QPair<double,QString>> chapters);
+    void chaptersAvailable(QList<Chapter> chapters);
     // These signals transmit a list of (id, description) pairs
     void audioTracksAvailable(QList<QPair<int64_t,QString>> tracks);
     void videoTracksAvailable(QList<QPair<int64_t,QString>> tracks);
@@ -222,7 +223,7 @@ private:
     QMap<int64_t,TrackData> videoListData;
     QMap<int64_t,TrackData> audioListData;
     QMap<int64_t,TrackData> subtitleListData;
-    QVariantList chapters = QVariantList();
+    QVariantList chapters;
 
     QStringList audioLangPref;
     QStringList subtitleLangPref;

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -14,6 +14,11 @@
 #include "qthelper.hpp"
 #include "helpers.h"
 
+struct Chapter {
+    double time;
+    QString title;
+};
+
 class QLayout;
 class QMainWindow;
 class QThread;

--- a/playlist.cpp
+++ b/playlist.cpp
@@ -536,15 +536,15 @@ QueuePlaylist::QueuePlaylist(const QString &title)
 
 }
 
-QPair<QUuid,QUuid> QueuePlaylist::first()
+PlaylistItem QueuePlaylist::first()
 {
     QReadLocker lock(&listLock);
     if (items.isEmpty())
-        return QPair<QUuid,QUuid>(QUuid(),QUuid());
+        return { QUuid(), QUuid() };
     return { items.first()->playlistUuid(), items.first()->uuid() };
 }
 
-QPair<QUuid,QUuid> QueuePlaylist::takeFirst()
+PlaylistItem QueuePlaylist::takeFirst()
 {
     QWriteLocker lock(&listLock);
     if (items.isEmpty())

--- a/playlist.cpp
+++ b/playlist.cpp
@@ -30,12 +30,12 @@ Item::Item(QUrl url)
 
 QUuid Item::uuid() const
 {
-    return uuid_;
+    return itemUuid_;
 }
 
-void Item::setUuid(const QUuid &uuid)
+void Item::setUuid(const QUuid &itemUuid)
 {
-    uuid_ = uuid;
+    itemUuid_ = itemUuid;
 }
 
 QUuid Item::playlistUuid() const
@@ -43,9 +43,9 @@ QUuid Item::playlistUuid() const
     return playlistUuid_;
 }
 
-void Item::setPlaylistUuid(const QUuid &uuid)
+void Item::setPlaylistUuid(const QUuid &playlistUuid)
 {
-    playlistUuid_ = uuid;
+    playlistUuid_ = playlistUuid;
 }
 
 QUrl Item::url() const
@@ -159,7 +159,7 @@ QVariantMap Item::toVMap() const
 void Item::fromVMap(const QVariantMap &qvm)
 {
     url_ = qvm.contains(keyUrl) ? qvm.value(keyUrl).toUrl() : QUrl();
-    uuid_ = qvm.contains(keyUuid) ? qvm.value(keyUuid).toUuid() : QUuid::createUuid();
+    itemUuid_ = qvm.contains(keyUuid) ? qvm.value(keyUuid).toUuid() : QUuid::createUuid();
     metadata_ = qvm.contains(keyMetadata) ? qvm.value(keyMetadata).toMap() : QVariantMap();
 }
 
@@ -231,28 +231,28 @@ QSharedPointer<Item> Playlist::addItem(const QUrl &url)
 {
     QWriteLocker locker(&listLock);
     QSharedPointer<Item> i(ItemCollection::getSingleton()->addItem(url));
-    i->setPlaylistUuid(uuid_);
+    i->setPlaylistUuid(playlistUuid_);
     items.append(i);
     itemsByUuid.insert(i->uuid(), i);
     return i;
 }
 
-QSharedPointer<Item> Playlist::addItem(const QUuid &uuid, const QUrl &url)
+QSharedPointer<Item> Playlist::addItem(const QUuid &itemUuid, const QUrl &url)
 {
     QWriteLocker locker(&listLock);
-    QSharedPointer<Item> i(ItemCollection::getSingleton()->addItem(uuid, url));
-    i->setPlaylistUuid(uuid_);
+    QSharedPointer<Item> i(ItemCollection::getSingleton()->addItem(itemUuid, url));
+    i->setPlaylistUuid(playlistUuid_);
     i->setUrl(url);
-    i->setUuid(uuid);
+    i->setUuid(itemUuid);
     items.append(i);
-    itemsByUuid.insert(uuid, i);
+    itemsByUuid.insert(itemUuid, i);
     return i;
 }
 
 QSharedPointer<Item> Playlist::addItemClone(const QSharedPointer<Item> &item)
 {
     QSharedPointer<Item> i = addItem(item->url());
-    i->setPlaylistUuid(uuid_);
+    i->setPlaylistUuid(playlistUuid_);
     i->setMetadata(item->metadata());
     return i;
 }
@@ -272,29 +272,29 @@ QSharedPointer<Item> Playlist::itemAt(int index)
     return items.value(index);
 }
 
-QSharedPointer<Item> Playlist::itemOf(const QUuid &uuid)
+QSharedPointer<Item> Playlist::itemOf(const QUuid &itemUuid)
 {
     QReadLocker locker(&listLock);
-    return itemsByUuid.value(uuid, QSharedPointer<Item>());
+    return itemsByUuid.value(itemUuid, QSharedPointer<Item>());
 }
 
-QSharedPointer<Item> Playlist::itemAfter(const QUuid &uuid)
+QSharedPointer<Item> Playlist::itemAfter(const QUuid &itemUuid)
 {
     QReadLocker locker(&listLock);
-    if (!itemsByUuid.contains(uuid))
+    if (!itemsByUuid.contains(itemUuid))
         return QSharedPointer<Item>();
-    int index = items.indexOf(itemsByUuid[uuid]);
+    int index = items.indexOf(itemsByUuid[itemUuid]);
     if (index < 0 || index + 1 >= items.length())
         return QSharedPointer<Item>();
     return items[index + 1];
 }
 
-QSharedPointer<Item> Playlist::itemBefore(const QUuid &uuid)
+QSharedPointer<Item> Playlist::itemBefore(const QUuid &itemUuid)
 {
     QReadLocker locker(&listLock);
-    if (!itemsByUuid.contains(uuid))
+    if (!itemsByUuid.contains(itemUuid))
         return QSharedPointer<Item>();
-    int index = items.indexOf(itemsByUuid[uuid]);
+    int index = items.indexOf(itemsByUuid[itemUuid]);
     if (index <= 0)
         return QSharedPointer<Item>();
     return items[index - 1];
@@ -328,10 +328,10 @@ bool Playlist::isEmpty()
     return items.isEmpty();
 }
 
-bool Playlist::contains(const QUuid &uuid)
+bool Playlist::contains(const QUuid &itemUuid)
 {
     QReadLocker lock(&listLock);
-    return itemsByUuid.contains(uuid);
+    return itemsByUuid.contains(itemUuid);
 }
 
 void Playlist::iterateItems(const std::function<void(QSharedPointer<Item>)> &callback)
@@ -351,18 +351,18 @@ void Playlist::addItems(const QUuid &where,
         indexWhere = items.size();
     for (int i = 0; i < itemsToAdd.count(); ++i) {
         QSharedPointer<Item> item = itemsToAdd.at(i);
-        item->setPlaylistUuid(uuid_);
+        item->setPlaylistUuid(playlistUuid_);
         items.insert(indexWhere + i, item);
         itemsByUuid.insert(item->uuid(), item);
     }
 }
 
-void Playlist::removeItem(const QUuid &uuid)
+void Playlist::removeItem(const QUuid &itemUuid)
 {
     QWriteLocker locker(&listLock);
-    PlaylistCollection::queuePlaylist()->removeItem(uuid);
-    items.removeAll(itemsByUuid.take(uuid));
-    ItemCollection::getSingleton()->removeItem(uuid);
+    PlaylistCollection::queuePlaylist()->removeItem(itemUuid);
+    items.removeAll(itemsByUuid.take(itemUuid));
+    ItemCollection::getSingleton()->removeItem(itemUuid);
 }
 
 void Playlist::takeItemsRaw(const QList<QSharedPointer<Item>> &itemsToRemove)
@@ -389,7 +389,7 @@ QList<QUuid> Playlist::replaceItem(const QUuid &where, const QList<QUrl> &urls)
     int insertIndex = items.indexOf(itemsByUuid[where]);
     for (int urlIndex = 1; urlIndex < urls.count(); urlIndex++) {
         QSharedPointer<Item> i(new Item(urls[urlIndex]));
-        i->setPlaylistUuid(uuid_);
+        i->setPlaylistUuid(playlistUuid_);
         items.insert(insertIndex + urlIndex, i);
         itemsByUuid.insert(i->uuid(), i);
         addedItems.append(i->uuid());
@@ -440,13 +440,13 @@ void Playlist::setShuffle(bool shuffling)
 QUuid Playlist::uuid()
 {
     QReadLocker locker(&listLock);
-    return uuid_;
+    return playlistUuid_;
 }
 
-void Playlist::setUuid(const QUuid &uuid)
+void Playlist::setUuid(const QUuid &playlistUuid)
 {
     QWriteLocker locker(&listLock);
-    uuid_ = uuid;
+    playlistUuid_ = playlistUuid;
 }
 
 QUuid Playlist::nowPlaying()
@@ -454,9 +454,9 @@ QUuid Playlist::nowPlaying()
     return nowPlaying_;
 }
 
-void Playlist::setNowPlaying(const QUuid &uuid)
+void Playlist::setNowPlaying(const QUuid &itemUuid)
 {
-    nowPlaying_ = uuid;
+    nowPlaying_ = itemUuid;
 }
 
 QStringList Playlist::toStringList()
@@ -475,7 +475,7 @@ void Playlist::fromStringList(QStringList sl)
     itemsByUuid.clear();
     for (QString &s : sl) {
         QSharedPointer<Item> item(new Item());
-        item->setPlaylistUuid(uuid_);
+        item->setPlaylistUuid(playlistUuid_);
         item->fromString(s);
         items.append(item);
         itemsByUuid.insert(item->uuid(), item);
@@ -489,7 +489,7 @@ QVariantMap Playlist::toVMap()
     qvm.insert(keyCreated, created_);
     qvm.insert(keyTitle, title_);
     qvm.insert(keyShuffle, shuffle_);
-    qvm.insert(keyUuid, uuid_);
+    qvm.insert(keyUuid, playlistUuid_);
     qvm.insert(keyNowPlaying, nowPlaying_);
 
     QVariantList qvl;
@@ -513,13 +513,13 @@ void Playlist::fromVMap(const QVariantMap &qvm)
     created_ = qvm.contains(keyCreated) ? qvm[keyCreated].toDateTime() : created_;
     title_ = qvm.contains(keyTitle) ? qvm[keyTitle].toString() : QString();
     shuffle_ = qvm.contains(keyShuffle) ? qvm[keyShuffle].toBool() : false;
-    uuid_ = qvm.contains(keyUuid) ? qvm[keyUuid].toUuid() : QUuid::createUuid();
+    playlistUuid_ = qvm.contains(keyUuid) ? qvm[keyUuid].toUuid() : QUuid::createUuid();
     nowPlaying_ = qvm.contains(keyNowPlaying) ? qvm[keyNowPlaying].toUuid() : nowPlaying_;
     if (qvm.contains(keyItems)) {
         auto items = qvm[keyItems].toList();
         for (const QVariant &v : items) {
             QSharedPointer<Item> i(new Item());
-            i->setPlaylistUuid(uuid_);
+            i->setPlaylistUuid(playlistUuid_);
             i->fromVMap(v.toMap());
             this->items.append(i);
             this->itemsByUuid.insert(i->uuid(), i);
@@ -623,10 +623,10 @@ void QueuePlaylist::addItems(const QUuid &where, const QList<QSharedPointer<Item
         items[i]->setQueuePosition(i+1);
 }
 
-void QueuePlaylist::removeItem(const QUuid &uuid)
+void QueuePlaylist::removeItem(const QUuid &itemUuid)
 {
     QWriteLocker lock(&listLock);
-    removeItem_(uuid);
+    removeItem_(itemUuid);
 }
 
 void QueuePlaylist::removeItems(const QList<QUuid> &itemsToRemove)
@@ -680,14 +680,14 @@ int QueuePlaylist::contains_(const QList<QUuid> &itemsToCheck) const
     return count;
 }
 
-void QueuePlaylist::removeItem_(const QUuid &uuid)
+void QueuePlaylist::removeItem_(const QUuid &itemUuid)
 {
-    if (!itemsByUuid.contains(uuid))
+    if (!itemsByUuid.contains(itemUuid))
         return;
-    QSharedPointer<Item> item = itemsByUuid[uuid];
+    QSharedPointer<Item> item = itemsByUuid[itemUuid];
     int index = items.indexOf(item);
     items.removeOne(item);
-    itemsByUuid.remove(uuid);
+    itemsByUuid.remove(itemUuid);
     item->setQueuePosition(0);
     int count = items.count();
     for (int i = index; i < count; i++)
@@ -767,11 +767,11 @@ QSharedPointer<Playlist> PlaylistCollection::newPlaylist(const QString &title)
     return doNewPlaylist(title, QUuid::createUuid());
 }
 
-QSharedPointer<Playlist> PlaylistCollection::clonePlaylist(const QUuid &uuid)
+QSharedPointer<Playlist> PlaylistCollection::clonePlaylist(const QUuid &playlistUuid)
 {
-    if (!playlistsByUuid.contains(uuid))
+    if (!playlistsByUuid.contains(playlistUuid))
         return QSharedPointer<Playlist>();
-    auto origin = playlistsByUuid[uuid];
+    auto origin = playlistsByUuid[playlistUuid];
     auto remote = newPlaylist(origin->title());
     auto cloner = [remote,origin](QSharedPointer<Item> i) {
         auto clone = remote->addItemClone(i);
@@ -783,20 +783,20 @@ QSharedPointer<Playlist> PlaylistCollection::clonePlaylist(const QUuid &uuid)
     return remote;
 }
 
-QSharedPointer<Playlist> PlaylistCollection::takePlaylist(const QUuid &uuid)
+QSharedPointer<Playlist> PlaylistCollection::takePlaylist(const QUuid &playlistUuid)
 {
-    QSharedPointer<Playlist> playlist = playlistOf(uuid);
-    removePlaylist(uuid);
+    QSharedPointer<Playlist> playlist = playlistOf(playlistUuid);
+    removePlaylist(playlistUuid);
     return playlist;
 }
 
-void PlaylistCollection::removePlaylist(const QUuid &uuid)
+void PlaylistCollection::removePlaylist(const QUuid &playlistUuid)
 {
-    if (!playlistsByUuid.contains(uuid))
+    if (!playlistsByUuid.contains(playlistUuid))
         return;
-    QSharedPointer<Playlist> p = playlistsByUuid.value(uuid);
+    QSharedPointer<Playlist> p = playlistsByUuid.value(playlistUuid);
     playlists.removeAll(p);
-    playlistsByUuid.remove(uuid);
+    playlistsByUuid.remove(playlistUuid);
 }
 
 void PlaylistCollection::removePlaylist(const QSharedPointer<Playlist> &p)
@@ -811,9 +811,9 @@ QSharedPointer<Playlist> PlaylistCollection::playlistAt(int col) const
     return (col < playlists.count()) ? playlists.at(col) : QSharedPointer<Playlist>();
 }
 
-QSharedPointer<Playlist> PlaylistCollection::playlistOf(const QUuid &uuid) const
+QSharedPointer<Playlist> PlaylistCollection::playlistOf(const QUuid &playlistUuid) const
 {
-    return playlistsByUuid.value(uuid);
+    return playlistsByUuid.value(playlistUuid);
 }
 
 void PlaylistCollection::addPlaylist(const QSharedPointer<Playlist> &playlist)
@@ -848,10 +848,10 @@ QVariantList PlaylistCollection::toVList()
 }
 
 QSharedPointer<Playlist> PlaylistCollection::doNewPlaylist(const QString &title,
-                                                           const QUuid &uuid)
+                                                           const QUuid &playlistUuid)
 {
     QSharedPointer<Playlist> p(new Playlist(title));
-    p->setUuid(uuid);
+    p->setUuid(playlistUuid);
     playlists.append(p);
     playlistsByUuid.insert(p->uuid(), p);
     return p;

--- a/playlist.cpp
+++ b/playlist.cpp
@@ -197,7 +197,7 @@ QSharedPointer<Item> ItemCollection::addItem(const QUuid &itemUuid, const QUrl &
     return item;
 }
 
-QSharedPointer<Item> ItemCollection::itemOf(const QUuid &itemUuid)
+QSharedPointer<Item> ItemCollection::getItem(const QUuid &itemUuid)
 {
     return items.value(itemUuid, QSharedPointer<Item>());
 }
@@ -272,7 +272,7 @@ QSharedPointer<Item> Playlist::itemAt(int index)
     return items.value(index);
 }
 
-QSharedPointer<Item> Playlist::itemOf(const QUuid &itemUuid)
+QSharedPointer<Item> Playlist::getItem(const QUuid &itemUuid)
 {
     QReadLocker locker(&listLock);
     return itemsByUuid.value(itemUuid, QSharedPointer<Item>());
@@ -581,7 +581,7 @@ void QueuePlaylist::toggle(const QUuid &playlistUuid, const QList<QUuid> &uuids,
 void QueuePlaylist::toggleFromPlaylist(const QUuid &playlistUuid, QList<QUuid> &added, QList<int> &removedIndices)
 {
     QWriteLocker lock(&listLock);
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     QReadLocker plLock(&pl->listLock);
     if (contains_(pl->itemsByUuid.keys()) == pl->itemsByUuid.count()) {
         // remove all items from playlist
@@ -659,10 +659,10 @@ int QueuePlaylist::toggle_(const QUuid &playlistUuid, const QUuid &itemUuid, boo
         }
         return 0;
     }
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     if (!pl)
         return 0;
-    QSharedPointer<Item> item = pl->itemOf(itemUuid);
+    QSharedPointer<Item> item = pl->getItem(itemUuid);
     if (!item)
         return 0;
     items.append(item);
@@ -785,7 +785,7 @@ QSharedPointer<Playlist> PlaylistCollection::clonePlaylist(const QUuid &playlist
 
 QSharedPointer<Playlist> PlaylistCollection::takePlaylist(const QUuid &playlistUuid)
 {
-    QSharedPointer<Playlist> playlist = playlistOf(playlistUuid);
+    QSharedPointer<Playlist> playlist = getPlaylist(playlistUuid);
     removePlaylist(playlistUuid);
     return playlist;
 }
@@ -811,7 +811,7 @@ QSharedPointer<Playlist> PlaylistCollection::playlistAt(int col) const
     return (col < playlists.count()) ? playlists.at(col) : QSharedPointer<Playlist>();
 }
 
-QSharedPointer<Playlist> PlaylistCollection::playlistOf(const QUuid &playlistUuid) const
+QSharedPointer<Playlist> PlaylistCollection::getPlaylist(const QUuid &playlistUuid) const
 {
     return playlistsByUuid.value(playlistUuid);
 }

--- a/playlist.h
+++ b/playlist.h
@@ -16,6 +16,11 @@
 #include <QVariantMap>
 #include <QReadWriteLock>
 
+struct PlaylistItem {
+    QUuid list;
+    QUuid item;
+};
+
 class Item {
 public:
     Item(QUrl url = QUrl());
@@ -148,8 +153,8 @@ class QueuePlaylist : public Playlist {
 public:
     QueuePlaylist(const QString &title = QString());
 
-    QPair<QUuid, QUuid> first();
-    QPair<QUuid, QUuid> takeFirst();
+    PlaylistItem first();
+    PlaylistItem takeFirst();
     int toggle(const QUuid &playlistUuid, const QUuid &itemUuid, bool always = false);
     void toggle(const QUuid &playlistUuid, const QList<QUuid> &uuids, QList<QUuid> &added, QList<int> &removed);
     void toggleFromPlaylist(const QUuid &playlistUuid, QList<QUuid> &added, QList<int> &removedIndices);

--- a/playlist.h
+++ b/playlist.h
@@ -26,9 +26,9 @@ public:
     Item(QUrl url = QUrl());
 
     QUuid uuid() const;
-    void setUuid(const QUuid &uuid);
+    void setUuid(const QUuid &itemUuid);
     QUuid playlistUuid() const;
-    void setPlaylistUuid(const QUuid &uuid);
+    void setPlaylistUuid(const QUuid &playlistUuid);
     QUrl url() const;
     void setUrl(const QUrl &url);
     const QVariantMap &metadata() const;
@@ -58,7 +58,7 @@ public:
     void fromVMap(const QVariantMap &qvm);
 
 private:
-    QUuid uuid_;
+    QUuid itemUuid_;
     QUuid playlistUuid_;
     QUrl url_;
     QVariantMap metadata_;
@@ -96,22 +96,22 @@ public:
     Playlist(const QString &title = QString());
     ~Playlist();
     QSharedPointer<Item> addItem(const QUrl &url = QUrl());
-    QSharedPointer<Item> addItem(const QUuid &uuid, const QUrl &url);
+    QSharedPointer<Item> addItem(const QUuid &itemUuid, const QUrl &url);
     QSharedPointer<Item> addItemClone(const QSharedPointer<Item> &item);
     void addItemRaw(const QSharedPointer<Item> &item);
 
     QSharedPointer<Item> itemAt(int index);
-    QSharedPointer<Item> itemOf(const QUuid &uuid);
-    QSharedPointer<Item> itemAfter(const QUuid &uuid);
-    QSharedPointer<Item> itemBefore(const QUuid &uuid);
+    QSharedPointer<Item> itemOf(const QUuid &itemUuid);
+    QSharedPointer<Item> itemAfter(const QUuid &itemUuid);
+    QSharedPointer<Item> itemBefore(const QUuid &itemUuid);
     QSharedPointer<Item> itemFirst();
     QSharedPointer<Item> itemLast();
     int count();
     bool isEmpty();
-    bool contains(const QUuid &uuid);
+    bool contains(const QUuid &itemUuid);
     void iterateItems(const std::function<void(QSharedPointer<Item>)> &callback);
     virtual void addItems(const QUuid &where, const QList<QSharedPointer<Item> > &itemsToAdd);
-    virtual void removeItem(const QUuid &uuid);
+    virtual void removeItem(const QUuid &itemUuid);
     void takeItemsRaw(const QList<QSharedPointer<Item>> &itemsToRemove);
     QList<QUuid> replaceItem(const QUuid &where, const QList<QUrl> &urls);
     virtual void clear();
@@ -123,9 +123,9 @@ public:
     bool shuffle();
     void setShuffle(bool shuffle);
     QUuid uuid();
-    void setUuid(const QUuid &uuid);
+    void setUuid(const QUuid &playlistUuid);
     QUuid nowPlaying();
-    void setNowPlaying(const QUuid &uuid);
+    void setNowPlaying(const QUuid &itemUuid);
 
     QStringList toStringList();
     void fromStringList(QStringList sl);
@@ -140,7 +140,7 @@ protected:
     QDateTime created_;
     QString title_;
     bool shuffle_ = false;
-    QUuid uuid_;
+    QUuid playlistUuid_;
     QUuid nowPlaying_;
 
     QReadWriteLock listLock;
@@ -160,7 +160,7 @@ public:
     void toggleFromPlaylist(const QUuid &playlistUuid, QList<QUuid> &added, QList<int> &removedIndices);
     void appendItems(const QUuid &playlistUuid, const QList<QUuid> &itemsToAdd);
     void addItems(const QUuid &where, const QList<QSharedPointer<Item> > &itemsToAdd);
-    void removeItem(const QUuid &uuid);
+    void removeItem(const QUuid &itemUuid);
     void removeItems(const QList<QUuid> &itemsToRemove);
     void clear();
     int contains(const QList<QUuid> &itemsToCheck);
@@ -168,7 +168,7 @@ public:
 private:
     int toggle_(const QUuid &playlistUuid, const QUuid &itemUuid, bool always = false);
     int contains_(const QList<QUuid> &itemsToCheck) const;
-    void removeItem_(const QUuid &uuid);
+    void removeItem_(const QUuid &itemUuid);
     QList<int> removeItems_(const QList<QUuid> &itemsToRemove);
 };
 
@@ -188,12 +188,12 @@ public:
 
     void iteratePlaylists(const std::function<void(QSharedPointer<Playlist>)> &callback);
     QSharedPointer<Playlist> newPlaylist(const QString &title = QString());
-    QSharedPointer<Playlist> clonePlaylist(const QUuid &uuid);
-    QSharedPointer<Playlist> takePlaylist(const QUuid &uuid);
-    void removePlaylist(const QUuid &uuid);
+    QSharedPointer<Playlist> clonePlaylist(const QUuid &playlistUuid);
+    QSharedPointer<Playlist> takePlaylist(const QUuid &playlistUuid);
+    void removePlaylist(const QUuid &playlistUuid);
     void removePlaylist(const QSharedPointer<Playlist> &p);
     QSharedPointer<Playlist> playlistAt(int col) const;
-    QSharedPointer<Playlist> playlistOf(const QUuid &uuid) const;
+    QSharedPointer<Playlist> playlistOf(const QUuid &playlistUuid) const;
 
     void addPlaylist(const QSharedPointer<Playlist> &playlist);
     void fromVList(const QVariantList &data);
@@ -204,7 +204,7 @@ private:
     QHash<QUuid, QSharedPointer<Playlist>> playlistsByUuid;
 
     QSharedPointer<Playlist> doNewPlaylist(const QString &title,
-                                           const QUuid &uuid);
+                                           const QUuid &playlistUuid);
 };
 
 class PlaylistSearcher : public QObject {

--- a/playlist.h
+++ b/playlist.h
@@ -80,7 +80,7 @@ public:
 
     QSharedPointer<Item> addItem(const QUrl url = QUrl());
     QSharedPointer<Item> addItem(const QUuid &itemUuid, const QUrl &url);
-    QSharedPointer<Item> itemOf(const QUuid &itemUuid);
+    QSharedPointer<Item> getItem(const QUuid &itemUuid);
     void removeItem(const QUuid &itemUuid);
     void storeItem(const QSharedPointer<Item> &item);
 
@@ -101,7 +101,7 @@ public:
     void addItemRaw(const QSharedPointer<Item> &item);
 
     QSharedPointer<Item> itemAt(int index);
-    QSharedPointer<Item> itemOf(const QUuid &itemUuid);
+    QSharedPointer<Item> getItem(const QUuid &itemUuid);
     QSharedPointer<Item> itemAfter(const QUuid &itemUuid);
     QSharedPointer<Item> itemBefore(const QUuid &itemUuid);
     QSharedPointer<Item> itemFirst();
@@ -193,7 +193,7 @@ public:
     void removePlaylist(const QUuid &playlistUuid);
     void removePlaylist(const QSharedPointer<Playlist> &p);
     QSharedPointer<Playlist> playlistAt(int col) const;
-    QSharedPointer<Playlist> playlistOf(const QUuid &playlistUuid) const;
+    QSharedPointer<Playlist> getPlaylist(const QUuid &playlistUuid) const;
 
     void addPlaylist(const QSharedPointer<Playlist> &playlist);
     void fromVList(const QVariantList &data);

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -437,9 +437,9 @@ void PlaylistWindow::addSimplePlaylist(QStringList data)
     addNewTab(pl->uuid(), pl->title());
 }
 
-void PlaylistWindow::addPlaylistByUuid(QUuid uuid)
+void PlaylistWindow::addPlaylistByUuid(QUuid playlistUuid)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(uuid);
+    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
     if (!pl) {
         throw std::runtime_error("received a nullptr for a playlist");
     }
@@ -504,8 +504,8 @@ void PlaylistWindow::importTab()
 
 void PlaylistWindow::exportTab()
 {
-    auto uuid = currentPlaylistWidget()->uuid();
-    savePlaylist(uuid);
+    auto playlistUuid = currentPlaylistWidget()->uuid();
+    savePlaylist(playlistUuid);
 }
 
 void PlaylistWindow::copy()
@@ -569,8 +569,8 @@ void PlaylistWindow::incExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
     auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
-    auto incrementer = [pl](QUuid uuid) {
-        auto item = pl->itemOf(uuid);
+    auto incrementer = [pl](QUuid itemUuid) {
+        auto item = pl->itemOf(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->incExtraPlayTimes();
     };
@@ -582,8 +582,8 @@ void PlaylistWindow::decExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
     auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
-    auto decrementer = [pl](QUuid uuid) {
-        auto item = pl->itemOf(uuid);
+    auto decrementer = [pl](QUuid itemUuid) {
+        auto item = pl->itemOf(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->decExtraPlayTimes();
     };
@@ -595,8 +595,8 @@ void PlaylistWindow::zeroExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
     auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
-    auto zeroer = [pl](QUuid uuid) {
-        auto item = pl->itemOf(uuid);
+    auto zeroer = [pl](QUuid itemUuid) {
+        auto item = pl->itemOf(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->setExtraPlayTimes(0);
     };
@@ -786,7 +786,7 @@ void PlaylistWindow::playlist_removeItemRequested()
     if (!qdp)
         return;
 
-    qdp->traverseSelected([qdp](QUuid uuid) { qdp->removeItem(uuid); });
+    qdp->traverseSelected([qdp](QUuid itemUuid) { qdp->removeItem(itemUuid); });
     updatePlaylistHasItems();
 }
 

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -59,15 +59,14 @@ void PlaylistWindow::clearPlaylist(QUuid what)
 PlaylistItem PlaylistWindow::addToPlaylist(const QUuid &playlist, const QList<QUrl> &what)
 {
     QList<QUrl> filtered = Helpers::filterUrls(what);
-    PlaylistItem info;
+    PlaylistItem playlistItem;
     auto qdp = widgets.contains(playlist) ? widgets.value(playlist) : widgets[QUuid()];
     for (QUrl &url : filtered) {
-        PlaylistItem itemInfo = qdp->importUrl(url);
-        if (info.item.isNull())
-            info = itemInfo;
+        if (playlistItem.item.isNull())
+            playlistItem = qdp->importUrl(url);;
     }
     updatePlaylistHasItems();
-    return info;
+    return playlistItem;
 }
 
 PlaylistItem PlaylistWindow::addToCurrentPlaylist(QList<QUrl> what)

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -56,26 +56,26 @@ void PlaylistWindow::clearPlaylist(QUuid what)
     updatePlaylistHasItems();
 }
 
-QPair<QUuid, QUuid> PlaylistWindow::addToPlaylist(const QUuid &playlist, const QList<QUrl> &what)
+PlaylistItem PlaylistWindow::addToPlaylist(const QUuid &playlist, const QList<QUrl> &what)
 {
     QList<QUrl> filtered = Helpers::filterUrls(what);
-    QPair<QUuid, QUuid> info;
+    PlaylistItem info;
     auto qdp = widgets.contains(playlist) ? widgets.value(playlist) : widgets[QUuid()];
     for (QUrl &url : filtered) {
-        QPair<QUuid,QUuid> itemInfo = qdp->importUrl(url);
-        if (info.second.isNull())
+        PlaylistItem itemInfo = qdp->importUrl(url);
+        if (info.item.isNull())
             info = itemInfo;
     }
     updatePlaylistHasItems();
     return info;
 }
 
-QPair<QUuid, QUuid> PlaylistWindow::addToCurrentPlaylist(QList<QUrl> what)
+PlaylistItem PlaylistWindow::addToCurrentPlaylist(QList<QUrl> what)
 {
     return addToPlaylist(currentPlaylist, what);
 }
 
-QPair<QUuid, QUuid> PlaylistWindow::urlToQuickPlaylist(QUrl what)
+PlaylistItem PlaylistWindow::urlToQuickPlaylist(QUrl what)
 {
     auto pl = PlaylistCollection::getSingleton()->playlistOf(QUuid());
     pl->clear();
@@ -107,14 +107,14 @@ bool PlaylistWindow::isPlaylistShuffle(QUuid list)
     return pl->shuffle();
 }
 
-QPair<QUuid,QUuid> PlaylistWindow::getItemAfter(QUuid list, QUuid item)
+PlaylistItem PlaylistWindow::getItemAfter(QUuid list, QUuid item)
 {
     auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
     if (!pl)
         return { QUuid(), QUuid() };
     auto qpl = PlaylistCollection::queuePlaylist();
-    QPair<QUuid, QUuid> next = qpl->takeFirst();
-    if (!next.second.isNull())
+    PlaylistItem next = qpl->takeFirst();
+    if (!next.item.isNull())
         return next;
     QSharedPointer<Item> after;
     if (pl->shuffle() && !pl->isEmpty()) {
@@ -424,7 +424,7 @@ void PlaylistWindow::changePlaylistSelection( QUrl itemUrl, QUuid playlistUuid, 
         return;
     auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
     auto qpl = PlaylistCollection::queuePlaylist();
-    if (!itemUuid.isNull() && qpl->first().second == itemUuid) {
+    if (!itemUuid.isNull() && qpl->first().item == itemUuid) {
         queueWidget->removeItem(itemUuid);
     }
 }

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -76,7 +76,7 @@ PlaylistItem PlaylistWindow::addToCurrentPlaylist(QList<QUrl> what)
 
 PlaylistItem PlaylistWindow::urlToQuickPlaylist(QUrl what)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(QUuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(QUuid());
     pl->clear();
     widgets[QUuid()]->clear();
     ui->tabWidget->setCurrentWidget(widgets[QUuid()]);
@@ -85,13 +85,13 @@ PlaylistItem PlaylistWindow::urlToQuickPlaylist(QUrl what)
 
 bool PlaylistWindow::isCurrentPlaylistEmpty()
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(currentPlaylist);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(currentPlaylist);
     return pl ? pl->isEmpty() : true;
 }
 
 bool PlaylistWindow::isPlaylistSingularFile(QUuid list)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl || pl->count() != 1)
         return false;
     auto item = pl->itemFirst();
@@ -100,7 +100,7 @@ bool PlaylistWindow::isPlaylistSingularFile(QUuid list)
 
 bool PlaylistWindow::isPlaylistShuffle(QUuid list)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return false;
     return pl->shuffle();
@@ -108,7 +108,7 @@ bool PlaylistWindow::isPlaylistShuffle(QUuid list)
 
 PlaylistItem PlaylistWindow::getItemAfter(QUuid list, QUuid item)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return { QUuid(), QUuid() };
     auto qpl = PlaylistCollection::queuePlaylist();
@@ -129,7 +129,7 @@ PlaylistItem PlaylistWindow::getItemAfter(QUuid list, QUuid item)
 
 QUuid PlaylistWindow::getItemBefore(QUuid list, QUuid item)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return QUuid();
     QSharedPointer<Item> before = pl->itemBefore(item);
@@ -140,10 +140,10 @@ QUuid PlaylistWindow::getItemBefore(QUuid list, QUuid item)
 
 QUrl PlaylistWindow::getUrlOf(QUuid list, QUuid item)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return QUrl();
-    auto i = pl->itemOf(item);
+    auto i = pl->getItem(item);
     if (!i)
         return QUrl();
     return i->url();
@@ -151,7 +151,7 @@ QUrl PlaylistWindow::getUrlOf(QUuid list, QUuid item)
 
 QUrl PlaylistWindow::getUrlOfFirst(QUuid list)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     auto item = pl->itemFirst();
     if (item.isNull())
         return QUrl();
@@ -160,10 +160,10 @@ QUrl PlaylistWindow::getUrlOfFirst(QUuid list)
 
 void PlaylistWindow::setMetadata(QUuid list, QUuid item, const QVariantMap &map)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return;
-    auto i = pl->itemOf(item);
+    auto i = pl->getItem(item);
     if (!i)
         return;
     i->setMetadata(map);
@@ -176,7 +176,7 @@ void PlaylistWindow::setMetadata(QUuid list, QUuid item, const QVariantMap &map)
 
 void PlaylistWindow::replaceItem(QUuid list, QUuid item, const QList<QUrl> &urls)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return;
 
@@ -200,19 +200,19 @@ void PlaylistWindow::replaceItem(QUuid list, QUuid item, const QList<QUrl> &urls
 
 int PlaylistWindow::extraPlayTimes(QUuid list, QUuid item)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return -1;
-    auto i = pl->itemOf(item);
+    auto i = pl->getItem(item);
     return i ? i->extraPlayTimes() : -1;
 }
 
 void PlaylistWindow::setExtraPlayTimes(QUuid list, QUuid item, int amount)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return;
-    auto i = pl->itemOf(item);
+    auto i = pl->getItem(item);
     if (!i)
         return;
     i->setExtraPlayTimes(amount);
@@ -220,10 +220,10 @@ void PlaylistWindow::setExtraPlayTimes(QUuid list, QUuid item, int amount)
 
 void PlaylistWindow::deltaExtraPlayTimes(QUuid list, QUuid item, int delta)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(list);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(list);
     if (!pl)
         return;
-    auto i = pl->itemOf(item);
+    auto i = pl->getItem(item);
     if (!i)
         return;
     i->deltaExtraPlayTimes(delta);
@@ -252,7 +252,7 @@ void PlaylistWindow::tabsFromVList(const QVariantList &qvl)
                 this, &PlaylistWindow::itemDesired);
         connect(qdp, &DrawnPlaylist::contextMenuRequested,
                 this, &PlaylistWindow::playlist_contextMenuRequested);
-        auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+        auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
         ui->tabWidget->addTab(qdp, pl->title());
         widgets.insert(pl->uuid(), qdp);
     }
@@ -421,7 +421,7 @@ void PlaylistWindow::changePlaylistSelection( QUrl itemUrl, QUuid playlistUuid, 
     (void)itemUrl;
     if (!activateItem(playlistUuid, itemUuid))
         return;
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     auto qpl = PlaylistCollection::queuePlaylist();
     if (!itemUuid.isNull() && qpl->first().item == itemUuid) {
         queueWidget->removeItem(itemUuid);
@@ -438,7 +438,7 @@ void PlaylistWindow::addSimplePlaylist(QStringList data)
 
 void PlaylistWindow::addPlaylistByUuid(QUuid playlistUuid)
 {
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     if (!pl) {
         throw std::runtime_error("received a nullptr for a playlist");
     }
@@ -530,7 +530,7 @@ void PlaylistWindow::pasteQueue()
 void PlaylistWindow::playCurrentItem()
 {
     auto qdp = currentPlaylistWidget();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto itemUuid = qdp->currentItemUuid();
     if (itemUuid.isNull())
         return;
@@ -540,7 +540,7 @@ void PlaylistWindow::playCurrentItem()
 bool PlaylistWindow::playActiveItem()
 {
     auto qdp = currentPlaylistWidget();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto itemUuid = qdp->nowPlayingItem();
     if (itemUuid.isNull())
         return false;
@@ -567,9 +567,9 @@ void PlaylistWindow::selectPrevious()
 void PlaylistWindow::incExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto incrementer = [pl](QUuid itemUuid) {
-        auto item = pl->itemOf(itemUuid);
+        auto item = pl->getItem(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->incExtraPlayTimes();
     };
@@ -580,9 +580,9 @@ void PlaylistWindow::incExtraPlayTimes()
 void PlaylistWindow::decExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto decrementer = [pl](QUuid itemUuid) {
-        auto item = pl->itemOf(itemUuid);
+        auto item = pl->getItem(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->decExtraPlayTimes();
     };
@@ -593,9 +593,9 @@ void PlaylistWindow::decExtraPlayTimes()
 void PlaylistWindow::zeroExtraPlayTimes()
 {
     auto qdp = currentPlaylistWidget();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto zeroer = [pl](QUuid itemUuid) {
-        auto item = pl->itemOf(itemUuid);
+        auto item = pl->getItem(itemUuid);
         if (Q_LIKELY(!item.isNull()))
             item->setExtraPlayTimes(0);
     };
@@ -607,7 +607,7 @@ void PlaylistWindow::activateNext()
 {
     auto qdp = currentPlaylistWidget();
     auto now = qdp->nowPlayingItem();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto next = pl->itemAfter(now);
     if (!!next)
         activateItem(qdp->uuid(), next->uuid());
@@ -617,7 +617,7 @@ void PlaylistWindow::activatePrevious()
 {
     auto qdp = currentPlaylistWidget();
     auto now = qdp->nowPlayingItem();
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(qdp->uuid());
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
     auto prev = pl->itemBefore(now);
     if (!!prev)
         activateItem(qdp->uuid(), prev->uuid());
@@ -699,7 +699,7 @@ void PlaylistWindow::savePlaylist(const QUuid &playlistUuid)
     QString file;
     file = QFileDialog::getSaveFileName(this, tr("Export File"), QString(),
                                         tr("Playlist files (*.m3u *.m3u8)"), nullptr, options);
-    auto pl = PlaylistCollection::getSingleton()->playlistOf(playlistUuid);
+    auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     if (!file.isEmpty() && pl)
         emit exportPlaylist(file, pl->toStringList());
 }
@@ -807,7 +807,7 @@ void PlaylistWindow::playlist_copySelectionToClipboard(const QUuid &playlistUuid
     auto pl = qdp->playlist();
     QList<QUrl> urls;
     qdp->traverseSelected([&pl,&urls](QUuid itemUuid) {
-        urls.append(pl->itemOf(itemUuid)->url());
+        urls.append(pl->getItem(itemUuid)->url());
     });
     QMimeData *mimeData = new QMimeData();
     mimeData->setUrls(urls);
@@ -983,7 +983,7 @@ void PlaylistWindow::on_tabWidget_tabBarDoubleClicked(int index)
         int tabIndex = ui->tabWidget->indexOf(widget);
         if (tabIndex < 0)
             return;
-        auto pl = PlaylistCollection::getSingleton()->playlistOf(tabUuid);
+        auto pl = PlaylistCollection::getSingleton()->getPlaylist(tabUuid);
         if (!pl)
             return;
         pl->setTitle(qid->textValue());

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -83,7 +83,7 @@ public slots:
     bool activateItem(QUuid playlistUuid, QUuid itemUuid);
     void changePlaylistSelection(QUrl itemUrl, QUuid playlistUuid, QUuid itemUuid);
     void addSimplePlaylist(QStringList data);
-    void addPlaylistByUuid(QUuid uuid);
+    void addPlaylistByUuid(QUuid playlistUuid);
     void setDisplayFormatSpecifier(QString fmt);
     void dockLocationMaybeChanged();
 

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -6,6 +6,7 @@
 #include <QUuid>
 #include <random>
 #include "helpers.h"
+#include "playlist.h"
 
 namespace Ui {
 class PlaylistWindow;
@@ -25,13 +26,13 @@ public:
 
     void setCurrentPlaylist(QUuid what);
     void clearPlaylist(QUuid what);
-    QPair<QUuid, QUuid> addToPlaylist(const QUuid &playlist, const QList<QUrl> &what);
-    QPair<QUuid, QUuid> addToCurrentPlaylist(QList<QUrl> what);
-    QPair<QUuid, QUuid> urlToQuickPlaylist(QUrl what);
+    PlaylistItem addToPlaylist(const QUuid &playlist, const QList<QUrl> &what);
+    PlaylistItem addToCurrentPlaylist(QList<QUrl> what);
+    PlaylistItem urlToQuickPlaylist(QUrl what);
     bool isCurrentPlaylistEmpty();
     bool isPlaylistSingularFile(QUuid list);
     bool isPlaylistShuffle(QUuid list);
-    QPair<QUuid, QUuid> getItemAfter(QUuid list, QUuid item);
+    PlaylistItem getItemAfter(QUuid list, QUuid item);
     QUuid getItemBefore(QUuid list, QUuid item);
     QUrl getUrlOf(QUuid list, QUuid item);
     QUrl getUrlOfFirst(QUuid list);

--- a/widgets/drawncollection.cpp
+++ b/widgets/drawncollection.cpp
@@ -37,15 +37,15 @@ QSize CollectionPainter::sizeHint(const QStyleOptionViewItem &option, const QMod
 
 
 
-CollectionItem::CollectionItem(QUuid uuid, QListWidget *parent)
-    : QListWidgetItem(uuid.toString(), parent)
+CollectionItem::CollectionItem(QUuid playlistUuid, QListWidget *parent)
+    : QListWidgetItem(playlistUuid.toString(), parent)
 {
-    uuid_ = uuid;
+    playlistUuid_ = playlistUuid;
 }
 
 QUuid CollectionItem::uuid()
 {
-    return uuid_;
+    return playlistUuid_;
 }
 
 
@@ -90,9 +90,9 @@ void DrawnCollection::repopulatePlaylists()
 
 void DrawnCollection::self_currentRowChanged(int currentRow)
 {
-    QUuid uuid;
+    QUuid playlistUuid;
     if (currentRow != -1)
-        uuid = reinterpret_cast<CollectionItem*>(this->item(currentRow))->uuid();
-    emit playlistSelected(uuid);
+        playlistUuid = reinterpret_cast<CollectionItem*>(this->item(currentRow))->uuid();
+    emit playlistSelected(playlistUuid);
 }
 

--- a/widgets/drawncollection.cpp
+++ b/widgets/drawncollection.cpp
@@ -11,7 +11,7 @@ void CollectionPainter::paint(QPainter *painter, const QStyleOptionViewItem &opt
 {
     DrawnCollection *collectionWidget = qobject_cast<DrawnCollection*>(parent());
     auto collection = collectionWidget->collection();
-    auto playlist = collection->playlistOf(QUuid(index.data(Qt::DisplayRole).toString()));
+    auto playlist = collection->getPlaylist(QUuid(index.data(Qt::DisplayRole).toString()));
 
 
     QStyleOptionViewItem o2 = option;

--- a/widgets/drawncollection.h
+++ b/widgets/drawncollection.h
@@ -19,10 +19,10 @@ public:
 class CollectionItem : public QListWidgetItem
 {
 public:
-    CollectionItem(QUuid uuid, QListWidget *parent = nullptr);
+    CollectionItem(QUuid playlistUuid, QListWidget *parent = nullptr);
     QUuid uuid();
 private:
-    QUuid uuid_;
+    QUuid playlistUuid_;
 };
 
 

--- a/widgets/drawnplaylist.cpp
+++ b/widgets/drawnplaylist.cpp
@@ -253,18 +253,19 @@ void DrawnPlaylist::removeAll()
     clear();
 }
 
-QPair<QUuid,QUuid> DrawnPlaylist::importUrl(QUrl url)
+PlaylistItem DrawnPlaylist::importUrl(QUrl url)
 {
-    QPair<QUuid,QUuid> info;
+    PlaylistItem playlistItem;
     QSharedPointer<Playlist> playlist = this->playlist();
-    if (!playlist)  return info;
+    if (!playlist)
+        return playlistItem;
     auto item = playlist->addItem(url);
-    info.first = uuid_;
-    info.second = item->uuid();
+    playlistItem.list = uuid_;
+    playlistItem.item = item->uuid();
     if (currentFilterText.isEmpty() ||
             PlaylistSearcher::itemMatchesFilter(item, currentFilterList))
         addItem(item->uuid());
-    return info;
+    return playlistItem;
 }
 
 void DrawnPlaylist::currentToQueue()

--- a/widgets/drawnplaylist.h
+++ b/widgets/drawnplaylist.h
@@ -62,7 +62,7 @@ public:
     void sort(std::function<T(QSharedPointer<Item>)> converter,
               std::function<bool(const T &a, const T &b)> lessThan);
 
-    QPair<QUuid,QUuid> importUrl(QUrl url);
+    PlaylistItem importUrl(QUrl url);
     void currentToQueue();
 
     QUuid nowPlayingItem();

--- a/widgets/drawnplaylist.h
+++ b/widgets/drawnplaylist.h
@@ -23,7 +23,7 @@ public:
 
 class PlayItem : public QListWidgetItem {
 public:
-    PlayItem(const QUuid &uuid = QUuid(), const QUuid &playlistUuid = QUuid(), QListWidget *parent = nullptr);
+    PlayItem(const QUuid &itemUuid = QUuid(), const QUuid &playlistUuid = QUuid(), QListWidget *parent = nullptr);
     ~PlayItem();
 
     QUuid playlistUuid();
@@ -31,7 +31,7 @@ public:
 
 private:
     QUuid playlistUuid_;
-    QUuid uuid_;
+    QUuid itemUuid_;
 };
 
 
@@ -46,16 +46,16 @@ public:
     void setCollection(QSharedPointer<PlaylistCollection> collection);
     virtual QSharedPointer<Playlist> playlist() const;
     QUuid uuid() const;
-    void setUuid(const QUuid &uuid);
+    void setUuid(const QUuid &playlistUuid);
     QUuid currentItemUuid() const;
     QList<QUuid> currentItemUuids() const;
     void traverseSelected(std::function<void(QUuid)> callback);
     void setCurrentItem(QUuid itemUuid);
     void scrollToItem(QUuid itemUuid);
-    virtual void addItem(QUuid uuid);
+    virtual void addItem(QUuid itemUuid);
     void addItems(const QList<QUuid> &items);
     void addItemsAfter(QUuid item, const QList<QUuid> &items);
-    void removeItem(QUuid uuid);
+    void removeItem(QUuid itemUuid);
     void removeItems(const QList<int> &indicies);
     void removeAll();
     template<class T>
@@ -66,7 +66,7 @@ public:
     void currentToQueue();
 
     QUuid nowPlayingItem();
-    void setNowPlayingItem(QUuid uuid);
+    void setNowPlayingItem(QUuid itemUuid);
 
     QVariantMap toVMap() const;
     void fromVMap(const QVariantMap &qvm);
@@ -81,7 +81,7 @@ protected:
 
 private:
     QSharedPointer<PlaylistCollection> collection_;
-    QUuid uuid_;
+    QUuid playlistUuid_;
     QHash <QUuid, PlayItem*> itemsByUuid;
     QUuid lastSelectedItem;
     QUuid nowPlayingItem_;
@@ -138,7 +138,7 @@ class DrawnQueue : public DrawnPlaylist {
 public:
     DrawnQueue();
     virtual QSharedPointer<Playlist> playlist() const;
-    void addItem(QUuid uuid);
+    void addItem(QUuid itemUuid);
 };
 
 class PlaylistSelectionPrivate;


### PR DESCRIPTION
- Use a struct instead of QPair for playlist items
For code readability.
- Make it more obvious what uuid contains
Rename uuid to itemUuid or playlistUuid to improve code readability.
- Simplify code in PlaylistWindow::addToPlaylist
- Use a struct instead of QPair for chapters
Ideally, the conversion could be moved to the struct.
- Use a struct instead of QPair for track items
- Use more standard naming for methods returning a pointer
Rename:
itemOf(itemUuid) -> getItem(itemUuid)
playlistOf(playlistUuid) -> getPlaylist(playlistUuid)
For some reason, those don't seem as obvious as indexOf(string).