### PR TITLE
Add a setting to remember panels state and keep last window geometry setting active

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -873,6 +873,8 @@ void Flow::setupFlowConnections()
             this, &Flow::settingswindow_rememberFilePosition);
     connect(settingsWindow, &SettingsWindow::rememberWindowGeometry,
             this, &Flow::settingswindow_rememberWindowGeometry);
+    connect(settingsWindow, &SettingsWindow::rememberPanels,
+            this, &Flow::settingswindow_rememberPanels);
     connect(settingsWindow, &SettingsWindow::mprisIpc,
             this, &Flow::settingswindow_mprisIpc);
     connect(settingsWindow, &SettingsWindow::stylesheetIsFusion,
@@ -1198,16 +1200,16 @@ QVariantMap Flow::favoritesToVMap() const
 
 QVariantMap Flow::windowsToVMap_v2()
 {
-    if (!rememberWindowGeometry)
-        return QVariantMap();
-
     windowManager.clearJson();
-    windowManager.saveDocks(mainWindow->dockHost());
-    windowManager.saveWindow(settingsWindow);
-    windowManager.saveWindow(propertiesWindow);
-    windowManager.saveWindow(logWindow);
-    windowManager.saveWindow(libraryWindow);
-    windowManager.saveAppWindow(mainWindow);
+    if (rememberPanels)
+        windowManager.saveDocks(mainWindow->dockHost());
+    if (rememberWindowGeometry) {
+        windowManager.saveWindow(settingsWindow);
+        windowManager.saveWindow(propertiesWindow);
+        windowManager.saveWindow(logWindow);
+        windowManager.saveWindow(libraryWindow);
+    }
+    windowManager.saveAppWindow(mainWindow, rememberWindowGeometry, rememberPanels);
     return windowManager.json();
 }
 
@@ -1488,6 +1490,12 @@ void Flow::settingswindow_rememberWindowGeometry(bool yes)
 {
     // Remember our preference to process the window geometry when we exit
     this->rememberWindowGeometry = yes;
+}
+
+void Flow::settingswindow_rememberPanels(bool yes)
+{
+    // Remember our preference to save the panels state when we exit
+    this->rememberPanels = yes;
 }
 
 void Flow::settingswindow_keymapData(const QVariantMap &keyMap)

--- a/main.h
+++ b/main.h
@@ -91,6 +91,7 @@ private slots:
     void settingswindow_rememberHistory(bool yes, bool onlyVideos);
     void settingswindow_rememberFilePosition(bool yes);
     void settingswindow_rememberWindowGeometry(bool yes);
+    void settingswindow_rememberPanels(bool yes);
     void settingswindow_keymapData(const QVariantMap &keyMap);
     void settingswindow_mprisIpc(bool enabled);
     void settingswindow_stylesheetIsFusion(bool yes);
@@ -148,6 +149,7 @@ private:
     bool rememberHistoryOnlyForVideos = true;
     bool rememberFilePosition = false;
     bool rememberWindowGeometry = false;
+    bool rememberPanels = false;
     bool nowPlayingDisplayingSubtitles = true;
     bool nowPlayingNoSubtitleTracks = false;
     bool repeatAfter = false;

--- a/platform/windowmanager.cpp
+++ b/platform/windowmanager.cpp
@@ -33,12 +33,18 @@ QVariantMap WindowManager::json()
     return json_;
 }
 
-void WindowManager::saveAppWindow(MainWindow *window)
+void WindowManager::saveAppWindow(MainWindow *window, bool rememberWindowGeometry, bool rememberPanels)
 {
+    QVariantMap geometry;
+    QVariantMap panels;
+    if (rememberWindowGeometry)
+        geometry = Helpers::rectToVmap(QRect(window->geometry().topLeft(),
+                                            window->size()));
+    if (rememberPanels)
+        panels = window->state();
     QVariantMap data = {
-        { keyGeometry, Helpers::rectToVmap(QRect(window->geometry().topLeft(),
-                                            window->size())) },
-        { keyState, window->state() },
+        { keyGeometry, geometry },
+        { keyState, panels },
         { keyMaximized, window->isMaximized() }
     };
     json_.insert(window->objectName(), data);

--- a/platform/windowmanager.h
+++ b/platform/windowmanager.h
@@ -34,7 +34,7 @@ public:
     void setJson(const QVariantMap &json);
     QVariantMap json();
 
-    void saveAppWindow(MainWindow *window);
+    void saveAppWindow(MainWindow *window, bool rememberWindowGeometry, bool rememberPanels);
     void saveDocks(QMainWindow *dockHost);
     void saveWindow(QWidget *window);
 

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -720,6 +720,7 @@ void SettingsWindow::sendSignals()
     emit rememberFilePosition(WIDGET_LOOKUP(ui->playerRememberFilePosition).toBool());
     emit rememberSelectedPlaylist(WIDGET_LOOKUP(ui->playerRememberLastPlaylist).toBool());
     emit rememberWindowGeometry(WIDGET_LOOKUP(ui->playerRememberWindowGeometry).toBool());
+    emit rememberPanels(WIDGET_LOOKUP(ui->playerRememberPanels).toBool());
     emit rememberPanNScan(WIDGET_LOOKUP(ui->playerRememberPanScanZoom).toBool());
 
     emit mprisIpc(WIDGET_LOOKUP(ui->ipcMpris).toBool());
@@ -1098,6 +1099,7 @@ void SettingsWindow::setFreestanding(bool freestanding)
     ui->playerRememberFilePosition->setVisible(yes);
     ui->playerRememberLastPlaylist->setVisible(false /*yes*/);
     ui->playerRememberWindowGeometry->setVisible(yes);
+    ui->playerRememberPanels->setVisible(yes);
     ui->playerRememberPanScanZoom->setVisible(false /*yes*/);
     ui->playerHistoryBox->setEnabled(yes);
     ui->webTcpIpBox->setEnabled(yes);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -373,7 +373,6 @@ void SettingsWindow::disableWindowManagment()
 {
     // Wayland breaks applications
     ui->playerLimitProportions->setDisabled(true);
-    ui->playerRememberWindowGeometry->setDisabled(true);
     ui->playbackAutoCenterWindow->setDisabled(true);
 }
 

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -90,6 +90,7 @@ signals:
     void rememberFilePosition(bool yes);
     void rememberSelectedPlaylist(bool yes);
     void rememberWindowGeometry(bool yes);
+    void rememberPanels(bool yes);
     void rememberPanNScan(bool yes);
 
     void mprisIpc(bool enabled);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -235,6 +235,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="playerRememberPanels">
+                <property name="text">
+                 <string>Remember panels state</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="playerRememberPanScanZoom">
                 <property name="text">
                  <string>Remember last Pan-n-Scan Zoom</string>


### PR DESCRIPTION
- Add a setting to remember panels state
This allows saving the panels state without saving the window geometry setting.
This also always remembers the window maximized state.

In Wayland mode, 4c058600b4e9760e2908081997962282fa5693ed disabled the geometry settings.
This means that these settings can't be changed, but they were still being followed for the panels and maximized state.

Remembering the playlist state still requires the auto zoom to be enabled though, otherwise it's always hidden on start.

- Don't disable "Remember last window geometry" in Wayland mode
This isn't the right culprit for the "part of the window can get hidden when opening video in Wayland mode" bug. Or it isn't anymore.

Fixes #301.