### PR TITLE
Use static build of libmpv and include yt-dlp on msys2

### DIFF
--- a/.github/actions/windows/commands/kill_mpc-qt/action.yml
+++ b/.github/actions/windows/commands/kill_mpc-qt/action.yml
@@ -5,6 +5,9 @@ runs:
   using: "composite"
 
   steps:
+  - name: Wait 15 seconds
+    run:  sleep 15
+    shell: bash
   - name: Kill mpc-qt
     run:  taskkill /im mpc-qt.exe
     shell: pwsh

--- a/.github/actions/windows/commands/run_mpc-qt/action.yml
+++ b/.github/actions/windows/commands/run_mpc-qt/action.yml
@@ -13,8 +13,8 @@ runs:
   - name: Run mpc-qt and open a file if provided
     run: ${{ env.EXEDIR }}mpc-qt.exe ${{ inputs.filename }} &
     shell: msys2 {0}
-  - name: wait 3 seconds
-    run:  sleep 3
+  - name: wait 5 seconds
+    run:  sleep 5
     shell: bash
   - name: check that mpc-qt is running
     uses: ./.github/actions/windows/commands/check_if_running

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -28,10 +28,27 @@ jobs:
           mingw-w64-x86_64-qt-creator
           mingw-w64-x86_64-imagemagick
           mingw-w64-x86_64-boost
-          mingw-w64-x86_64-mpv
     - name: Avoid line ending issues on Windows
       run: git config --global core.autocrlf input
     - uses: actions/checkout@v4
+    - name: Download static build of libmpv
+      uses: robinraju/release-downloader@v1
+      with:
+        repository: "shinchiro/mpv-winbuild-cmake"
+        latest: true
+        fileName: "mpv-dev-x86_64-????????-git-*.7z"
+    - name: Download yt-dlp
+      uses: robinraju/release-downloader@v1
+      with:
+        repository: "yt-dlp/yt-dlp"
+        latest: true
+        fileName: "yt-dlp.exe"
+    - name: Extract mpv
+      run: |
+        7z x mpv-dev-x86_64-*.7z -ompv-dev
+        mv mpv-dev/libmpv* mpv-dev/lib
+    - name: Set version
+      run: echo "FORCE_VERSION=$( cat .github/actions/data/VERSION )" >> $GITHUB_ENV
     - name: Build
       run: |
         chmod +x *.sh
@@ -39,7 +56,7 @@ jobs:
         ln -s lrelease-qt6.exe /mingw64/bin/lrelease.exe
         ln -s lupdate-qt6.exe /mingw64/bin/lupdate.exe
         bash make-win-icon.sh
-        bash make-release-msys2.sh          
+        bash make-release-msys2.sh
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -23,7 +23,6 @@ jobs:
         update: true
         install: >-
           coreutils
-          mingw-w64-x86_64-mpv
 
     - name: Get mpc-qt dir
       run: |


### PR DESCRIPTION
This should make it possible to use the mpc-qt build for releases.

mpc-qt takes longer to start with a static build of libmpv, so we have to wait longer in the tests.