### PR TITLE
Trigger dev-builds action after appimage

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,3 +38,16 @@ jobs:
     name: Flatpak
     needs: tests
     uses: ./.github/workflows/flatpak.yml
+
+  pre-release:
+    name: Pre-release
+    if: github.ref_name == 'master'
+    runs-on: ubuntu-latest
+    needs: [appimage, flatpak]
+    env:
+      GH_TOKEN: ${{ secrets.API_TOKEN_GITHUB_DEV_BUILDS }}
+
+    steps:
+    - name: Trigger dev-builds release workflow
+      run: |
+        gh workflow run --repo mpc-qt/dev-builds "Release maker"


### PR DESCRIPTION
This makes the dev-builds repository action download the artifacts from the latest commit to the master branch of mpc-qt. Thus allowing us to provide links to download test builds.