### PR TITLE
Implement Go To feature

### DIFF
--- a/gotowindow.cpp
+++ b/gotowindow.cpp
@@ -1,0 +1,109 @@
+#include <QKeyEvent>
+#include <QLineEdit>
+#include <QRegularExpressionValidator>
+#include <QtGlobal>
+#include <helpers.h>
+
+#include "gotowindow.h"
+#include "ui_gotowindow.h"
+
+GoToWindow::GoToWindow(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::GoToWindow)
+{
+    ui->setupUi(this);
+}
+
+GoToWindow::~GoToWindow()
+{
+    delete ui;
+}
+
+void GoToWindow::init(double currentTime, double maxTime, double fps)
+{
+    maxTime_ = maxTime;
+    fps_ = fps == 0 ? 24 : fps;
+
+    ui->goToTime->setText(Helpers::toDateFormatWithZero(currentTime));
+    QRegularExpression regexTime(R"(^([0-9]?[0-9]):([0-9]?[0-9]):([0-9]?[0-9])\.[0-9]{3}$)");
+    QRegularExpressionValidator* validatorTime = new QRegularExpressionValidator(regexTime, this);
+    ui->goToTime->setValidator(validatorTime);
+    ui->goToTime->installEventFilter(this);
+
+    QRegularExpression regexFrame(R"(^([0-9]{1,})$)");
+    QRegularExpressionValidator* validatorFrame = new QRegularExpressionValidator(regexFrame, this);
+    ui->goToFrame->setValidator(validatorFrame);
+    ui->goToFrame->setText(QString::number(currentTime * fps, 'f', 0));
+
+    setFixedSize(size());
+    show();
+}
+
+void GoToWindow::on_goToTime_textChanged(const QString &text)
+{
+    double time = Helpers::fromDateFormat(text);
+    if (time < 0 || time > maxTime_)
+        ui->goToTime->setStyleSheet("QLineEdit { background-color: #903736; }");
+    else
+        ui->goToTime->setStyleSheet("");
+}
+
+void GoToWindow::on_goToFrame_textChanged(const QString &text)
+{
+    double time = text.toDouble() / fps_;
+    if (time < 0 || time > maxTime_)
+        ui->goToFrame->setStyleSheet("QLineEdit { background-color: #903736; }");
+    else
+        ui->goToFrame->setStyleSheet("");
+}
+
+void GoToWindow::on_goToTimeButton_clicked()
+{
+    double time = Helpers::fromDateFormat(ui->goToTime->text());
+    if (time < 0 || time > maxTime_)
+        return;
+    emit goTo(time);
+    close();
+}
+
+void GoToWindow::on_goToFrameButton_clicked()
+{
+    double time = ui->goToFrame->text().toDouble() / fps_;
+    if (time < 0 || time > maxTime_)
+        return;
+    emit goTo(time);
+    close();
+}
+
+bool GoToWindow::eventFilter(QObject *obj, QEvent *event)
+{
+    if (obj == ui->goToTime && event->type() == QEvent::KeyPress) {
+        auto keyEvent = reinterpret_cast<QKeyEvent*>(event);
+        int cursorPos = ui->goToTime->cursorPosition();
+        int key = keyEvent->key();
+        if (key == Qt::Key_Backspace) {
+            ui->goToTime->deselect();
+            if (cursorPos > 0) {
+                if (ui->goToTime->text()[cursorPos - 1].isDigit()) {
+                    ui->goToTime->cursorBackward(true);
+                    ui->goToTime->insert("0");
+                    ui->goToTime->setCursorPosition(cursorPos - 1);
+                }
+                else
+                    ui->goToTime->cursorBackward(false);
+                return true;
+            }
+        }
+        else if (key == Qt::Key_Delete)
+            return true;
+        else if (key >= Qt::Key_0 && key <= Qt::Key_9) {
+            if (ui->goToTime->text()[cursorPos].isDigit())
+                ui->goToTime->cursorForward(true);
+            else {
+                ui->goToTime->cursorForward(false);
+                return true;
+            }
+        }
+    }
+    return false;
+}

--- a/gotowindow.h
+++ b/gotowindow.h
@@ -1,0 +1,39 @@
+#ifndef GOTOWINDOW_H
+#define GOTOWINDOW_H
+
+#include <QWidget>
+
+namespace Ui {
+class GoToWindow;
+}
+
+class GoToWindow : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit GoToWindow(QWidget *parent = nullptr);
+    ~GoToWindow();
+
+signals:
+    void goTo(double time);
+
+public slots:
+    void init(double currentTime, double maxTime, double fps);
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event);
+
+private slots:
+    void on_goToTime_textChanged(const QString &text);
+    void on_goToFrame_textChanged(const QString &text);
+    void on_goToTimeButton_clicked();
+    void on_goToFrameButton_clicked();
+
+private:
+    Ui::GoToWindow *ui;
+    double maxTime_ = 0;
+    double fps_ = 0;
+};
+
+#endif // GOTOWINDOW_H

--- a/gotowindow.ui
+++ b/gotowindow.ui
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>GoToWindow</class>
+ <widget class="QWidget" name="GoToWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>319</width>
+    <height>154</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Go To...</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="0">
+   <item row="0" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="2" column="0">
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Time</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="5">
+        <widget class="QPushButton" name="goToFrameButton">
+         <property name="text">
+          <string>Go!</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Frame</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QLineEdit" name="goToTime">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="text">
+          <string notr="true">01:24:23.123</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="QPushButton" name="goToTimeButton">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Go!</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="4">
+        <spacer name="horizontalSpacer_6">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="2">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="2" column="3">
+        <widget class="QLineEdit" name="goToFrame"/>
+       </item>
+       <item row="0" column="0" colspan="6">
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</string>
+         </property>
+         <property name="scaledContents">
+          <bool>false</bool>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -252,6 +252,12 @@ QString Helpers::toDateFormat(double time)
             .arg(QString().number(fr),3,'0');
 }
 
+QString Helpers::toDateFormatWithZero(double time)
+{
+    QString date = toDateFormat(time);
+    return date.split(':').first().length() < 2 ? "0" + date : date;
+}
+
 QString Helpers::toDateFormatFixed(double time, Helpers::TimeFormat format)
 {
     int t = int(time*1000 + 0.5);
@@ -300,6 +306,15 @@ QTime Helpers::timeFromCFormat(const char time[])
     return t;
 }
 
+double Helpers::fromDateFormat(QString date)
+{
+    QStringList times = date.split(':');
+    for (auto time : times) {
+        if (time.toDouble() >= 60)
+            return -1;
+    }
+    return times[0].toDouble()*3600 + times[1].toDouble()*60 + times[2].toDouble();
+}
 
 static QString grabBrackets(QString source, int &position, int &length) {
     QString match;

--- a/helpers.h
+++ b/helpers.h
@@ -46,9 +46,11 @@ namespace Helpers {
     QString fileSizeToString(int64_t bytes);
     QString fileSizeToStringShort(int64_t bytes);
     QString toDateFormat(double time);
+    QString toDateFormatWithZero(double time);
     QString toDateFormatFixed(double time, TimeFormat format);
     QDate dateFromCFormat(const char date[]);
     QTime timeFromCFormat(const char time[]);
+    double fromDateFormat(QString date);
     QString parseFormat(QString fmt, QString fileName, DisabledTrack disabled,
                         Subtitles subtitles, double timeNav, double timeBegin,
                         double timeEnd);

--- a/main.cpp
+++ b/main.cpp
@@ -150,6 +150,10 @@ Flow::~Flow()
         delete favoritesWindow;
         favoritesWindow = nullptr;
     }
+    if (gotoWindow) {
+        delete gotoWindow;
+        gotoWindow = nullptr;
+    }
     if (screenSaver) {
         screenSaver->uninhibitSaver();
         delete screenSaver;
@@ -261,6 +265,8 @@ void Flow::init() {
     propertiesWindow = new PropertiesWindow();
     Logger::log("main", "creating favorites window");
     favoritesWindow = new FavoritesWindow();
+    Logger::log("main", "creating goto window");
+    gotoWindow = new GoToWindow();
     Logger::log("main", "creating log window");
     logWindow = new LogWindow();
     Logger::log("main", "creating library window");
@@ -546,6 +552,10 @@ void Flow::setupMainWindowConnections()
     connect(mainWindow, &MainWindow::organizeFavorites,
             favoritesWindow, &FavoritesWindow::show);
 
+    // mainwindow -> goto
+    connect(mainWindow, &MainWindow::showGoToWindow,
+            gotoWindow, &GoToWindow::init);
+
     // favorites -> mainwindow
     connect(favoritesWindow, &FavoritesWindow::favoriteTracks,
             mainWindow, &MainWindow::setFavoriteTracks);
@@ -584,6 +594,10 @@ void Flow::setupManagerConnections()
     // manager -> settings
     connect(playbackManager, &PlaybackManager::playerSettingsRequested,
             settingsWindow, &SettingsWindow::sendSignals);
+
+    // goto -> manager
+    connect(gotoWindow, &GoToWindow::goTo,
+            playbackManager, &PlaybackManager::navigateToTime);
 }
 
 void Flow::setupSettingsConnections()

--- a/main.h
+++ b/main.h
@@ -13,6 +13,7 @@
 #include "settingswindow.h"
 #include "propertieswindow.h"
 #include "favoriteswindow.h"
+#include "gotowindow.h"
 #include "thumbnailerwindow.h"
 #include "platform/screensaver.h"
 #include "platform/windowmanager.h"
@@ -114,6 +115,7 @@ private:
     SettingsWindow *settingsWindow = nullptr;
     PropertiesWindow *propertiesWindow = nullptr;
     FavoritesWindow *favoritesWindow = nullptr;
+    GoToWindow *gotoWindow = nullptr;
     LogWindow *logWindow = nullptr;
     LibraryWindow *libraryWindow = nullptr;
     ThumbnailerWindow *thumbnailerWindow = nullptr;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -976,7 +976,7 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->actionNavigateChaptersNext->setEnabled(enabled);
     ui->actionNavigateFilesPrevious->setEnabled(enabled);
     ui->actionNavigateFilesNext->setEnabled(enabled);
-    ui->actionNavigateGoto->setEnabled(false);
+    ui->actionNavigateGoto->setEnabled(enabled);
     ui->actionFavoritesAdd->setEnabled(enabled);
 
     ui->menuFileSubtitleDatabase->setEnabled(false);
@@ -2864,6 +2864,12 @@ void MainWindow::on_actionNavigateFilesPrevious_triggered()
 void MainWindow::on_actionNavigateFilesNext_triggered()
 {
     emit fileNext(true);
+}
+
+void MainWindow::on_actionNavigateGoto_triggered()
+{
+    emit showGoToWindow(mpvObject_->playTime(), mpvObject_->playLength(),
+                        ui->framerate->text().toDouble());
 }
 
 void MainWindow::on_actionHelpHomepage_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -154,6 +154,7 @@ signals:
     void chapterNext();
     void filePrevious(bool forceFolderFallback);
     void fileNext(bool forceFolderFallback);
+    void showGoToWindow(double playTime, double playLength, double fps);
     void chapterSelected(int64_t id);
     void timeSelected(double time);
     void fullscreenModeChanged(bool fullscreen);
@@ -388,6 +389,8 @@ private slots:
 
     void on_actionNavigateFilesPrevious_triggered();
     void on_actionNavigateFilesNext_triggered();
+
+    void on_actionNavigateGoto_triggered();
 
     void on_actionHelpHomepage_triggered();
     void on_actionHelpAbout_triggered();

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -128,6 +128,7 @@ win32:HEADERS += platform/screensaver_win.h \
                  platform/devicemanager_win.h
 
 SOURCES += main.cpp\
+    gotowindow.cpp \
     librarywindow.cpp \
     mpvwidget.cpp \
     mainwindow.cpp \
@@ -159,6 +160,7 @@ SOURCES += main.cpp\
     widgets/screencombo.cpp
 
 HEADERS  += \
+    gotowindow.h \
     librarywindow.h \
     mpvwidget.h \
     mainwindow.h \
@@ -191,6 +193,7 @@ HEADERS  += \
     widgets/screencombo.h
 
 FORMS    += \
+    gotowindow.ui \
     librarywindow.ui \
     mainwindow.ui \
     playlistwindow.ui \

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -94,6 +94,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -94,6 +94,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -102,6 +102,29 @@
     </message>
 </context>
 <context>
+    <name>GoToWindow</name>
+    <message>
+        <source>Go To...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Go!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Frame</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter a timecode using the format [hh:]mm:ss.ms to jump to a specified time. You do not need to enter the separators explicitely.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LibraryWindow</name>
     <message>
         <source>Library</source>


### PR DESCRIPTION
If the regex validator is set to prevent entering incorrect times (like 63), it doesn't play nice with the event filter.
I first tried with an input mask, but it's doesn't look nice and above all it leads to ugly bugs, like incorrect seeking.

The frame number may not be fully accurate because the fps is the estimated-vf-fps. We may want to show the fps somewhere like mpc-hc does (it actually allows to change it too).