### PR TITLE
Check if tracks menu action exists before trying to access it

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2013,19 +2013,19 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
 
 void MainWindow::audioTrackSet(int64_t id)
 {
-    if (audioTracksGroup != nullptr)
+    if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length())
         audioTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
 }
 
 void MainWindow::videoTrackSet(int64_t id)
 {
-    if (videoTracksGroup != nullptr)
+    if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length())
         videoTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
 }
 
 void MainWindow::subtitleTrackSet(int64_t id)
 {
-    if (subtitleTracksGroup != nullptr) {
+    if (subtitleTracksGroup != nullptr && id <= subtitleTracksGroup->actions().length()) {
         if (id <= 0)
             id = subtitleTracksGroup->actions().length();
         subtitleTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);


### PR DESCRIPTION
With:
- file_1 which has two audio tracks and track_1 selected
- file_2 which has three audio tracks and track_3 selected
If we open file_1 then file_2, audioTrackSet gets called to mark track_3 as selected before the audio tracks menu has been updated to contain three tracks instead of two, thus segfaulting.

This doesn't seem to happen with subtitles and I haven't tested it with video tracks, but better be safe I guess.