### PR TITLE
Use constexpr or extern for static const char

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -17,6 +17,9 @@
 #include "helpers.h"
 #include "platform/unify.h"
 
+const char blackIconsPath[] = ":/images/theme/black/";
+const char whiteIconsPath[] = ":/images/theme/white/";
+
 QSet<QString> Helpers::audioVideoFileExtensions {
     // DVD/Blu-ray audio formats
     "ac3", "a52",

--- a/helpers.h
+++ b/helpers.h
@@ -13,8 +13,8 @@
 #include <QTime>
 #include <QDir>
 
-static const char blackIconsPath[] = ":/images/theme/black/";
-static const char whiteIconsPath[] = ":/images/theme/white/";
+extern const char blackIconsPath[];
+extern const char whiteIconsPath[];
 
 class QPushButton;
 class QFileDialog;

--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -11,12 +11,12 @@
 #include "platform/devicemanager.h"
 #include "platform/unify.h"
 
-static const char httpVersion[] = "HTTP/1.1";
-static const char errorDocument[] = "<html><head><title>%1</title></head>"
+constexpr char httpVersion[] = "HTTP/1.1";
+constexpr char errorDocument[] = "<html><head><title>%1</title></head>"
                                     "<body><h1>%1</h1></body></html>";
-static const char mimeFormUrlEncoded[] = "application/x-www-form-urlencoded";
-static const char mimeHtml[] = "text/html";
-static const char dateZero[] = "1970.01.01 00:00";
+constexpr char mimeFormUrlEncoded[] = "application/x-www-form-urlencoded";
+constexpr char mimeHtml[] = "text/html";
+constexpr char dateZero[] = "1970.01.01 00:00";
 
 static QMap<HttpResponse::HttpStatus,QString> statusToText = {
     { HttpResponse::Http200Ok, "200 OK" },
@@ -80,7 +80,7 @@ HttpResponse::HttpResponse()
 
 void HttpResponse::fillHeaders()
 {
-    static const char dateFmt[] = "ddd, dd MMM yyyy HH:mm:ss t";
+    constexpr char dateFmt[] = "ddd, dd MMM yyyy HH:mm:ss t";
     headers["Date"] = dateResponse.toString(dateFmt);
     if (!headers.contains("Server"))
         headers["Server"] = QCoreApplication::applicationName();
@@ -227,7 +227,7 @@ QString HttpServer::urlEncode(QString plainText)
         map[(byte)']'] = 1;
         return map;
     }();
-    static const char hexadecimal[] = "0123456789ABCDEF";
+    constexpr char hexadecimal[] = "0123456789ABCDEF";
     QByteArray ba = plainText.toUtf8();
     QByteArray dest;
     const byte *data = reinterpret_cast<const byte*>(ba.constData());

--- a/main.cpp
+++ b/main.cpp
@@ -29,12 +29,12 @@
 
 //---------------------------------------------------------------------------
 
-static const char flatpakDesktopFile[] = "io.github.mpc_qt.Mpc-Qt";
+constexpr char flatpakDesktopFile[] = "io.github.mpc_qt.Mpc-Qt";
 
-static const char keyCommand[] = "command";
-static const char keyDirectory[] = "directory";
-static const char keyFiles[] = "files";
-static const char keyStreams[] = "streams";
+constexpr char keyCommand[] = "command";
+constexpr char keyDirectory[] = "directory";
+constexpr char keyFiles[] = "files";
+constexpr char keyStreams[] = "streams";
 
 static const char fileFavorites[] = "favorites";
 static const char fileGeometryV2[] = "geometry_v2";

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -28,8 +28,8 @@
 #include <QStyle>
 
 using namespace Helpers;
-static const char SKIPACTION[] = "Skip";
-static const char textWindowTitle[] = "Media Player Classic Qute Theater";
+constexpr char SKIPACTION[] = "Skip";
+constexpr char textWindowTitle[] = "Media Player Classic Qute Theater";
 
 
 MainWindow::MainWindow(QWidget *parent) :

--- a/manager.cpp
+++ b/manager.cpp
@@ -4,8 +4,8 @@
 #include "logger.h"
 
 using namespace Helpers;
-static const char strTrue[] =  "true";
-static const char strFalse[] =  "false";
+constexpr char strTrue[] =  "true";
+constexpr char strFalse[] =  "false";
 
 Q_GLOBAL_STATIC_WITH_ARGS(QRegularExpression, wordSplitter, ("\\W+"));
 

--- a/platform/windowmanager.cpp
+++ b/platform/windowmanager.cpp
@@ -7,10 +7,10 @@
 #include "mainwindow.h"
 #include "windowmanager.h"
 
-static const char keyGeometry[] = "geometry";
-static const char keyMaximized[] = "maximized";
-static const char keyQtState[] = "qtState";
-static const char keyState[] = "state";
+constexpr char keyGeometry[] = "geometry";
+constexpr char keyMaximized[] = "maximized";
+constexpr char keyQtState[] = "qtState";
+constexpr char keyState[] = "state";
 
 WindowManager::WindowManager(QObject *parent)
     : QObject{parent}

--- a/thumbnailerwindow.cpp
+++ b/thumbnailerwindow.cpp
@@ -11,10 +11,10 @@
 #include "ui_thumbnailerwindow.h"
 
 // NOTE: do we configure the thumb format in the settings dialog?
-static const char logModule[] = "thumbnailer";
-static const char friendlyName[] = "Media Player Classic Qute Theater - Thumbnailer";
-static const char thumbFormat[] = "%f_thumbs_[%t{yyyy.MM.dd_hh.mm.ss}]";
-static const char saveDialogFilter[] = "Images (*.png *.jpg *.jpeg)";
+constexpr char logModule[] = "thumbnailer";
+constexpr char friendlyName[] = "Media Player Classic Qute Theater - Thumbnailer";
+constexpr char thumbFormat[] = "%f_thumbs_[%t{yyyy.MM.dd_hh.mm.ss}]";
+constexpr char saveDialogFilter[] = "Images (*.png *.jpg *.jpeg)";
 
 constexpr int thumbMargin = 8;
 constexpr int pageMargin = 10;


### PR DESCRIPTION
- Move definition of const char out of header file
See https://github.com/mpc-qt/mpc-qt/pull/260#discussion_r1841676590
- Use C++11 constexpr char instead of static const char