### PR TITLE
Full playlist shuffle mode

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -395,9 +395,7 @@ void Flow::readConfig()
         QVariantMap favoriteMap = storage.readVMap(fileFavorites);
         favoriteFiles = TrackInfo::tracksFromVList(favoriteMap.value(keyFiles).toList());
         favoriteStreams = TrackInfo::tracksFromVList(favoriteMap.value(keyStreams).toList());
-        LogStream("main") << "reading fileRecent start";
         recentFiles = TrackInfo::tracksFromVList(storage.readVList(fileRecent));
-        LogStream("main") << "reading fileRecent done";
     }
 }
 

--- a/manager.cpp
+++ b/manager.cpp
@@ -702,8 +702,11 @@ void PlaybackManager::playNextTrack()
 {
     PlaylistItem next;
     next = playlistWindow_->getItemAfter(nowPlayingList, nowPlayingItem);
-    if (next.item.isNull() && playlistWindow_->isPlaylistRepeat(nowPlayingList))
-       next = playlistWindow_->getFirstItem(nowPlayingList);
+    if (next.item.isNull() && playlistWindow_->isPlaylistRepeat(nowPlayingList)) {
+        if (playlistWindow_->isPlaylistShuffle(nowPlayingList))
+            playlistWindow_->reshufflePlaylist(nowPlayingList);
+        next = playlistWindow_->getFirstItem(nowPlayingList);
+    }
     QUrl url = playlistWindow_->getUrlOf(next.list, next.item);
     if (!url.isEmpty())
         startPlayWithUuid(url, next.list, next.item, false);

--- a/playlist.h
+++ b/playlist.h
@@ -34,7 +34,7 @@ public:
     const QVariantMap &metadata() const;
     void setMetadata(const QVariantMap &qvm);
 
-    int originalPosition();
+    int originalPosition() const;
     void setOriginalPosition(int i);
 
     int queuePosition() const;
@@ -124,6 +124,8 @@ public:
     void setRepeat(bool repeat);
     bool shuffle();
     void setShuffle(bool shuffle);
+    void shuffleItems();
+    void unshuffleItems();
     QUuid uuid();
     void setUuid(const QUuid &playlistUuid);
     QUuid nowPlaying();

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -7,6 +7,7 @@
 #include <QFileDialog>
 #include <QMenu>
 #include <QThread>
+#include "logger.h"
 #include "playlistwindow.h"
 #include "ui_playlistwindow.h"
 #include "widgets/drawnplaylist.h"
@@ -744,9 +745,11 @@ void PlaylistWindow::sortPlaylistByUrl(const QUuid &playlistUuid)
 
 void PlaylistWindow::shufflePlaylist(const QUuid &playlistUuid, bool shuffle)
 {
+    LogStream("playlistwindow") << "shufflePlaylist start";
     if (widgets.contains(playlistUuid))
         widgets[playlistUuid]->playlist()->setShuffle(shuffle);
     refreshPlaylist(playlistUuid);
+    LogStream("playlistwindow") << "shufflePlaylist done";
 }
 
 void PlaylistWindow::reshufflePlaylist(const QUuid &playlistUuid)
@@ -758,11 +761,13 @@ void PlaylistWindow::reshufflePlaylist(const QUuid &playlistUuid)
 
 void PlaylistWindow::refreshPlaylist(const QUuid &playlistUuid)
 {
+    LogStream("playlistwindow") << "refreshPlaylist start";
     auto qdp = widgets.value(playlistUuid, nullptr);
     if (qdp) {
         qdp->repopulateItems();
         qdp->setCurrentItem(widgets[playlistUuid]->playlist()->nowPlaying());
     }
+    LogStream("playlistwindow") << "refreshPlaylist done";
 }
 
 void PlaylistWindow::restorePlaylist(const QUuid &playlistUuid)

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -42,6 +42,7 @@ public:
     int extraPlayTimes(QUuid list, QUuid item);
     void setExtraPlayTimes(QUuid list, QUuid item, int amount);
     void deltaExtraPlayTimes(QUuid list, QUuid item, int delta);
+    void reshufflePlaylist(const QUuid &playlistUuid);
 
     QVariantList tabsToVList() const;
     void tabsFromVList(const QVariantList &qvl);
@@ -124,7 +125,6 @@ private slots:
     void sortPlaylistByLabel(const QUuid &playlistUuid);
     void sortPlaylistByUrl(const QUuid &playlistUuid);
     void shufflePlaylist(const QUuid &playlistUuid, bool shuffle);
-    void reshufflePlaylist(const QUuid &playlistUuid);
     void refreshPlaylist(const QUuid & playlistUuid);
     void restorePlaylist(const QUuid &playlistUuid);
 

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -4,7 +4,6 @@
 #include <QDockWidget>
 #include <QHash>
 #include <QUuid>
-#include <random>
 #include "helpers.h"
 #include "playlist.h"
 
@@ -124,7 +123,9 @@ private slots:
     void savePlaylist(const QUuid &playlistUuid);
     void sortPlaylistByLabel(const QUuid &playlistUuid);
     void sortPlaylistByUrl(const QUuid &playlistUuid);
-    void randomizePlaylist(const QUuid &playlistUuid);
+    void shufflePlaylist(const QUuid &playlistUuid, bool shuffle);
+    void reshufflePlaylist(const QUuid &playlistUuid);
+    void refreshPlaylist(const QUuid & playlistUuid);
     void restorePlaylist(const QUuid &playlistUuid);
 
     void self_visibilityChanged();
@@ -158,8 +159,6 @@ private:
     QHash<QUuid, DrawnPlaylist*> widgets;
     DrawnPlaylist* queueWidget = nullptr;
     PlaylistSelection *clipboard = nullptr;
-    std::random_device randomDevice;
-    std::mt19937 randomGenerator;
 };
 
 #endif // PLAYLISTWINDOW_H

--- a/storage.cpp
+++ b/storage.cpp
@@ -8,6 +8,7 @@
 #include <QFileInfo>
 #include <QTextStream>
 #include <QUrl>
+#include "logger.h"
 #include "storage.h"
 #include "platform/unify.h"
 
@@ -56,8 +57,10 @@ void Storage::writeVList(QString name, const QVariantList &qvl)
 
 QVariantList Storage::readVList(QString name)
 {
-    QJsonDocument doc = readJsonObject(name);
-    return doc.array().toVariantList();
+    LogStream("storage") << "reading " + name + " start";
+    QVariantList vList = readJsonObject(name).array().toVariantList();
+    LogStream("storage") << "reading " + name + " done";
+    return vList;
 }
 
 QStringList Storage::readM3U(const QString &where)

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1688,7 +1688,7 @@
     </message>
     <message>
         <source>Randomize</source>
-        <translation>Randomize</translation>
+        <translation type="vanished">Randomize</translation>
     </message>
     <message>
         <source>Restore</source>
@@ -1729,6 +1729,10 @@
     <message>
         <source>Repeat</source>
         <translation type="unfinished">Repeat</translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1660,7 +1660,7 @@
     </message>
     <message>
         <source>Randomize</source>
-        <translation>Aleatorizar</translation>
+        <translation type="vanished">Aleatorizar</translation>
     </message>
     <message>
         <source>Restore</source>
@@ -1700,6 +1700,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1656,7 +1656,7 @@
     </message>
     <message>
         <source>Randomize</source>
-        <translation>Satunnaista</translation>
+        <translation type="vanished">Satunnaista</translation>
     </message>
     <message>
         <source>Restore</source>
@@ -1696,6 +1696,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1659,10 +1659,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Randomize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Restore</source>
         <translation type="unfinished">Kembalikan</translation>
     </message>
@@ -1700,6 +1696,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1643,10 +1643,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Randomize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1684,6 +1680,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1687,10 +1687,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Randomize</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Restore</source>
         <translation type="unfinished">Herstellen</translation>
     </message>
@@ -1728,6 +1724,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1668,7 +1668,7 @@
     </message>
     <message>
         <source>Randomize</source>
-        <translation>Перемешать</translation>
+        <translation type="vanished">Перемешать</translation>
     </message>
     <message>
         <source>Restore</source>
@@ -1709,6 +1709,10 @@
     <message>
         <source>Repeat</source>
         <translation type="unfinished">Повтор</translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1660,7 +1660,7 @@
     </message>
     <message>
         <source>Randomize</source>
-        <translation>随机排序</translation>
+        <translation type="vanished">随机排序</translation>
     </message>
     <message>
         <source>Restore</source>
@@ -1700,6 +1700,10 @@
     </message>
     <message>
         <source>Repeat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Reshuffle</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/widgets/drawnplaylist.h
+++ b/widgets/drawnplaylist.h
@@ -76,6 +76,8 @@ public:
 
     void setFilter(QString needles);
 
+    void repopulateItems();
+
 protected:
     bool event(QEvent *e);
 
@@ -101,8 +103,6 @@ signals:
     void contextMenuRequested(QPoint p, QUuid playlistUuid, QUuid itemUuid);
 
 private slots:
-    void repopulateItems();
-
     void model_rowsMoved(const QModelIndex & parent, int start, int end,
                          const QModelIndex & destination, int row);
     void self_currentItemChanged(QListWidgetItem *current,


### PR DESCRIPTION
- Implement full playlist shuffle mode
When shuffle mode is enabled, the original positions of the playlist items are saved, and the playlist is visibly shuffled. Each item is only played once and the next item is the item below the current item.
The currently playing item is kept as the first item in shuffle mode.
Once shuffle mode is disabled, the items are restored to their original positions.
The Randomize feature is replaced by a Reshuffle feature in the shuffle mode.
The Sort and Restore features are disabled in shuffle mode.
When the user adds items, they are added to the end of the playlist.
- Add logging for playlist shuffle and files load
DrawnPlaylist::repopulateItems() (called by PlaylistWindow::refreshPlaylist) is by far the slowest step of shuffling the playlist.
On a 2013 Intel Core i3-4130 @ 3.40GHz with a SATA SSD and a 200 000 items playlist (which takes up 62 MB on disk):
- - shufflePlaylist takes 15 ms
- - refreshPlaylist takes 461 ms
Reading that playlist on start takes 812 ms.
- Reshuffle the playlist on repeat
Once we reach the end of the playlist in repeat mode, reshuffle it before restarting playing it.