### PR TITLE
Send the request to main server while waiting for lock file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -230,6 +230,7 @@ void Flow::detectMode() {
         std::unique_ptr<QLockFile> lockFile = std::make_unique<QLockFile>(lockFilePath);
         lockFile->setStaleLockTime(0);
         while (!lockFile->tryLock()) {
+            alreadyAServer = JsonServer::sendPayload(makePayload(), MpcQtServer::defaultSocketName());
             programMode = alreadyAServer ? EarlyQuitMode : PrimaryMode;
             if (programMode == EarlyQuitMode)
                 break;


### PR DESCRIPTION
7d5f30edd53747327948ffdf79e901ef41ae7e04 intended to do this, it was a mistake.

Without this, we're kinda back to what it was before 1f88fb3507ee5b18b5719614db33db258b454a40.
The difference is that we get zombie instance(s) that become alive in turn once the main instance gets closed.