### PR TITLE
Logging improvements

### DIFF
--- a/logger.cpp
+++ b/logger.cpp
@@ -44,6 +44,7 @@ void loggerCallback(QtMsgType type, const QMessageLogContext &context, const QSt
     case QtFatalMsg:
         Logger::fatalMessage();
         fprintf(realStdErr.ptr, "[FATALITY] [qt] fatal: %s\n", msg.toUtf8().data());
+        fflush(realStdErr.ptr);
         std::abort();
     }
 }
@@ -144,7 +145,7 @@ void Logger::fatalMessage()
 {
     // Oops!  Something went very wrong!
     // Try to flush anything pending to stderr and abort
-    if (loggerInstance) {
+    if (loggerInstance && !logToConsole) {
         for (const auto &i : std::as_const(loggerInstance->pendingMessages))
             std::fprintf(realStdErr.ptr, "%s\n", i.toLocal8Bit().data());
     }

--- a/logger.cpp
+++ b/logger.cpp
@@ -20,6 +20,7 @@ public:
 };
 
 
+static bool logToConsole = false; // by default, do not log to console
 static bool loggerInstanceSetBefore = false;
 static Logger *loggerInstance = nullptr;
 static StdFileCopy realStdErr(stderr);
@@ -81,6 +82,11 @@ Logger *Logger::singleton()
         loggerInstanceSetBefore = true;
     }
     return loggerInstance;
+}
+
+void Logger::setConsoleLogging(bool consoleLogging)
+{
+    logToConsole = consoleLogging;
 }
 
 // The log buffer class has likely been moved to
@@ -217,8 +223,11 @@ void Logger::makeLog(QString line)
     if (!loggingEnabled)
         return;
     line = QString("[%1] %2").arg(QString::number(elapsed.nsecsElapsed()/1000000000.0, 'f', 3), line.trimmed());
-    // If you're encountering early or fantastic errors, uncomment this line:
-    //fprintf(realStdErr.ptr, "%s\n",  line.toLocal8Bit().constData());
+    // If you're encountering early or fantastic errors, make this if statement true
+    if (logToConsole) {
+        fprintf(realStdErr.ptr, "%s\n",  line.toLocal8Bit().constData());
+        fflush(realStdErr.ptr);
+    }
     if (immediateMode) {
         emit logMessage(line);
         if (logFileStream) {

--- a/logger.h
+++ b/logger.h
@@ -20,6 +20,7 @@ public:
     explicit Logger(QObject *owner = nullptr);
     ~Logger();
     static Logger *singleton();
+    static void setConsoleLogging(bool consoleLogging);
 
     // log: lossely based on the requirements for printing mpv messages
     static void log(QString line);

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,6 @@
 #include <clocale>
 #include <csignal>
+#include <cstring>
 #include <QApplication>
 #include <QLocalSocket>
 #include <QFileDialog>
@@ -37,6 +38,9 @@ constexpr char keyDirectory[] = "directory";
 constexpr char keyFiles[] = "files";
 constexpr char keyStreams[] = "streams";
 
+constexpr char optConsoleLog[] = "log-to-console";
+constexpr char optConsoleLogEx[] = "--log-to-console";
+
 //---------------------------------------------------------------------------
 
 int main(int argc, char *argv[])
@@ -50,6 +54,14 @@ int main(int argc, char *argv[])
     Flow::earlyPlatformOverride();
 
     QApplication a(argc, argv);
+    bool foundLoggingOpt = false;
+    for (int i = 1; i < argc; i++) {
+        if (!std::strcmp(argv[i], optConsoleLogEx)) {
+            foundLoggingOpt = true;
+            break;
+        }
+    }
+    Logger::setConsoleLogging(foundLoggingOpt);
     Logger::singleton();
     a.setWindowIcon(QIcon(":/images/icon/mpc-qt.svg"));
 
@@ -204,12 +216,14 @@ void Flow::parseArgs()
     QCommandLineOption noFilesOpt("no-files", tr("Do not load file history, playlists, or favorites."));
     QCommandLineOption sizeOpt("size", tr("Main window size."), "w,h");
     QCommandLineOption posOpt("pos", tr("Main window position."), "x,y");
+    QCommandLineOption loggingOpt(optConsoleLog, tr("Also write logging messages to console."));
 
     parser.addOption(freestandingOpt);
     parser.addOption(noConfigOpt);
     parser.addOption(noFilesOpt);
     parser.addOption(sizeOpt);
     parser.addOption(posOpt);
+    parser.addOption(loggingOpt);
     parser.addPositionalArgument("urls", tr("URLs to open, optionally."), "[urls...]");
 
     parser.process(QCoreApplication::arguments());

--- a/main.cpp
+++ b/main.cpp
@@ -120,7 +120,8 @@ Flow::Flow(QObject *owner) :
     connect(logThread, &QThread::finished,
             logger, &QObject::deleteLater);
     connect(this, &Flow::flushLog,
-            logger, &Logger::flushMessages);
+            logger, &Logger::flushMessages,
+            Qt::BlockingQueuedConnection);
     Logger::log("main", "starting logging");
 
     readConfig();

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation>Do not load file history, playlists, or favorites.</translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation>No cargar el historial de archivos, listas de reproducción ni favoritos.</translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -92,6 +92,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation>Jangan memuat histori berkas, daftar putar atau unggulan.</translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -92,6 +92,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation>Laad geen bestandshistorie, afspeellijsten, of favorieten.</translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation>Не загружать историю файлов, списки воспроизведения или избранное.</translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -100,6 +100,10 @@
         <source>Do not load file history, playlists, or favorites.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Also write logging messages to console.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>GoToWindow</name>


### PR DESCRIPTION
Turn the mechanism where logs can be pushed on to stderr into a full-blown feature.  This new feature is invoked with the argument `--log-to-console`.  This is principally a debugging feature.

**Why shouldn't I do this?** The log thread will flush stderr after every line, which may slow it down.