### PR TITLE
Don't write playlists backup to disk on exit if not changed and add logging for files write

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -36,14 +36,6 @@ static const char keyDirectory[] = "directory";
 static const char keyFiles[] = "files";
 static const char keyStreams[] = "streams";
 
-static const char fileFavorites[] = "favorites";
-static const char fileGeometryV2[] = "geometry_v2";
-static const char fileKeys[] = "keys_v2";
-static const char filePlaylists[] = "playlists";
-static const char filePlaylistsBackup[] = "playlists_backup";
-static const char fileRecent[] = "recent";
-static const char fileSettings[] = "settings";
-
 //---------------------------------------------------------------------------
 
 int main(int argc, char *argv[])

--- a/storage.cpp
+++ b/storage.cpp
@@ -57,9 +57,11 @@ QVariantMap Storage::readVMap(QString name)
 
 void Storage::writeVList(QString name, const QVariantList &qvl)
 {
+    LogStream("storage") << "writing " + name + " start";
     QJsonDocument doc;
     doc.setArray(QJsonArray::fromVariantList(qvl));
     writeJsonObject(name, doc);
+    LogStream("storage") << "writing " + name + " done";
 }
 
 QVariantList Storage::readVList(QString name)

--- a/storage.cpp
+++ b/storage.cpp
@@ -1,7 +1,6 @@
 #include <QCoreApplication>
 #include <QStandardPaths>
 #include <QSettings>
-#include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QDir>
@@ -11,6 +10,14 @@
 #include "logger.h"
 #include "storage.h"
 #include "platform/unify.h"
+
+const char fileFavorites[] = "favorites";
+const char fileGeometryV2[] = "geometry_v2";
+const char fileKeys[] = "keys_v2";
+const char filePlaylists[] = "playlists";
+const char filePlaylistsBackup[] = "playlists_backup";
+const char fileRecent[] = "recent";
+const char fileSettings[] = "settings";
 
 QString Storage::configPath;
 
@@ -90,6 +97,11 @@ void Storage::writeM3U(const QString &where, QStringList items)
 
 void Storage::writeJsonObject(QString fname, const QJsonDocument &doc)
 {
+    if (fname == filePlaylistsBackup && doc == playlistsBackup &&
+            QFileInfo::exists(QDir(configPath).absoluteFilePath(fname + ".json"))) {
+        LogStream("storage") << "backup not needed for " + fname;
+        return;
+    }
     QFile file(QDir(configPath).absoluteFilePath(fname + ".json"));
     if (!file.open(QIODevice::WriteOnly | QIODevice::Text))
         return;
@@ -102,5 +114,7 @@ QJsonDocument Storage::readJsonObject(QString fname)
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
         return QJsonDocument();
     QJsonDocument doc = QJsonDocument::fromJson(QTextStream(&file).readAll().toUtf8());
+    if (fname == filePlaylistsBackup)
+        playlistsBackup = doc;
     return doc;
 }

--- a/storage.h
+++ b/storage.h
@@ -1,7 +1,16 @@
 #ifndef STORAGE_H
 #define STORAGE_H
 
+#include <QJsonDocument>
 #include <QObject>
+
+extern const char fileFavorites[];
+extern const char fileGeometryV2[];
+extern const char fileKeys[];
+extern const char filePlaylists[];
+extern const char filePlaylistsBackup[];
+extern const char fileRecent[];
+extern const char fileSettings[];
 
 class Storage : public QObject
 {
@@ -29,6 +38,7 @@ public slots:
 
 private:
     static QString configPath;
+    QJsonDocument playlistsBackup;
 };
 
 #endif // STORAGE_H


### PR DESCRIPTION
- Don't write playlists backup to disk on exit if not changed
Based on idea of @cmdrkotori in #255.
- Add logging for files write