### PR TITLE
Re-raise segmentation fault signal instead of exiting with error

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -108,7 +108,8 @@ void signalHandler(int signal) {
     if (signal == SIGSEGV) {
         Logger::log("main", "Segmentation fault! Please report this error.");
         QMetaObject::invokeMethod(Logger::singleton(), "flushMessages", Qt::BlockingQueuedConnection);
-        exit(1);
+        std::signal(SIGSEGV, SIG_DFL);
+        std::raise(SIGSEGV);
     }
     else
         QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);


### PR DESCRIPTION
This allows the system or a debugger to notice the crash and capture a core dump or the stack trace.
Follow-up to 132e145b1ddfacdd97b50122e54b7565d9aa8fbe.