### PR TITLE
Fix the tray icon

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -304,7 +304,7 @@
     "playerTitleDontPrefix": false,
     "playerTitleFileNameOnly": true,
     "playerTitleReplaceName": true,
-    "playerTrayIcon": false,
+    "playerTrayIcon": true,
     "playlistFormat": "%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}",
     "pngColorspace": false,
     "pngCompression": 7,

--- a/.github/actions/windows/tests/start_with_config_video/action.yml
+++ b/.github/actions/windows/tests/start_with_config_video/action.yml
@@ -5,6 +5,12 @@ runs:
   using: "composite"
 
   steps:
+  - name: Disable Hidden Icons menu in Taskbar
+    run: |
+      reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer" /v "EnableAutoTray" /t REG_DWORD /d 0 /f
+      taskkill /f /im explorer.exe
+      start explorer.exe
+    shell: pwsh
   - name: Create settings dir if needed
     run:  mkdir -p ${{ env.CONFIGDIR }}
     shell: msys2 {0}

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -26,6 +26,8 @@
 #include <QToolTip>
 #include <QScreen>
 #include <QStyle>
+#include <QSvgRenderer>
+#include <QPainter>
 
 using namespace Helpers;
 constexpr char SKIPACTION[] = "Skip";
@@ -626,7 +628,9 @@ void MainWindow::setupTrayIcon()
     trayIcon = new QSystemTrayIcon(this);
     trayIcon->setContextMenu(trayMenu);
     trayIcon->setToolTip(textWindowTitle);
-    trayIcon->setIcon(QIcon(":/images/icon/mpc-qt.svg"));
+    Logger::log("mainwindow", "rendering trayIcon sizes");
+    trayIcon->setIcon(createIconFromSvg(QStringLiteral(":/images/icon/mpc-qt.svg"), 64));
+    Logger::log("mainwindow", "rendering trayIcon sizes done");
 }
 
 void MainWindow::setupActionGroups()
@@ -1260,6 +1264,21 @@ QList<QUrl> MainWindow::doQuickOpenFileDialog()
     if (!urls.isEmpty())
         lastDir = urls[0];
     return urls;
+}
+
+QIcon MainWindow::createIconFromSvg(const QString& svgPath, int maxSize) {
+    QIcon icon;
+    QSvgRenderer svgRenderer(svgPath);
+
+    // Render the SVG at multiple sizes and add to the QIcon
+    for (int size = 16; size <= maxSize; ++size) {
+        QPixmap pixmap(QSize(size, size));
+        pixmap.fill(Qt::transparent); // Ensure transparency
+        QPainter painter(&pixmap);
+        svgRenderer.render(&painter);
+        icon.addPixmap(pixmap);
+    }
+    return icon;
 }
 
 void MainWindow::httpQuickOpenFile()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -112,6 +112,8 @@ private:
     void showOsdTimer(bool onSeek);
     QList<QUrl> doQuickOpenFileDialog();
 
+    QIcon createIconFromSvg(const QString& svgPath, int maxSize);
+
 signals:
     void instanceShouldQuit();
     void fileOpened(QUrl what, QUrl subs);

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -4,7 +4,7 @@
 #
 #-------------------------------------------------
 
-QT       += core gui network widgets openglwidgets
+QT       += core gui network widgets openglwidgets svg
 
 QMAKE_CXXFLAGS += -Wall
 


### PR DESCRIPTION
- Manually render the tray icon
For some reason, the tray icon stays invisible when automatically rendered, so we have to render it manually in most sizes to keep it crisp.
Fixes https://github.com/mpc-qt/mpc-qt/issues/285.
- Enable tray icon in CI tests
It'll make it easier to check it works on Windows.