### PR TITLE
Save position of current file when playing new one from playlist

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1427,6 +1427,7 @@ void Flow::manager_openingNewFile()
 void Flow::manager_startingPlayingFile(QUrl url)
 {
     if (rememberFilePosition) {
+        updateRecentPosition(false);
         // Check if there's a position saved in recents for this file
         foreach (TrackInfo track, recentFiles) {
             if (track.url == url) {
@@ -1595,7 +1596,7 @@ void Flow::updateRecentPosition(bool resetPosition)
         resetPosition = true;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
                                          videoTrack, audioTrack, subtitleTrack, hasVideo);
-    if (!itemUuid.isNull() && (hasVideo || !rememberHistoryOnlyForVideos))
+    if (!itemUuid.isNull() && url.isLocalFile() && (hasVideo || !rememberHistoryOnlyForVideos))
         updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position,
                       videoTrack, audioTrack, subtitleTrack);
 }


### PR DESCRIPTION
When we start playing a file from a playlist,
PlaybackManager::startPlayWithUuid gets directly triggered, so we need to save the position when that happens.

We need to check if the url isn't empty because it gets reset when we open the same file again from the playlist, so it would add an empty entry in recent files.

We could probably stop calling Flow::updateRecentPosition in Flow::manager_playLengthChanged if we call updateRecentPosition again at the end of Flow::manager_startingPlayingFile, but it'll require more testing to avoid regressions.