### PR TITLE
Work around bug on Wayland where video doesn't fit window

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1426,6 +1426,10 @@ void Flow::manager_openingNewFile()
 
 void Flow::manager_startingPlayingFile(QUrl url)
 {
+    if (firstFile) {
+        firstFile = false;
+        mainWindow->fixMpvwSize();
+    }
     if (rememberFilePosition) {
         updateRecentPosition(false);
         // Check if there's a position saved in recents for this file

--- a/main.h
+++ b/main.h
@@ -142,6 +142,7 @@ private:
     QStringList customFiles;
 
     static bool settingsDisableWindowManagement;
+    bool firstFile = true;
     bool inhibitScreensaver = false;
     bool manipulateScreensaver = false;
     bool rememberHistory = true;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -316,6 +316,14 @@ void MainWindow::unfreezeWindow()
     frozenWindow = false;
 }
 
+// REMOVEME: work around bug on Wayland where video doesn't fit window
+void MainWindow::fixMpvwSize()
+{
+    QSize size = mpvw->size();
+    mpvw->resize(noVideoSize_);
+    mpvw->resize(size);
+}
+
 void MainWindow::setActionPlayLoopUse()
 {
     ui->actionPlayLoopUse->setChecked(false);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -45,6 +45,7 @@ public:
     QSize desirableSize(bool first_run = false);
     QPoint desirablePosition(QSize &size, bool first_run = false);
     void unfreezeWindow();
+    void fixMpvwSize();
     void setActionPlayLoopUse();
 
 protected:


### PR DESCRIPTION
When playing a video on Wayland in Wayland mode, the video doesn't fit the window (it overflows) until the window is resized, switched to fullscreen or the playlist is shown/hidden.

See #304.