### PR TITLE
Work around KDE bug to hide cursor on rightmost pixels in fullscreen

### DIFF
--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -641,8 +641,10 @@ void MpvObject::setMpvOptionVariant(QString name, QVariant value)
 
 void MpvObject::showCursor()
 {
-    if (widget)
+    if (widget) {
         widget->self()->setCursor(Qt::ArrowCursor);
+        widget->self()->window()->setCursor(Qt::ArrowCursor);
+    }
 }
 
 void MpvObject::hideCursor()
@@ -652,6 +654,12 @@ void MpvObject::hideCursor()
         if (qApp->platformName().contains("wayland") && !w->window()->isActiveWindow())
             return;
         w->setCursor(Qt::BlankCursor);
+        //REMOVEME: work around KDE Plasma 6.2.4 bug where cursor stays visible in rightmost position
+        auto window = w->window();
+        if (window->isFullScreen() && QCursor::pos().x() == window->geometry().right()) {
+            window->setCursor(Qt::BlankCursor);
+            LogStream("glwidget") << "workaround: hiding cursor on rightmost pixels";
+        }
     }
 }
 


### PR DESCRIPTION
Because of a KDE Plasma 6.2.x bug, the mpvwidget doesn't extend to the rightmost pixels of the window with screen scaling, so we have to hide the cursor in the window too.
This has side effects in windowed mode, so we only do it in fullscreen mode.
Fixes #294.