### PR TITLE
Don't show tooltip when changing volume outside of settings window

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1105,7 +1105,6 @@ void SettingsWindow::setFreestanding(bool freestanding)
 void SettingsWindow::setVolume(int level)
 {
     WIDGET_LOOKUP(ui->playbackVolume).setValue(level);
-    ui->playbackVolume->setValue(level);
 }
 
 void SettingsWindow::setZoomPreset(int which)


### PR DESCRIPTION
Since setVolume is called when the main window volume slider gets changed, setting it again here didn't make sense. And after 746637b3847ab3758483e8e76846541375c4c940 it triggered the tooltip.