### PR TITLE
Don't show track # by default in playlist

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5645,10 +5645,10 @@ media file played</string>
               <item>
                <widget class="QLineEdit" name="playlistFormat">
                 <property name="text">
-                 <string notr="true">%track{#. }{}{}%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>
+                 <string notr="true">%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>
                 </property>
                 <property name="placeholderText">
-                 <string notr="true">%track{#. }{}{}%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>
+                 <string notr="true">%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}</string>
                 </property>
                </widget>
               </item>

--- a/text/playlistFormat.html
+++ b/text/playlistFormat.html
@@ -47,5 +47,11 @@ p { margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-bl
 <p>genre</p>
 <p>title</p>
 <p>track</p>
+<p class="c3"><br></p>
+<p><span class="c1">Examples</span></p>
+<p class="c3"><br></p>
+<p>%track{#. }{}{}</p>
+<p>%artist{# - }{Unknown Artist - }{}</p>
+<p>%title{#}{$}{$}</p>
 </body>
 </html>


### PR DESCRIPTION
- Remove track # from default playlist format string
It's not very useful even for whole albums since it's only shown for a file after that file playback has started.
- Add examples for playlist format string
Including for the removed track # so it can easily be re-added by the user if needed.