### PR TITLE
Add a disabled state for white icons (dark fallback theme)

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -658,10 +658,27 @@ QIcon IconThemer::fetchIcon(const QString &name)
     if (folderMode_ == CustomFolder && customDir.exists() && customDir.exists(name)) {
         return QIcon(customFolder_ + name + ".svg");
     }
+    QIcon icon;
     if (folderMode_ != SystemFolder) {
-        return QIcon(fallbackFolder_ + name + ".svg");
+        icon = QIcon(fallbackFolder_ + name + ".svg");
     }
-    return QIcon::fromTheme(name, QIcon(fallbackFolder_ + name + ".svg"));
+    else {
+        icon =  QIcon::fromTheme(name, QIcon(fallbackFolder_ + name + ".svg"));
+    }
+    if (fallbackFolder_ == whiteIconsPath) {
+        // Add a disabled mode for white icons (dark theme) as Qt doesn't provide one
+        QImage image = icon.pixmap(QSize(16, 16), QIcon::Normal, QIcon::On).toImage();
+        for (int x = 0; x < image.width(); x++) {
+            for (int y = 0; y < image.height(); y++) {
+                QColor pixelColor = image.pixelColor(x, y);
+                pixelColor.setAlpha(pixelColor.alpha() / 3);
+                image.setPixelColor(x, y, pixelColor);
+            }
+        }
+        QPixmap pixmap = QPixmap::fromImage(image);
+        icon.addPixmap(pixmap, QIcon::Disabled);
+    }
+    return icon;
 }
 
 void IconThemer::setIconFolders(FolderMode folderMode,

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -654,23 +654,23 @@ void IconThemer::addIconData(const IconThemer::IconData &data)
 
 QIcon IconThemer::fetchIcon(const QString &name)
 {
-    QDir customDir(custom);
-    if (mode == CustomFolder && customDir.exists() && customDir.exists(name)) {
-        return QIcon(custom + name + ".svg");
+    QDir customDir(customFolder_);
+    if (folderMode_ == CustomFolder && customDir.exists() && customDir.exists(name)) {
+        return QIcon(customFolder_ + name + ".svg");
     }
-    if (mode != SystemFolder) {
-        return QIcon(fallback + name + ".svg");
+    if (folderMode_ != SystemFolder) {
+        return QIcon(fallbackFolder_ + name + ".svg");
     }
-    return QIcon::fromTheme(name, QIcon(fallback + name + ".svg"));
+    return QIcon::fromTheme(name, QIcon(fallbackFolder_ + name + ".svg"));
 }
 
 void IconThemer::setIconFolders(FolderMode folderMode,
                                 const QString &fallbackFolder,
                                 const QString &customFolder)
 {
-    mode = folderMode;
-    fallback = fallbackFolder;
-    custom = customFolder;
+    folderMode_ = folderMode;
+    fallbackFolder_ = fallbackFolder;
+    customFolder_ = customFolder;
     for (const IconData &data : std::as_const(iconDataList))
         updateButton(data);
 }

--- a/helpers.h
+++ b/helpers.h
@@ -13,6 +13,9 @@
 #include <QTime>
 #include <QDir>
 
+static const char blackIconsPath[] = ":/images/theme/black/";
+static const char whiteIconsPath[] = ":/images/theme/white/";
+
 class QPushButton;
 class QFileDialog;
 class QLocalServer;

--- a/helpers.h
+++ b/helpers.h
@@ -89,9 +89,9 @@ public slots:
 
 private:
     QList<IconData> iconDataList;
-    FolderMode mode;
-    QString fallback;
-    QString custom;
+    FolderMode folderMode_;
+    QString fallbackFolder_;
+    QString customFolder_;
 };
 
 class DisplayNode;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1693,9 +1693,9 @@ void MainWindow::setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> stre
         addTracks(streams);
 }
 
-void MainWindow::setIconTheme(IconThemer::FolderMode mode, QString fallback, QString custom)
+void MainWindow::setIconTheme(IconThemer::FolderMode folderMode, QString fallbackFolder, QString customFolder)
 {
-    themer.setIconFolders(mode, fallback, custom);
+    themer.setIconFolders(folderMode, fallbackFolder, customFolder);
 }
 
 void MainWindow::setHighContrastWidgets(bool yes)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -225,7 +225,7 @@ public slots:
     void setRecentDocuments(QList<TrackInfo> tracks);
     void setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration, bool setControlsInFullscreen);
     void setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> streams);
-    void setIconTheme(IconThemer::FolderMode mode, QString fallback, QString custom);
+    void setIconTheme(IconThemer::FolderMode folderMode, QString fallbackFolder, QString customFolder);
     void setHighContrastWidgets(bool yes);
     void setInfoColors(const QColor &foreground, const QColor &background);
     void setTime(double time, double length);

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -409,11 +409,11 @@ void PlaylistWindow::addQuickQueue()
     ui->quickPage->layout()->addWidget(queueWidget);
 }
 
-void PlaylistWindow::setIconTheme(IconThemer::FolderMode mode,
-                                  const QString &fallback,
-                                  const QString &custom)
+void PlaylistWindow::setIconTheme(IconThemer::FolderMode folderMode,
+                                  const QString &fallbackFolder,
+                                  const QString &customFolder)
 {
-    themer.setIconFolders(mode, fallback, custom);
+    themer.setIconFolders(folderMode, fallbackFolder, customFolder);
 }
 
 void PlaylistWindow::setHideFullscreen(bool hidden)

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -80,7 +80,7 @@ signals:
     void playlistMovedToBackup(QUuid backupUuid);
 
 public slots:
-    void setIconTheme(IconThemer::FolderMode mode, const QString &fallback, const QString &custom);
+    void setIconTheme(IconThemer::FolderMode folderMode, const QString &fallbackFolder, const QString &customFolder);
     void setHideFullscreen(bool hidden);
 
     bool activateItem(QUuid playlistUuid, QUuid itemUuid);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -131,8 +131,8 @@ static QMap<QString,FilterKernel> filterKernels {
 
 
 QHash<QString, QStringList> SettingMap::indexedValueToText = {
-    {"interfaceIconsInbuilt", { ":/images/theme/black/", \
-                                ":/images/theme/white/" }},
+    {"interfaceIconsInbuilt", { blackIconsPath, \
+                                whiteIconsPath }},
     {"videoFramebuffer", {"rgb8-rgba8", "rgb10-rgb10_a2", "rgba12-rgba12",\
                           "rgb16-rgba16", "rgb16f-rgba16f",\
                           "rgb32f-rgba32f"}},

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -94,7 +94,7 @@ signals:
 
     void mprisIpc(bool enabled);
     void logoSource(const QString &s);
-    void iconTheme(IconThemer::FolderMode mode, const QString &fallback, const QString &custom);
+    void iconTheme(IconThemer::FolderMode folderMode, const QString &fallbackFolder, const QString &customFolder);
     void highContrastWidgets(bool yes);
     void applicationPalette(const QPalette s);
     void videoColor(QColor background);


### PR DESCRIPTION
- Use more verbose names for folderMode, fallbackFolder and customFolder
- Add a disabled state pixmap for white icons in fallback theme
Qt doesn't provide a useful disabled mode for white icons (dark theme), they just stay white.

Before:

![Copie d'écran_20241110_125327](https://github.com/user-attachments/assets/839fadfd-c7d2-4c48-87d1-a00414a67654)

After:

![Copie d'écran_20241110_125223](https://github.com/user-attachments/assets/d339d24e-de93-4a69-9e50-c12ed1084c53)