### PR TITLE
Don't repeat file when playlist in shuffle mode with only one file

### DIFF
--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -122,7 +122,7 @@ PlaylistItem PlaylistWindow::getItemAfter(QUuid list, QUuid item)
     } else {
         after = pl->itemAfter(item);
     }
-    if (!after)
+    if (!after || after->uuid() == item)
         return { QUuid(), QUuid() };
     return { pl->uuid(), after->uuid() };
 }


### PR DESCRIPTION
The shuffle mode currently picks randomly the next file just before playing it, so if there's only one file, it'll play it in loop instead of stopping.

In the future, we should probably randomize the whole playlist (but keep the sort order) and save that state across restarts. That way, the same file won't play twice, it'll be possible to go back to the previously played track and the playlist will have an actual end.