### PR TITLE
Fix track selection when opening a recent file

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1266,13 +1266,19 @@ void Flow::mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents)
     else
         playbackManager->openFile(track.url);
 
-    // Navigate to a particular position if set and if this is from the favorites menu
+    // Navigate to a particular position if this is from the favorites menu
     // or if this is from the recents menu and not disabled
-    if (track.position > 0 && track.url.isLocalFile() && (!isFromRecents || rememberFilePosition)) {
-        playbackManager->navigateToTime(track.position);
+    if (track.url.isLocalFile() && (!isFromRecents || rememberFilePosition)) {
+        if (track.position > 0)
+            playbackManager->navigateToTime(track.position);
         playbackManager->setVideoTrack(track.videoTrack, true);
         playbackManager->setAudioTrack(track.audioTrack, true);
         playbackManager->setSubtitleTrack(track.subtitleTrack, true);
+    }
+    else {
+        playbackManager->setVideoTrack(-1, true);
+        playbackManager->setAudioTrack(-1, true);
+        playbackManager->setSubtitleTrack(-1, true);
     }
 }
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2018,14 +2018,20 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
 
 void MainWindow::audioTrackSet(int64_t id)
 {
-    if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length())
+    if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length()) {
+        if (id <= 0)
+            id = audioTracksGroup->actions().length();
         audioTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+    }
 }
 
 void MainWindow::videoTrackSet(int64_t id)
 {
-    if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length())
+    if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length()) {
+        if (id <= 0)
+            id = videoTracksGroup->actions().length();
         videoTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+    }
 }
 
 void MainWindow::subtitleTrackSet(int64_t id)

--- a/manager.cpp
+++ b/manager.cpp
@@ -399,30 +399,26 @@ void PlaybackManager::setAudioTrackPreference(QString langs)
 
 void PlaybackManager::setAudioTrack(int64_t id, bool userSelected)
 {
-    if (id > 0) {
-        if (userSelected)
-            audioTrackSelected = id;
+    if (userSelected)
+        audioTrackSelected = id;
+    if (id > 0)
         mpvObject_->setAudioTrack(id);
-    }
 }
 
 void PlaybackManager::setSubtitleTrack(int64_t id, bool userSelected)
 {
-    if (id >= 0) {
-        if (userSelected)
-            subtitleTrackSelected = id;
-        subtitleTrackActive = id;
-        updateSubtitleTrack();
-    }
+    if (userSelected)
+        subtitleTrackSelected = id;
+    subtitleTrackActive = id;
+    updateSubtitleTrack();
 }
 
 void PlaybackManager::setVideoTrack(int64_t id, bool userSelected)
 {
-    if (id > 0) {
-        if (userSelected)
-            videoTrackSelected = id;
+    if (userSelected)
+        videoTrackSelected = id;
+    if (id > 0)
         mpvObject_->setVideoTrack(id);
-    }
 }
 
 void PlaybackManager::setSubtitleEnabled(bool enabled)

--- a/manager.cpp
+++ b/manager.cpp
@@ -589,15 +589,21 @@ void PlaybackManager::selectDesiredTracks()
         if (subtitlesPreferExternal) {
             for (auto it = subtitleListData.constBegin();
                  it != subtitleListData.constEnd(); it++) {
-                if (it.value().isExternal)
+                if (it.value().isExternal) {
+                    Logger::log("manager",
+                                "external subtitle track auto selected: " + QString::number(it.key()));
                     return it.key();
+                }
             }
         }
         if (subtitlesPreferDefaultForced) {
             for (auto it = subtitleListData.constBegin();
                  it != subtitleListData.constEnd(); it++)
-                if (it.value().isForced || it.value().isDefault)
+                if (it.value().isForced || it.value().isDefault) {
+                    Logger::log("manager",
+                                "default/forced subtitle track auto selected: " + QString::number(it.key()));
                     return it.key();
+                }
         }
         return -1;
     };
@@ -610,10 +616,15 @@ void PlaybackManager::selectDesiredTracks()
                 if (it.value().lang == lang) {
                     if (it.value().isForced || it.value().isDefault)
                         lastGoodTrack = it.key();
-                    else
+                    else{
+                        Logger::log("manager",
+                                    "lang track auto selected: " + QString::number(it.key()));
                         return it.key();
+                    }
                 }
         }
+        Logger::log("manager",
+                    "lastGoodTrack track auto selected: " + QString::number(lastGoodTrack));
         return lastGoodTrack;
     };
     int64_t videoId = videoTrackSelected;

--- a/manager.cpp
+++ b/manager.cpp
@@ -588,14 +588,14 @@ void PlaybackManager::selectDesiredTracks()
     auto findSubIdByPreference = [&](void) -> int64_t {
         if (subtitlesPreferExternal) {
             for (auto it = subtitleListData.constBegin();
-                it != subtitleListData.constEnd(); it++) {
+                 it != subtitleListData.constEnd(); it++) {
                 if (it.value().isExternal)
                     return it.key();
             }
         }
         if (subtitlesPreferDefaultForced) {
             for (auto it = subtitleListData.constBegin();
-                it != subtitleListData.constEnd(); it++)
+                 it != subtitleListData.constEnd(); it++)
                 if (it.value().isForced || it.value().isDefault)
                     return it.key();
         }
@@ -606,7 +606,7 @@ void PlaybackManager::selectDesiredTracks()
         int64_t lastGoodTrack = -1;
         for (const QString &lang : langPref) {
             for (auto it = tracks.constBegin();
-                it != tracks.constEnd(); it++)
+                 it != tracks.constEnd(); it++)
                 if (it.value().lang == lang) {
                     if (it.value().isForced || it.value().isDefault)
                         lastGoodTrack = it.key();


### PR DESCRIPTION
- Improve code style in PlaybackManager::selectDesiredTracks
This mostly reverts https://github.com/mpc-qt/mpc-qt/commit/8e20b00514ab0b6292d49bf6e10b831f04385ed7.
- Add logging in PlaybackManager::selectDesiredTracks
- Let selected tracks get reset when opened from recent files
If the current file has subtitle id 2 manually selected and we open a recent file which has no manually selected subtitle (id = -1), it'll end up having subtitle 0 (or 2 if it has at least two) selected, thus bypassing auto track selection.
This applies to audio and video tracks too.

So we let the tracks be set to -1 and add a safety check in MainWindow.
  
Setting the tracks in Flow:mainwindow_recentOpened for recent files when rememberFilePosition is true is probably not needed as they are already set in Flow::manager_startingPlayingFile.
But let's play it safe as this is a bug fix.