### PR TITLE
Ensure mpc-qt closes correctly when handling signals

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -133,6 +133,9 @@ Flow::~Flow()
         // as the sole application.  Freestanding applications don't write any
         // settings, but they do inherit them.
         if (programMode == PrimaryMode) {
+            updateRecentPosition(false);
+            settings = settingsWindow->settings();
+            writeConfig();
             storage.writeVList(filePlaylists, mainWindow->playlistWindow()->tabsToVList());
             storage.writeVList(filePlaylistsBackup, PlaylistCollection::getBackup()->toVList());
         }
@@ -1577,10 +1580,6 @@ void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title
 void Flow::endProgram()
 {
     Logger::log("main", "endProgram");
-    updateRecentPosition(false);
-    // We're about to quit, so write out our config
-    settings = settingsWindow->settings();
-    writeConfig();
     QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
 }
 
 void signalHandler(int) {
-    QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
 }
 
 //---------------------------------------------------------------------------

--- a/main.cpp
+++ b/main.cpp
@@ -116,6 +116,7 @@ Flow::Flow(QObject *owner) :
 
 Flow::~Flow()
 {
+    Logger::log("main", "~Flow");
     if (server) {
         delete server;
         server = nullptr;
@@ -180,6 +181,7 @@ Flow::~Flow()
         logWindow = nullptr;
     }
     if (logThread) {
+        Logger::log("logger", "flushing log before closing it");
         emit flushLog();
         logThread->quit();
         logThread->wait();


### PR DESCRIPTION
- Use QCoreApplication::exit when handling IPC signals
When using quit, if the playlist is opened, mpc-qt tends to hang with the window hidden instead of closing.
- Move settings and recent update to the destructor
So that they're called when handling IPC signals.
- Add logging in the destructor