### PR TITLE
Don't bail out until lock file can be locked or we get a response

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -229,9 +229,12 @@ void Flow::detectMode() {
             QDir::tempPath() + QLatin1Char('/') + QLatin1String("mpc-qt.lock");
         std::unique_ptr<QLockFile> lockFile = std::make_unique<QLockFile>(lockFilePath);
         lockFile->setStaleLockTime(0);
-        if (!lockFile->tryLock())
-            programMode = EarlyQuitMode;
-        else
+        while (!lockFile->tryLock()) {
+            programMode = alreadyAServer ? EarlyQuitMode : PrimaryMode;
+            if (programMode == EarlyQuitMode)
+                break;
+        }
+        if (lockFile->isLocked() || lockFile->tryLock())
             lockFile_ = std::move(lockFile);
     }
 }


### PR DESCRIPTION
Since 1f88fb3507ee5b18b5719614db33db258b454a40 if the user tries to open mpc-qt while the previous instance is still closing (usually because it's writing the playlists file), the new instance closes immediately.

This ensures it will wait until the lock file can be locked or until an other main instance replies.