### PR TITLE
Add the default playlist format string in editable form

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5645,7 +5645,7 @@ media file played</string>
               <item>
                <widget class="QLineEdit" name="playlistFormat">
                 <property name="text">
-                 <string/>
+                 <string notr="true">%track{#. }{}{}%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>
                 </property>
                 <property name="placeholderText">
                  <string notr="true">%track{#. }{}{}%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>


### PR DESCRIPTION
This makes it easier to edit for the user than just a placeholder text.