### PR TITLE
Disable auto zoom by default in Wayland mode

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1378,6 +1378,13 @@ void SettingsWindow::on_playbackMouseHideWindowed_toggled(bool checked)
     ui->playbackMouseHideWindowedDuration->setEnabled(checked);
 }
 
+// REMOVEME: Disable auto zoom in Wayland mode as window centering isn't possible yet
+void SettingsWindow::on_tweaksPreferWayland_toggled(bool checked)
+{
+    if (checked && QGuiApplication::platformName() == "wayland")
+        ui->playbackAutoZoom->setChecked(false);
+}
+
 void SettingsWindow::on_tweaksTimeTooltip_toggled(bool checked)
 {
     ui->tweaksTimeTooltipLocation->setEnabled(checked);

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -273,6 +273,8 @@ private slots:
 
     void on_playbackMouseHideWindowed_toggled(bool checked);
 
+    void on_tweaksPreferWayland_toggled(bool checked);
+
     void on_tweaksTimeTooltip_toggled(bool checked);
 
     void on_tweaksOsdFontChkBox_toggled(bool checked);


### PR DESCRIPTION
Workaround to prevent part of the window from getting hidden when getting resized by the auto zoom.
This can happen if the video file is close to the screen resolution as Wayland doesn't allow re-centering a window.

See #304.