### PR TITLE
Don't use EGL for Nvidia and log display devices

### DIFF
--- a/main.h
+++ b/main.h
@@ -39,6 +39,7 @@ public:
     int run();
     bool earlyQuit();
     static void earlyPlatformOverride();
+    static bool isNvidiaGPU();
 
 signals:
     void windowsRestored();


### PR DESCRIPTION
EGL tends to cause black window issues with Nvidia drivers.

Fixes #303.