### PR TITLE
Don't set nowPlayingItem in playNextFileUrl

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1428,6 +1428,7 @@ void Flow::manager_openingNewFile()
 
 void Flow::manager_startingPlayingFile(QUrl url)
 {
+    Logger::log("main", "manager_startingPlayingFile");
     if (firstFile) {
         firstFile = false;
         mainWindow->fixMpvwSize();

--- a/manager.cpp
+++ b/manager.cpp
@@ -756,8 +756,8 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta)
     } while (!Helpers::urlSurvivesFilter(url, true));
     emit playingNextFile();
     playlistWindow_->clearPlaylist(nowPlayingList);
-    nowPlayingItem = playlistWindow_->addToPlaylist(nowPlayingList, { url }).item;
-    startPlayWithUuid(url, nowPlayingList, nowPlayingItem, false);
+    QUuid nowPlayingItemLocal = playlistWindow_->addToPlaylist(nowPlayingList, { url }).item;
+    startPlayWithUuid(url, nowPlayingList, nowPlayingItemLocal, false);
     return true;
 }
 


### PR DESCRIPTION
It already gets set in startPlayWithUuid.
Otherwise, when calling updateRecentPosition in manager_startingPlayingFile, the next file gets the position of the current file.

Fixes regression caused by f8c7aab2d405d6e15538aff96d582a783a02fefa
Fixes #332