### PR TITLE
Recreate the playlist when playing the next file in folder

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -743,7 +743,8 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta)
         url = QUrl::fromLocalFile(nextFile);
     } while (!Helpers::urlSurvivesFilter(url, true));
     emit playingNextFile();
-    playlistWindow_->replaceItem(nowPlayingList, nowPlayingItem, { url });
+    playlistWindow_->clearPlaylist(nowPlayingList);
+    nowPlayingItem = playlistWindow_->addToPlaylist(nowPlayingList, { url }).item;
     startPlayWithUuid(url, nowPlayingList, nowPlayingItem, false);
     return true;
 }


### PR DESCRIPTION
This prevents recents from having duplicate uuids (as Playlist::replaceItem reuses the uuid for the first file), which breaks them.
Ideally, this would be done in Playlist::replaceItem to also handle removing an archive item when it doesn't contain any playable file. But there's also the fact that PlaybackManager::mpvw_playlistChanged isn't called when an archive contains only one file.