### PR TITLE
Re-add the appstream file and update it

### DIFF
--- a/io.github.mpc_qt.Mpc-Qt.appdata.xml
+++ b/io.github.mpc_qt.Mpc-Qt.appdata.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
- <id>io.github.mpc_qt.Mpc-Qt</id>
+ <id>io.github.mpc_qt.mpc-qt</id>
  <metadata_license>CC0-1.0</metadata_license>
  <project_license>GPL-2.0+</project_license>
  <name>Media Player Classic Qute Theater</name>
  <summary>A clone of Media Player Classic reimplemented in Qt.</summary>
- <launchable type="desktop-id">io.github.mpc_qt.Mpc-Qt.desktop</launchable>
+ <launchable type="desktop-id">io.github.mpc-qt.mpc-qt.desktop</launchable>
  <content_rating type="oars-1.1" />
+ <developer id="io.github.mpc-qt">
+  <name>The MPC-QT developers</name>
+ </developer>
  <description>
   <p>
-   Media Player Classic Qute Theater (Mpc-Qt) is a cross-platform application that uses Qt to reproduce most of the interface and functionality of Media Player Classic Home Cinema (Mpc-Hc), and uses libmpv's powerful media presentation framework to play video instead of DirectShow. It is not a strict clone; there are some improvements.
+   Media Player Classic Qute Theater (MPC-QT) is a cross-platform application that uses Qt to reproduce most of the interface and functionality of Media Player Classic Home Cinema (MPC-HC), and uses libmpv's powerful media presentation framework to play video instead of DirectShow. It is not a strict clone; there are some improvements.
   </p>
   <p>Features:</p>
   <ul>
@@ -17,13 +20,13 @@
    <li>Multiple playlists</li>
    <li>Quick queueing like xmms/qmmp</li>
    <li>Mpris - multimedia keys support</li>
-   <li>Web interface like Mpc-Hc's</li>
-   <li>Flatpak: Filesystem access for writing screenshots</li>
+   <li>Web interface like MPC-HC's</li>
+   <li>Screenshot templates</li>
   </ul>
  </description>
  <screenshots>
   <screenshot type="default">
-   <image>https://mpc-qt.github.io/images/Screenshot_20220226_155532.png</image>
+   <image>https://mpc-qt.github.io/images/Screenshot_20241109_190909.png</image>
    <caption>The main window showing the application in action</caption>
   </screenshot>
  </screenshots>

--- a/io.github.mpc_qt.Mpc-Qt.appdata.xml
+++ b/io.github.mpc_qt.Mpc-Qt.appdata.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+ <id>io.github.mpc_qt.Mpc-Qt</id>
+ <metadata_license>CC0-1.0</metadata_license>
+ <project_license>GPL-2.0+</project_license>
+ <name>Media Player Classic Qute Theater</name>
+ <summary>A clone of Media Player Classic reimplemented in Qt.</summary>
+ <launchable type="desktop-id">io.github.mpc_qt.Mpc-Qt.desktop</launchable>
+ <content_rating type="oars-1.1" />
+ <description>
+  <p>
+   Media Player Classic Qute Theater (Mpc-Qt) is a cross-platform application that uses Qt to reproduce most of the interface and functionality of Media Player Classic Home Cinema (Mpc-Hc), and uses libmpv's powerful media presentation framework to play video instead of DirectShow. It is not a strict clone; there are some improvements.
+  </p>
+  <p>Features:</p>
+  <ul>
+   <li>libmpv backend</li>
+   <li>Multiple playlists</li>
+   <li>Quick queueing like xmms/qmmp</li>
+   <li>Mpris - multimedia keys support</li>
+   <li>Web interface like Mpc-Hc's</li>
+   <li>Flatpak: Filesystem access for writing screenshots</li>
+  </ul>
+ </description>
+ <screenshots>
+  <screenshot type="default">
+   <image>https://mpc-qt.github.io/images/Screenshot_20220226_155532.png</image>
+   <caption>The main window showing the application in action</caption>
+  </screenshot>
+ </screenshots>
+ <url type="homepage">https://mpc-qt.github.io/</url>
+ <url type="bugtracker">https://github.com/mpc-qt/mpc-qt/issues</url>
+</component>

--- a/mpc-qt.pro
+++ b/mpc-qt.pro
@@ -113,10 +113,13 @@ unix {
     shortcut.files = io.github.mpc-qt.mpc-qt.desktop
     shortcut.path = $$PREFIX/share/applications/
 
+    appdata.files = io.github.mpc_qt.Mpc-Qt.appdata.xml
+    appdata.path = $$PREFIX/share/metainfo/
+
     logo.files = images/icon/mpc-qt.svg
     logo.path = $$PREFIX/share/icons/hicolor/scalable/apps/
 
-    INSTALLS += target docs shortcut logo
+    INSTALLS += target docs shortcut logo appdata
 }
 
 unix:SOURCES += platform/screensaver_unix.cpp \
@@ -223,6 +226,7 @@ OTHER_FILES += \
     DOCS/codebase2.svg \
     DOCS/codebase.svg \
     'DOCS/coding standards.md' \
+    io.github.mpc_qt.Mpc-Qt.appdata.xml \
     lconvert.pri
 
 DISTFILES += \


### PR DESCRIPTION
The appstream file is used by package managers to show information about and screenshots of an application.
Flathub also requires one.
#31