### PR TITLE
Add a translation test to CI tests

### DIFF
--- a/.github/actions/linux/commands/run_mpc-qt/action.yml
+++ b/.github/actions/linux/commands/run_mpc-qt/action.yml
@@ -6,12 +6,25 @@ inputs:
     description: "File to open with mpc-qt"
     required: false
     default: ""
+  locale:
+    description: "Locale to use"
+    required: false
+    default: "en_US.UTF-8"
 runs:
   using: "composite"
 
   steps:
   - name: Run mpc-qt and open a file if provided
     run:  |
+        : Set the locale to ${{ inputs.locale }}
+        sudo apt-get update
+        sudo apt-get install -y locales
+        sudo locale-gen ${{ inputs.locale }}
+        sudo update-locale LANG=${{ inputs.locale }}
+        export LANG=${{ inputs.locale }}
+        export LANGUAGE=${{ inputs.locale }}
+        export LC_ALL=${{ inputs.locale }}
+        locale
         : Run mpc-qt
         chmod +x mpc-qt/mpc-qt
         export DISPLAY=:99

--- a/.github/actions/linux/commands/screenshot/action.yml
+++ b/.github/actions/linux/commands/screenshot/action.yml
@@ -6,10 +6,14 @@ inputs:
     description: "Screenshot number to add to the filename"
     required: true
     default: ""
+  description:
+    description: "Screenshot description to add to the filename"
+    required: true
+    default: ""
 runs:
   using: "composite"
 
   steps:
   - name: Take a screenshot
-    run: xwd -display :99 -root -silent | convert xwd:- png:screenshot${{ inputs.number }}.png
+    run: xwd -display :99 -root -silent | convert xwd:- png:screenshot${{ inputs.number }}_${{ inputs.description }}.png
     shell: bash

--- a/.github/actions/linux/tests/start/action.yml
+++ b/.github/actions/linux/tests/start/action.yml
@@ -11,6 +11,7 @@ runs:
     uses: ./.github/actions/linux/commands/screenshot
     with:
       number: "1"
+      description: "no_config"
   - name: Kill mpc-q
     uses: ./.github/actions/linux/commands/kill_mpc-qt
   - name: ls ~/.config/mpc-qt/

--- a/.github/actions/linux/tests/start_with_config/action.yml
+++ b/.github/actions/linux/tests/start_with_config/action.yml
@@ -16,6 +16,7 @@ runs:
     uses: ./.github/actions/linux/commands/screenshot
     with:
       number: "2"
+      description: "config_and_translation"
   - name: Kill mpc-q
     uses: ./.github/actions/linux/commands/kill_mpc-qt
   - name: ls ~/.config/mpc-qt/

--- a/.github/actions/linux/tests/start_with_config/action.yml
+++ b/.github/actions/linux/tests/start_with_config/action.yml
@@ -10,6 +10,8 @@ runs:
     shell: bash
   - name: Run mpc-qt
     uses: ./.github/actions/linux/commands/run_mpc-qt
+    with:
+      locale: "es_ES.UTF-8"
   - name: Take a screenshot
     uses: ./.github/actions/linux/commands/screenshot
     with:

--- a/.github/actions/linux/tests/start_with_config_video/action.yml
+++ b/.github/actions/linux/tests/start_with_config_video/action.yml
@@ -16,6 +16,7 @@ runs:
     uses: ./.github/actions/linux/commands/screenshot
     with:
       number: "3"
+      description: "config_and_video"
   - name: Kill mpc-q
     uses: ./.github/actions/linux/commands/kill_mpc-qt
   - name: ls ~/.config/mpc-qt/

--- a/.github/actions/windows/commands/screenshot/action.yml
+++ b/.github/actions/windows/commands/screenshot/action.yml
@@ -14,6 +14,9 @@ runs:
   using: "composite"
 
   steps:
+    - name: Wait 5 seconds
+      run:  sleep 5
+      shell: bash
     - name: Take a screenshot with PowerShell
       run: |
           Add-Type -AssemblyName System.Windows.Forms

--- a/.github/actions/windows/commands/screenshot/action.yml
+++ b/.github/actions/windows/commands/screenshot/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Screenshot number to add to the filename"
     required: true
     default: ""
+  description:
+    description: "Screenshot description to add to the filename"
+    required: true
+    default: ""
 runs:
   using: "composite"
 
@@ -18,5 +22,5 @@ runs:
              [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height)
           $graphics = [System.Drawing.Graphics]::FromImage($bmp)
           $graphics.CopyFromScreen([System.Drawing.Point]::Empty, [System.Drawing.Point]::Empty, $bmp.Size)
-          $bmp.Save('screenshot${{ inputs.number }}.png')
+          $bmp.Save('screenshot${{ inputs.number }}_${{ inputs.description }}.png')
       shell: pwsh

--- a/.github/actions/windows/tests/start/action.yml
+++ b/.github/actions/windows/tests/start/action.yml
@@ -15,6 +15,7 @@ runs:
     uses: ./.github/actions/windows/commands/screenshot
     with:
       number: "1"
+      description: "no_config_dark_theme"
   - name: Kill mpc-q
     uses: ./.github/actions/windows/commands/kill_mpc-qt
   - name: Check mpc-qt config dir

--- a/.github/actions/windows/tests/start_with_config_video/action.yml
+++ b/.github/actions/windows/tests/start_with_config_video/action.yml
@@ -36,6 +36,7 @@ runs:
     uses: ./.github/actions/windows/commands/screenshot
     with:
       number: "2"
+      description: "config_video_and_translation"
   - name: Kill mpc-q
     uses: ./.github/actions/windows/commands/kill_mpc-qt
   - name: Check mpc-qt config dir

--- a/.github/actions/windows/tests/start_with_config_video/action.yml
+++ b/.github/actions/windows/tests/start_with_config_video/action.yml
@@ -11,6 +11,17 @@ runs:
       taskkill /f /im explorer.exe
       start explorer.exe
     shell: pwsh
+  - name: Set Environment Variables for translation test
+    shell: msys2 {0}
+    run: |
+      echo "LANG=es_ES.UTF-8" >> $GITHUB_ENV
+      echo "LC_ALL=es_ES.UTF-8" >> $GITHUB_ENV
+  - name: Verify Locale Settings
+    shell: msys2 {0}
+    run: |
+      echo "Current LANG: $LANG"
+      echo "Current LC_ALL: $LC_ALL"
+      locale
   - name: Create settings dir if needed
     run:  mkdir -p ${{ env.CONFIGDIR }}
     shell: msys2 {0}


### PR DESCRIPTION
* Add a translation test to CI tests
This allows checking that translations work in the CI screenshots.
* Use descriptive names for CI tests screenshots
* Wait before taking screenshot in Windows CI
The delay ensures that mpc-qt is running before the screenshot.

These make it easier to check that translations still work with the CMake builds.