### PR TITLE
Fix typo in playbackSubtitleTracks

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1415,7 +1415,7 @@ media file played</string>
               <item row="0" column="1">
                <widget class="QLineEdit" name="playbackSubtitleTracks">
                 <property name="placeholderText">
-                 <string notr="true">enm,eng</string>
+                 <string notr="true">en,eng</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
"enm" means Middle English "a form of the English language spoken after the Norman conquest until the late 15th century".