### PR TITLE
Improve title display

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -494,6 +494,10 @@ void Flow::setupMainWindowConnections()
     connect(mainWindow->playlistWindow(), &PlaylistWindow::hideFullscreenChanged,
             mainWindow, &MainWindow::setFullscreenHidePanels);
 
+    // propertieswindow -> mainwindow
+    connect(propertiesWindow, &PropertiesWindow::artistAndTitleChanged,
+            mainWindow, &MainWindow::setMediaTitle);
+
     // mainwindow -> playlistwindow
     connect(mainWindow, &MainWindow::playCurrentItemRequested,
             mainWindow->playlistWindow(), &PlaylistWindow::playCurrentItem);

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1726,7 +1726,7 @@ void MainWindow::setMediaTitle(QString title)
     if (freestanding_)
         window_title.append(tr(" [Freestanding]"));
     if (!title.isEmpty())
-        window_title.append(" - ").append(title);
+        window_title.prepend(" - ").prepend(title);
     setWindowTitle(window_title);
     ui->title->setText(!title.isEmpty() ? title : "-");
 }

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -150,6 +150,8 @@ void PropertiesWindow::setMetaData(QVariantMap data)
     ui->clipDescription->setTextCursor(cursor);
 
     metadataText = sectionText(tr("General"), data);
+    if (data.contains("artist") && data.contains("title"))
+        emit artistAndTitleChanged(data["artist"].toString() + " - " + data["title"].toString());
     updateLastTab();
 }
 

--- a/propertieswindow.h
+++ b/propertieswindow.h
@@ -18,6 +18,9 @@ public:
     explicit PropertiesWindow(QWidget *parent = nullptr);
     ~PropertiesWindow();
 
+signals:
+    void artistAndTitleChanged(QString artistAndTitle);
+
 public slots:
     void setFileName(const QString &filename);
     void setFileFormat(const QString &format);


### PR DESCRIPTION
- Display file title in title bar and task bar before app name
This makes it possible to see what's playing without having to switch to the app.
- Display artist name (in addition to title) in title bar and task bar
This is standard practice for audio media.