### PR TITLE
Close playlistWindow with MainWindow and add logging to destructors

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -79,6 +79,7 @@ MainWindow::MainWindow(QWidget *parent) :
 
 MainWindow::~MainWindow()
 {
+    Logger::log("mainwindow", "~MainWindow");
     mpvObject_->setWidgetType(Helpers::NullWidget);
     delete playlistWindow_;
     delete ui;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -374,6 +374,10 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+    Logger::log("mainwindow", "closeEvent");
+    bool showPlaylist = ui->actionViewHidePlaylist->isChecked();
+    playlistWindow_->close();
+    ui->actionViewHidePlaylist->setChecked(showPlaylist);
     event->accept();
     emit instanceShouldQuit();
 }

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -198,6 +198,7 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
 
 MpvObject::~MpvObject()
 {
+    Logger::log("mpvwidget", "~MpvObject");
     if (widget)
         delete widget;
     if (hideTimer) {

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -35,6 +35,7 @@ PlaylistWindow::PlaylistWindow(QWidget *parent) :
 
 PlaylistWindow::~PlaylistWindow()
 {
+    Logger::log("playlistwindow", "~PlaylistWindow");
     delete ui;
     delete clipboard;
 }

--- a/widgets/drawnplaylist.cpp
+++ b/widgets/drawnplaylist.cpp
@@ -7,6 +7,7 @@
 #include "drawnplaylist.h"
 #include "playlist.h"
 #include "helpers.h"
+#include "logger.h"
 
 PlayPainter::PlayPainter(QObject *parent) : QAbstractItemDelegate(parent) {}
 
@@ -131,6 +132,7 @@ DrawnPlaylist::DrawnPlaylist(QSharedPointer<PlaylistCollection> collection,
 
 DrawnPlaylist::~DrawnPlaylist()
 {
+    Logger::log("drawnplaylist", "~DrawnPlaylist");
     worker->deleteLater();
 }
 


### PR DESCRIPTION
- Close playlistWindow with MainWindow
Otherwise, it makes the app hang when closing with QApplication::quit().
That doesn't mean we want to use QApplication::quit() as it there are still cases where it makes the app hang on close.
We need to restore the state of the playlist window (shown/hidden) action after closing it so that it gets remembered for the next start.
- Add logging in main classes destructors