### PR TITLE
Flush log before closing log thread

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -104,6 +104,8 @@ Flow::Flow(QObject *owner) :
     logger->moveToThread(logThread);
     connect(logThread, &QThread::finished,
             logger, &QObject::deleteLater);
+    connect(this, &Flow::flushLog,
+            logger, &Logger::flushMessages);
 
     readConfig();
     Logger::log("main", "finished reading config");
@@ -172,6 +174,7 @@ Flow::~Flow()
         logWindow = nullptr;
     }
     if (logThread) {
+        emit flushLog();
         logThread->quit();
         logThread->wait();
         delete logThread;

--- a/main.h
+++ b/main.h
@@ -40,6 +40,7 @@ public:
 
 signals:
     void windowsRestored();
+    void flushLog();
 
 private:
     void readConfig();


### PR DESCRIPTION
This ensures that all log messages get written to disk. Otherwise, we lose the last ones.