### PR TITLE
Enable Fusion Qt style by default on Windows for dark theme support

### DIFF
--- a/.github/actions/windows/tests/start/action.yml
+++ b/.github/actions/windows/tests/start/action.yml
@@ -5,6 +5,10 @@ runs:
   using: "composite"
 
   steps:
+  - name: Enable dark theme for apps
+    run: |
+      reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" /v "AppsUseLightTheme" /t REG_DWORD /d 0 /f
+    shell: pwsh
   - name: Run mpc-qt
     uses: ./.github/actions/windows/commands/run_mpc-qt
   - name: Take a screenshot

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -417,6 +417,7 @@ void SettingsWindow::setupPlatformWidgets()
         ui->playbackAutozoomWarn->setVisible(false);
     }
 
+    ui->stylesheetFusion->setChecked(Platform::isWindows);
     ui->ipcMpris->setVisible(Platform::isUnix);
     ui->hwdecBackendVaapi->setEnabled(Platform::isUnix);
     ui->hwdecBackendNvdec->setEnabled(Platform::isWindows || Platform::isUnix);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -886,6 +886,9 @@ media file played</string>
           <layout class="QVBoxLayout" name="verticalLayout_15">
            <item>
             <widget class="QCheckBox" name="stylesheetFusion">
+             <property name="toolTip">
+              <string>Allows dark theme support on Windows</string>
+             </property>
              <property name="text">
               <string>Use Qt's inbuilt fusion style</string>
              </property>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4022,6 +4022,10 @@ arxiu multimèdia reproduït</translation>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>Arxius de perfil ICC (*.icc *.icm)</translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4022,6 +4022,10 @@ media file played</translation>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC profile files (*.icc *.icm)</translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3970,6 +3970,10 @@ archivo multimedia reproducido</translation>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3916,6 +3916,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3938,6 +3938,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3926,6 +3926,10 @@ ogni file multimediale riprodotto</translation>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4022,6 +4022,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC プロファイル (*.icc *.icm)</translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3994,6 +3994,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2791,19 +2791,19 @@ media file played</source>
     </message>
     <message>
         <source>BT.601-525</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {601-525?}</translation>
     </message>
     <message>
         <source>BT.601-625</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {601-625?}</translation>
     </message>
     <message>
         <source>BT.709</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {709?}</translation>
     </message>
     <message>
         <source>BT.2020</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {2020?}</translation>
     </message>
     <message>
         <source>Apple</source>
@@ -2831,7 +2831,7 @@ media file played</source>
     </message>
     <message>
         <source>BT.1886</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {1886?}</translation>
     </message>
     <message>
         <source>sRGB</source>
@@ -3856,7 +3856,7 @@ media file played</source>
     </message>
     <message>
         <source>BT.470M</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">BT.470m {470M?}</translation>
     </message>
     <message>
         <source>V-Gamut</source>
@@ -4016,6 +4016,10 @@ media file played</source>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3994,6 +3994,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4022,6 +4022,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ஐ.சி.சி சுயவிவரக் கோப்புகள் ( *.icc *.icm)</translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4020,6 +4020,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3920,6 +3920,10 @@ media file played</source>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC 配置文件 (*.icc *.icm)</translation>
     </message>
+    <message>
+        <source>Allows dark theme support on Windows</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
QApplication::setPalette() doesn't respect Windows's dark theme.
QApplication::setStyle(), which is used when Fusion is enabled, does.

Fixes #95.