### PR TITLE
Always use the built-in icons

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -416,10 +416,6 @@ void SettingsWindow::setupPlatformWidgets()
         ui->playbackAutozoomWarn->setVisible(false);
     }
 
-    if (Platform::isUnix) {
-        ui->interfaceIconsTheme->setCurrentIndex(2);
-    }
-
     ui->ipcMpris->setVisible(Platform::isUnix);
     ui->hwdecBackendVaapi->setEnabled(Platform::isUnix);
     ui->hwdecBackendNvdec->setEnabled(Platform::isWindows || Platform::isUnix);


### PR DESCRIPTION
The system icons theme isn't always quite right.
The built-in icons are probably good enough now to be at least as good in most cases.
Suggested in #309.