### PR TITLE
Send the first log message as early as possible

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -45,6 +45,7 @@ constexpr char optConsoleLogEx[] = "--log-to-console";
 
 int main(int argc, char *argv[])
 {
+    Logger::log("main", "starting logging");
     #if !defined(Q_OS_WIN)
     std::signal(SIGHUP, signalHandler);
     #endif
@@ -129,7 +130,6 @@ Flow::Flow(QObject *owner) :
     connect(this, &Flow::flushLog,
             logger, &Logger::flushMessages,
             Qt::BlockingQueuedConnection);
-    Logger::log("main", "starting logging");
 
     readConfig();
     Logger::log("main", "finished reading config");


### PR DESCRIPTION
This makes sure it's the first one.