### PR TITLE
Flush log messages on segmentation fault

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -50,6 +50,7 @@ int main(int argc, char *argv[])
     #endif
     std::signal(SIGINT, signalHandler);
     std::signal(SIGTERM, signalHandler);
+    std::signal(SIGSEGV, signalHandler);
 
     Flow::earlyPlatformOverride();
 
@@ -101,8 +102,14 @@ int main(int argc, char *argv[])
     return f.run();
 }
 
-void signalHandler(int) {
-    QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
+void signalHandler(int signal) {
+    if (signal == SIGSEGV) {
+        Logger::log("main", "Segmentation fault! Please report this error.");
+        QMetaObject::invokeMethod(Logger::singleton(), "flushMessages", Qt::BlockingQueuedConnection);
+        exit(1);
+    }
+    else
+        QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
 }
 
 //---------------------------------------------------------------------------

--- a/main.h
+++ b/main.h
@@ -22,7 +22,7 @@ class MprisInstance;
 class QLockFile;
 class QThread;
 
-void signalHandler(int);
+void signalHandler(int signal);
 
 // a simple class to control program execution and own application objects
 class Flow : public QObject {


### PR DESCRIPTION
- Handle SIGSEGV to flush log messages
This ensures all messages get written to the log file on segmentation fault.
Idea from #278.