### PR TITLE
Handle SIGHUP, SIGINT and SIGTERM signals

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <clocale>
+#include <csignal>
 #include <QApplication>
 #include <QLocalSocket>
 #include <QFileDialog>
@@ -40,6 +41,12 @@ constexpr char keyStreams[] = "streams";
 
 int main(int argc, char *argv[])
 {
+    #if !defined(Q_OS_WIN)
+    std::signal(SIGHUP, signalHandler);
+    #endif
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
+
     Flow::earlyPlatformOverride();
 
     QApplication a(argc, argv);
@@ -80,6 +87,10 @@ int main(int argc, char *argv[])
         return 0;
     f.init();
     return f.run();
+}
+
+void signalHandler(int) {
+    QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection);
 }
 
 //---------------------------------------------------------------------------

--- a/main.h
+++ b/main.h
@@ -22,7 +22,9 @@ class MprisInstance;
 class QLockFile;
 class QThread;
 
-// a simple class to control program exection and own application objects
+void signalHandler(int);
+
+// a simple class to control program execution and own application objects
 class Flow : public QObject {
     Q_OBJECT
     enum ProgramMode { UnknownMode, EarlyQuitMode, PrimaryMode, FreestandingMode, };


### PR DESCRIPTION
This allows mpc-qt to write files to disk before closing when it receives these signals.

For reference:
SIGHUP: sent when the terminal is closed
SIGINT: sent when CTRL+C is pressed in the terminal
SIGTERM: sent by default by kill and killall commands