### PR TITLE
Support pan and scan

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1989,10 +1989,16 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
         return;
     ui->menuPlayVideo->setEnabled(true);
     videoTracksGroup = new QActionGroup(this);
-    ui->menuPlayVideo->addAction(ui->actionDecreaseVideoAspect);
-    ui->menuPlayVideo->addAction(ui->actionIncreaseVideoAspect);
-    ui->menuPlayVideo->addAction(ui->actionResetVideoAspect);
-    ui->menuPlayVideo->addAction(ui->actionDisableVideoAspect);
+    ui->menuPlayVideo->addMenu(ui->menuPlayVideoAspect);
+    ui->menuPlayVideoAspect->addAction(ui->actionDecreaseVideoAspect);
+    ui->menuPlayVideoAspect->addAction(ui->actionIncreaseVideoAspect);
+    ui->menuPlayVideoAspect->addAction(ui->actionResetVideoAspect);
+    ui->menuPlayVideoAspect->addAction(ui->actionDisableVideoAspect);
+    ui->menuPlayVideo->addMenu(ui->menuPlayVideoPanScan);
+    ui->menuPlayVideoPanScan->addAction(ui->actionDecreasePanScan);
+    ui->menuPlayVideoPanScan->addAction(ui->actionIncreasePanScan);
+    ui->menuPlayVideoPanScan->addAction(ui->actionMinPanScan);
+    ui->menuPlayVideoPanScan->addAction(ui->actionMaxPanScan);
     ui->menuPlayVideo->addSeparator();
     for (const Track &track : tracks) {
         QAction *action = new QAction(this);
@@ -2644,6 +2650,34 @@ void MainWindow::on_actionDisableVideoAspect_toggled(bool checked)
 {
     mpvObject_->disableVideoAspect(checked);
     ui->actionDisableVideoAspect->setChecked(checked);
+}
+
+void MainWindow::on_actionDecreasePanScan_triggered()
+{
+    panScan -= 0.01;
+    if (panScan < 0)
+        panScan = 0;
+    mpvObject_->setPanScan(panScan);
+}
+
+void MainWindow::on_actionIncreasePanScan_triggered()
+{
+    panScan += 0.01;
+    if (panScan > 1)
+        panScan = 1;
+    mpvObject_->setPanScan(panScan);
+}
+
+void MainWindow::on_actionMinPanScan_triggered()
+{
+    panScan = 0;
+    mpvObject_->setPanScan(panScan);
+}
+
+void MainWindow::on_actionMaxPanScan_triggered()
+{
+    panScan = 1;
+    mpvObject_->setPanScan(panScan);
 }
 
 void MainWindow::on_actionViewOntopDefault_toggled(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -343,6 +343,11 @@ private slots:
     void on_actionResetVideoAspect_triggered();
     void on_actionDisableVideoAspect_toggled(bool checked);
 
+    void on_actionDecreasePanScan_triggered();
+    void on_actionIncreasePanScan_triggered();
+    void on_actionMinPanScan_triggered();
+    void on_actionMaxPanScan_triggered();
+
     void on_actionViewOntopDefault_toggled(bool checked);
     void on_actionViewOntopAlways_toggled(bool checked);
     void on_actionViewOntopPlaying_toggled(bool checked);
@@ -474,6 +479,7 @@ private:
     int64_t decoderDrops = 0;
     double audioBitrate = 0;
     double videoBitrate = 0;
+    double panScan = 0;
 
     IconThemer themer;
     QList<QAction *> menuFavoritesTail;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -900,11 +900,25 @@
      <property name="title">
       <string>&amp;Video</string>
      </property>
-     <addaction name="actionDecreaseVideoAspect"/>
-     <addaction name="actionIncreaseVideoAspect"/>
-     <addaction name="actionResetVideoAspect"/>
-     <addaction name="actionDisableVideoAspect"/>
-     <addaction name="separator"/>
+     <widget class="QMenu" name="menuPlayVideoAspect">
+      <property name="title">
+       <string>&amp;Aspect ratio</string>
+      </property>
+      <addaction name="actionDecreaseVideoAspect"/>
+      <addaction name="actionIncreaseVideoAspect"/>
+      <addaction name="actionResetVideoAspect"/>
+      <addaction name="actionDisableVideoAspect"/>
+     </widget>
+     <widget class="QMenu" name="menuPlayVideoPanScan">
+      <property name="title">
+       <string>&amp;Pan and Scan</string>
+      </property>
+      <addaction name="actionDecreasePanScan"/>
+      <addaction name="actionIncreasePanScan"/>
+      <addaction name="actionMinPanScan"/>
+      <addaction name="actionMaxPanScan"/>
+     </widget>
+      <addaction name="separator"/>
     </widget>
     <widget class="QMenu" name="menuPlayVolume">
      <property name="title">
@@ -2164,6 +2178,38 @@
    </property>
    <property name="shortcut">
     <string>9</string>
+   </property>
+  </action>
+  <action name="actionDecreasePanScan">
+   <property name="text">
+    <string>Decrease &amp;Pan and Scan</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">-</string>
+   </property>
+  </action>
+  <action name="actionIncreasePanScan">
+   <property name="text">
+    <string>Increase Pan and &amp;Scan</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">+</string>
+   </property>
+  </action>
+  <action name="actionMinPanScan">
+   <property name="text">
+    <string>&amp;Minimum Pan and Scan</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">/</string>
+   </property>
+  </action>
+  <action name="actionMaxPanScan">
+   <property name="text">
+    <string>M&amp;aximum Pan and Scan</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">*</string>
    </property>
   </action>
   <action name="actionViewHideLog">

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -441,6 +441,11 @@ void MpvObject::disableVideoAspect(bool yes)
     setMpvPropertyVariant("keepaspect", !yes ? "yes" : "no");
 }
 
+void MpvObject::setPanScan(double panScan)
+{
+    setMpvPropertyVariant("panscan", panScan);
+}
+
 int64_t MpvObject::chapter()
 {
     return chapter_;

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -71,6 +71,7 @@ public:
     void setVideoAspect(double aspectDiff);
     void setVideoAspectPreset(double aspect);
     void disableVideoAspect(bool yes);
+    void setPanScan(double panScan);
 
     int64_t chapter();
     bool setChapter(int64_t chapter);

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1388,6 +1388,30 @@
         <source>Title</source>
         <translation>Title</translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1360,6 +1360,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1356,6 +1356,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1360,6 +1360,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1344,6 +1344,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1388,6 +1388,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1368,6 +1368,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1360,6 +1360,30 @@
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Aspect ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decrease &amp;Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase Pan and &amp;Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Minimum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M&amp;aximum Pan and Scan</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
This makes it possible to for example correctly display on a 16:9 screen a 16:9 video made for 4:3 screens with letterbox black bars encoded in the video.
Since there are enough entries, it's also time to move them to submenus.
Fixes #55.