### PR TITLE
Restore color and audio settings when closing options with close button

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1200,6 +1200,12 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
         close();
 }
 
+void SettingsWindow::closeEvent(QCloseEvent *event)
+{
+    restoreColorControls();
+    restoreAudioSettings();
+}
+
 void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state)
 {
     // playerRememberFilePosition depends on playerKeepHistory

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -219,6 +219,8 @@ private slots:
 
     void on_buttonBox_clicked(QAbstractButton *button);
 
+    void closeEvent(QCloseEvent *event) override;
+
     void on_playerKeepHistory_checkStateChanged(Qt::CheckState state);
 
     void on_ccHdrMapper_currentIndexChanged(int index);


### PR DESCRIPTION
70280553eb8ae24d5a44b45e58d2cfbeef09c3f5 and
12beafeeadeaea7ec6addaef376823f643f11611 only restored settings when using the Cancel button to close options.