### PR TITLE
Transmit shuffle_ to toVMap instead of accessing afterwards

### DIFF
--- a/playlist.cpp
+++ b/playlist.cpp
@@ -150,15 +150,14 @@ void Item::fromString(QString input)
     setUrl(QUrl::fromUserInput(input));
 }
 
-QVariantMap Item::toVMap() const
+QVariantMap Item::toVMap(bool savePosition) const
 {
     QVariantMap v;
     v.insert(keyUrl, url());
     v.insert(keyUuid, uuid());
     v.insert(keyMetadata, metadata());
-    if (PlaylistCollection::getSingleton()->getPlaylist(playlistUuid()) &&
-        PlaylistCollection::getSingleton()->getPlaylist(playlistUuid())->shuffle())
-            v.insert(keyOriginalPosition, originalPosition());
+    if (savePosition)
+        v.insert(keyOriginalPosition, originalPosition());
     return v;
 }
 
@@ -536,7 +535,7 @@ QVariantMap Playlist::toVMap()
 
     QVariantList qvl;
     for (auto &i : items) {
-        qvl.append(i->toVMap());
+        qvl.append(i->toVMap(shuffle_));
     }
     qvm.insert(keyItems, qvl);
     return qvm;

--- a/playlist.h
+++ b/playlist.h
@@ -54,7 +54,7 @@ public:
     QString toString() const;
     void fromString(QString input);
 
-    QVariantMap toVMap() const;
+    QVariantMap toVMap(bool savePosition) const;
     void fromVMap(const QVariantMap &qvm);
 
 private:


### PR DESCRIPTION
This prevents access problems with playlists_backup and makes f9bc20e5f4d5303cc3e90c8e7f1f7ff10ab473fd unnecessary.
Fixes https://github.com/mpc-qt/mpc-qt/pull/260#issuecomment-2473450012