### PR TITLE
Enable the seekbar time tooltip by default

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7680,6 +7680,9 @@ media file played</string>
                <property name="text">
                 <string>Show time tooltip:</string>
                </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
             </layout>
@@ -7687,7 +7690,7 @@ media file played</string>
            <item row="9" column="1">
             <widget class="QComboBox" name="tweaksTimeTooltipLocation">
              <property name="enabled">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">


### PR DESCRIPTION
MPC-HC seems to have it enabled by default.

Fixes #315.