### PR TITLE
Flush pending messages to disk on fatal message

### DIFF
--- a/logger.h
+++ b/logger.h
@@ -30,7 +30,6 @@ public:
     static void logs(const QStringList &strings);
     static void logs(QString prefix, const QStringList &strings);
     static void logs(QString prefix, QString level, const QStringList &strings);
-    static void fatalMessage();
 
 signals:
     void logMessage(QString message);
@@ -40,6 +39,7 @@ public slots:
     void setLogFile(QString fileName);
     void setLoggingEnabled(bool enabled);
     void setFlushTime(int msec);
+    void fatalMessage();
     void flushMessages();
     void makeLog(QString line);
     void makeLogPrefixed(QString prefix, QString message);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7898,7 +7898,7 @@ media file played</string>
               <item>
                <widget class="QRadioButton" name="logUpdateNoDelay">
                 <property name="text">
-                 <string>No delay (consumes cpu)</string>
+                 <string>No delay (consumes cpu, use this for testing)</string>
                 </property>
                </widget>
               </item>
@@ -7921,7 +7921,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string> msec</string>
+                 <string> ms</string>
                 </property>
                 <property name="prefix">
                  <string>Every </string>

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -177,7 +177,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>20</number>
+          <number>21</number>
          </property>
          <widget class="QWidget" name="playerPage">
           <layout class="QGridLayout" name="playerPageLayout">
@@ -1347,6 +1347,9 @@ media file played</string>
               </item>
               <item row="1" column="1">
                <widget class="QScrollBar" name="playbackBalance">
+                <property name="cursor">
+                 <cursorShape>PointingHandCursor</cursorShape>
+                </property>
                 <property name="minimum">
                  <number>-100</number>
                 </property>
@@ -1356,13 +1359,13 @@ media file played</string>
                 <property name="orientation">
                  <enum>Qt::Orientation::Horizontal</enum>
                 </property>
-                <property name="cursor">
-                 <cursorShape>PointingHandCursor</cursorShape>
-                </property>
                </widget>
               </item>
               <item row="1" column="0">
                <widget class="QSlider" name="playbackVolume">
+                <property name="cursor">
+                 <cursorShape>PointingHandCursor</cursorShape>
+                </property>
                 <property name="maximum">
                  <number>130</number>
                 </property>
@@ -1377,9 +1380,6 @@ media file played</string>
                 </property>
                 <property name="tickInterval">
                  <number>10</number>
-                </property>
-                <property name="cursor">
-                 <cursorShape>PointingHandCursor</cursorShape>
                 </property>
                </widget>
               </item>
@@ -7103,6 +7103,9 @@ media file played</string>
                     <layout class="QHBoxLayout" name="jpgQualityLayout">
                      <item>
                       <widget class="QSlider" name="jpgQuality">
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
                        <property name="maximum">
                         <number>100</number>
                        </property>
@@ -7117,9 +7120,6 @@ media file played</string>
                        </property>
                        <property name="tickInterval">
                         <number>5</number>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
                        </property>
                       </widget>
                      </item>
@@ -7143,6 +7143,9 @@ media file played</string>
                     <layout class="QHBoxLayout" name="jpgSmoothLayout">
                      <item>
                       <widget class="QSlider" name="jpgSmooth">
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
                        <property name="maximum">
                         <number>100</number>
                        </property>
@@ -7154,9 +7157,6 @@ media file played</string>
                        </property>
                        <property name="tickInterval">
                         <number>5</number>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
                        </property>
                       </widget>
                      </item>
@@ -7205,6 +7205,9 @@ media file played</string>
                     <layout class="QHBoxLayout" name="pngCompressionLayout">
                      <item>
                       <widget class="QSlider" name="pngCompression">
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
                        <property name="maximum">
                         <number>9</number>
                        </property>
@@ -7219,9 +7222,6 @@ media file played</string>
                        </property>
                        <property name="tickInterval">
                         <number>1</number>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
                        </property>
                       </widget>
                      </item>
@@ -7245,6 +7245,9 @@ media file played</string>
                     <layout class="QHBoxLayout" name="pngFilterLayout">
                      <item>
                       <widget class="QSlider" name="pngFilter">
+                       <property name="cursor">
+                        <cursorShape>PointingHandCursor</cursorShape>
+                       </property>
                        <property name="maximum">
                         <number>5</number>
                        </property>
@@ -7259,9 +7262,6 @@ media file played</string>
                        </property>
                        <property name="tickInterval">
                         <number>1</number>
-                       </property>
-                       <property name="cursor">
-                        <cursorShape>PointingHandCursor</cursorShape>
                        </property>
                       </widget>
                      </item>
@@ -7892,7 +7892,7 @@ media file played</string>
            <item row="3" column="0">
             <widget class="QGroupBox" name="logUpdateBox">
              <property name="title">
-              <string>Window update interval</string>
+              <string>Update interval</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_7">
               <item>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3604,11 +3604,11 @@ media file played</translation>
     </message>
     <message>
         <source>No delay (consumes cpu)</source>
-        <translation>No delay (consumes cpu)</translation>
+        <translation type="vanished">No delay (consumes cpu)</translation>
     </message>
     <message>
         <source> msec</source>
-        <translation> msec</translation>
+        <translation type="vanished"> msec</translation>
     </message>
     <message>
         <source>Every </source>
@@ -3976,6 +3976,14 @@ media file played</translation>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3600,7 +3600,7 @@ media file played</translation>
     </message>
     <message>
         <source>Window update interval</source>
-        <translation>Window update interval</translation>
+        <translation type="vanished">Window update interval</translation>
     </message>
     <message>
         <source>No delay (consumes cpu)</source>
@@ -3973,6 +3973,10 @@ media file played</translation>
     <message>
         <source>Cinema screen</source>
         <translation>Cinema screen</translation>
+    </message>
+    <message>
+        <source>Update interval</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3563,14 +3563,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,6 +3924,14 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3563,10 +3563,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,6 +3928,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3513,14 +3513,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3878,6 +3870,14 @@ media file played</source>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3513,10 +3513,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3878,6 +3874,10 @@ media file played</source>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3531,10 +3531,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3900,6 +3896,10 @@ media file played</source>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3531,14 +3531,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3900,6 +3892,14 @@ media file played</source>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3519,10 +3519,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3888,6 +3884,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3519,14 +3519,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3888,6 +3880,14 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3583,10 +3583,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3956,6 +3952,10 @@ media file played</source>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3583,14 +3583,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3956,6 +3948,14 @@ media file played</source>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3576,11 +3576,11 @@ media file played</source>
     </message>
     <message>
         <source>No delay (consumes cpu)</source>
-        <translation>Без задержки (загружает процессор)</translation>
+        <translation type="vanished">Без задержки (загружает процессор)</translation>
     </message>
     <message>
         <source> msec</source>
-        <translation> мс</translation>
+        <translation type="vanished"> мс</translation>
     </message>
     <message>
         <source>Every </source>
@@ -3948,6 +3948,14 @@ media file played</source>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3572,7 +3572,7 @@ media file played</source>
     </message>
     <message>
         <source>Window update interval</source>
-        <translation>Интервал обновления окна</translation>
+        <translation type="vanished">Интервал обновления окна</translation>
     </message>
     <message>
         <source>No delay (consumes cpu)</source>
@@ -3944,6 +3944,10 @@ media file played</source>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3517,10 +3517,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Window update interval</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No delay (consumes cpu)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3882,6 +3878,10 @@ media file played</source>
     </message>
     <message>
         <source>Cinema screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update interval</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3517,14 +3517,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>No delay (consumes cpu)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source> msec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Every </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3882,6 +3874,14 @@ media file played</source>
     </message>
     <message>
         <source>Update interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No delay (consumes cpu, use this for testing)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Also flush any pending messages to the log file.  Most users on Windows would not see the pending message dump on stderr, and depend on the file to retrieve the log.  This may make fatal errors reported by qFatal more complete.  However, if the logs are not set to immediate mode and a segfault happens between dumps to disk, messages will still get missed.

Change "Window update interval" to "Update interval" to indicate that it applies across the board.  Change update interval suffix from "msec" to "ms".  Indicate that "No interval" should be used during testing.