### PR TITLE
Increase recent files size to 1000 when remember position is enabled

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -395,7 +395,9 @@ void Flow::readConfig()
         QVariantMap favoriteMap = storage.readVMap(fileFavorites);
         favoriteFiles = TrackInfo::tracksFromVList(favoriteMap.value(keyFiles).toList());
         favoriteStreams = TrackInfo::tracksFromVList(favoriteMap.value(keyStreams).toList());
+        LogStream("main") << "reading fileRecent start";
         recentFiles = TrackInfo::tracksFromVList(storage.readVList(fileRecent));
+        LogStream("main") << "reading fileRecent done";
     }
 }
 
@@ -1539,7 +1541,7 @@ void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title
     recentFiles.insert(0, track);
 
     // Trim the recent file list
-    while (recentFiles.size() > (rememberHistory ? 20 : 0))
+    while (recentFiles.size() > (rememberHistory ? (rememberFilePosition ? 1000 : 20) : 0))
         recentFiles.removeLast();
 
     // Notify (2022-03: the main window) that the recents have changed

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1615,7 +1615,7 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
     if (isEmpty)
         return;
 
-    for (int i = 0; i < tracks.count(); i++) {
+    for (int i = 0; i < tracks.count() && i < 20; i++) {
         TrackInfo track = tracks[i];
         QString displayString = track.url.fileName();
         QAction *a = new QAction(QString("%1 - %2").arg(i).arg(displayString),


### PR DESCRIPTION
But only show the 20 most recent ones in the menu.

I've tested it on a 2013 Intel Core i3-4130 @ 3.40GHz with an SSD, where it takes about 10 ms more to load the recent.json file.