### PR TITLE
Check if playlist pointer is valid before accessing shuffle property

### DIFF
--- a/playlist.cpp
+++ b/playlist.cpp
@@ -156,8 +156,9 @@ QVariantMap Item::toVMap() const
     v.insert(keyUrl, url());
     v.insert(keyUuid, uuid());
     v.insert(keyMetadata, metadata());
-    if (PlaylistCollection::getSingleton()->getPlaylist(playlistUuid())->shuffle())
-        v.insert(keyOriginalPosition, originalPosition());
+    if (PlaylistCollection::getSingleton()->getPlaylist(playlistUuid()) &&
+        PlaylistCollection::getSingleton()->getPlaylist(playlistUuid())->shuffle())
+            v.insert(keyOriginalPosition, originalPosition());
     return v;
 }
 


### PR DESCRIPTION
This crash happens on exit when playlist backups don't already contain the repeat attribute.
This check means that until backups get updated (and thus contain repeat) by removing or restoring a playlist, they won't get written to disk.
Regression caused by efceb5e1da37550e51195fb74d2aea9de3557679.