### PR TITLE
Suppress warning about unused event arg

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1202,6 +1202,7 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
 
 void SettingsWindow::closeEvent(QCloseEvent *event)
 {
+    Q_UNUSED(event)
     restoreColorControls();
     restoreAudioSettings();
 }


### PR DESCRIPTION
event->accept() wouldn't do anything as the event is accepted by default.