### PR TITLE
Detect the icons theme

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -132,7 +132,7 @@
     "hwdecWmv3": true,
     "interfaceIconsCustomFolder": "",
     "interfaceIconsInbuilt": 0,
-    "interfaceIconsTheme": 2,
+    "interfaceIconsTheme": 0,
     "interfaceWidgetCustom": false,
     "interfaceWidgetCustomPalette": [
         [

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -17,6 +17,7 @@
 #include "helpers.h"
 #include "platform/unify.h"
 
+const char autoIcons[] = "auto";
 const char blackIconsPath[] = ":/images/theme/black/";
 const char whiteIconsPath[] = ":/images/theme/white/";
 
@@ -690,7 +691,15 @@ void IconThemer::setIconFolders(FolderMode folderMode,
                                 const QString &customFolder)
 {
     folderMode_ = folderMode;
-    fallbackFolder_ = fallbackFolder;
+    if (fallbackFolder == autoIcons) {
+        // FIXME: with Qt 6.5, use QGuiApplication::styleHints()->colorScheme()
+        const QPalette defaultPalette;
+        const auto text = defaultPalette.color(QPalette::WindowText);
+        const auto window = defaultPalette.color(QPalette::Window);
+        fallbackFolder_ = text.lightness() > window.lightness() ? whiteIconsPath : blackIconsPath;
+    }
+    else
+        fallbackFolder_ = fallbackFolder;
     customFolder_ = customFolder;
     for (const IconData &data : std::as_const(iconDataList))
         updateButton(data);

--- a/helpers.h
+++ b/helpers.h
@@ -13,6 +13,7 @@
 #include <QTime>
 #include <QDir>
 
+extern const char autoIcons[];
 extern const char blackIconsPath[];
 extern const char whiteIconsPath[];
 

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -131,7 +131,8 @@ static QMap<QString,FilterKernel> filterKernels {
 
 
 QHash<QString, QStringList> SettingMap::indexedValueToText = {
-    {"interfaceIconsInbuilt", { blackIconsPath, \
+    {"interfaceIconsInbuilt", { autoIcons, \
+                                blackIconsPath, \
                                 whiteIconsPath }},
     {"videoFramebuffer", {"rgb8-rgba8", "rgb10-rgb10_a2", "rgba12-rgba12",\
                           "rgb16-rgba16", "rgb16f-rgba16f",\

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -722,6 +722,11 @@ media file played</string>
                 </property>
                 <item>
                  <property name="text">
+                  <string>Auto</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
                   <string>Black (for white palette)</string>
                  </property>
                 </item>


### PR DESCRIPTION
This should ensure the icons theme (black/white) matches by default the window theme.
Once we switch to Qt 6.5, the detection can be done with the Qt colorScheme() function.
Suggested in #309.

Tested on Windows, it works fine with both light and dark Windows applications themes.