### PR TITLE
Use Ubuntu 22.04 for the AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build with PPA
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install packages
       run: |
@@ -22,7 +22,7 @@ jobs:
         sudo apt upgrade
         sudo apt dist-upgrade
         sudo apt install qmake6 qt6-base-dev qt6-l10n-tools libqt6svg6-dev
-        sudo apt install devscripts equivs git
+        sudo apt install devscripts equivs git libunwind-dev
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Checkout mpv repository


### PR DESCRIPTION
GitHub is removing Ubuntu 20.04 from available CI runner images by April 1, 2025. Ubuntu 20.04 general support (other than security updates) ends on 2025-05-29 anyway.

Fixes #359.