### PR TITLE
Position current item of playlist at center of viewport

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1124,9 +1124,11 @@ void Flow::setupMpcHc()
     connect(playbackManager, &PlaybackManager::titleChanged,
             mpcHcServer, &MpcHcServer::setMediaTitle);
     connect(playbackManager, &PlaybackManager::nowPlayingChanged,
-            mpcHcServer, [this](QUrl itemUrl, QUuid listUuid, QUuid itemUuid) {
+            mpcHcServer, [this](QUrl itemUrl, QUuid listUuid, QUuid itemUuid,
+                                              bool clickedInPlaylist) {
             Q_UNUSED(listUuid);
             Q_UNUSED(itemUuid);
+            Q_UNUSED(clickedInPlaylist);
             mpcHcServer->setNowPlaying(itemUrl); });
     connect(playbackManager, &PlaybackManager::playbackSpeedChanged,
             mpcHcServer, &MpcHcServer::setPlaybackRate);

--- a/manager.cpp
+++ b/manager.cpp
@@ -186,10 +186,10 @@ void PlaybackManager::playStream(QUrl stream)
     startPlayWithUuid(urlToPlay, playlistItem.list, playlistItem.item, false);
 }
 
-void PlaybackManager::playItem(QUuid playlist, QUuid item)
+void PlaybackManager::playItem(QUuid playlist, QUuid item, bool clickedInPlaylist)
 {
     auto url = playlistWindow_->getUrlOf(playlist, item);
-    startPlayWithUuid(url, playlist, item, false);
+    startPlayWithUuid(url, playlist, item, false, QUrl(), clickedInPlaylist);
 }
 
 void PlaybackManager::playDevice(QUrl device)
@@ -547,7 +547,7 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
 
 void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
                                         QUuid itemUuid, bool isRepeating,
-                                        QUrl with)
+                                        QUrl with, bool clickedInPlaylist)
 {
     Logger::log("manager", "startPlayWithUuid");
     if (playbackState_ == WaitingState || what.isEmpty())
@@ -575,7 +575,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
         // configured in the settings dialog.
         playlistWindow_->setExtraPlayTimes(playlistUuid, itemUuid, playbackPlayTimes - 1);
     }
-    emit nowPlayingChanged(nowPlaying_, nowPlayingList, nowPlayingItem);
+    emit nowPlayingChanged(nowPlaying_, nowPlayingList, nowPlayingItem, clickedInPlaylist);
 }
 
 void PlaybackManager::selectDesiredTracks()

--- a/manager.h
+++ b/manager.h
@@ -73,7 +73,7 @@ signals:
     void hasNoAudio(bool empty);
     void hasNoSubtitles(bool empty);
     void subtitlesVisible(bool visible);
-    void nowPlayingChanged(QUrl itemUrl, QUuid listUuid, QUuid itemUuid);
+    void nowPlayingChanged(QUrl itemUrl, QUuid listUuid, QUuid itemUuid, bool clickedInPlaylist = false);
     void finishedPlaying(QUuid item);
     void afterPlaybackReset();
     void instanceShouldClose();
@@ -101,7 +101,7 @@ public slots:
 
     void playDiscFiles(QUrl where);             // from dvd/bd open
     void playStream(QUrl stream);               // from menu
-    void playItem(QUuid playlist, QUuid item);  // called by playlistwindow
+    void playItem(QUuid playlist, QUuid item, bool clickedInPlaylist = false);  // called by playlistwindow
     void playDevice(QUrl device);   // I don't have a device to test this
 
     void loadSubtitle(QUrl with);
@@ -166,7 +166,7 @@ public slots:
 private:
     enum AspectNameChanged { OnOpen, OnFirstPlay, Manually };
     void startPlayWithUuid(QUrl what, QUuid playlistUuid, QUuid itemUuid,
-                           bool isRepeating, QUrl with = QUrl());
+                           bool isRepeating, QUrl with = QUrl(), bool clickedInPlaylist = false);
     void selectDesiredTracks();
     void updateSubtitleTrack();
     void updateChapters();

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -69,7 +69,7 @@ signals:
     void windowDocked();
     void viewActionChanged(bool visible);
     void currentPlaylistHasItems(bool yes);
-    void itemDesired(QUuid playlistUuid, QUuid itemUuid);
+    void itemDesired(QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist);
     void importPlaylist(QString fname);
     void exportPlaylist(QString fname, QStringList items);
     void quickQueueMode(bool yes);
@@ -83,8 +83,8 @@ public slots:
     void setIconTheme(IconThemer::FolderMode folderMode, const QString &fallbackFolder, const QString &customFolder);
     void setHideFullscreen(bool hidden);
 
-    bool activateItem(QUuid playlistUuid, QUuid itemUuid);
-    void changePlaylistSelection(QUrl itemUrl, QUuid playlistUuid, QUuid itemUuid);
+    bool activateItem(QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist = false);
+    void changePlaylistSelection(QUrl itemUrl, QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist);
     void addSimplePlaylist(QStringList data);
     void addPlaylistByUuid(QUuid playlistUuid);
     void setDisplayFormatSpecifier(QString fmt);

--- a/widgets/drawnplaylist.cpp
+++ b/widgets/drawnplaylist.cpp
@@ -180,17 +180,22 @@ void DrawnPlaylist::setCurrentItem(QUuid itemUuid)
     QList<QListWidgetItem *> items = findItems(itemUuid.toString(), Qt::MatchExactly);
     if (items.isEmpty())
         setCurrentRow(-1);
-    else
+    else {
+        scrollToItem(itemUuid, false);
         QListWidget::setCurrentItem(items.first());
+    }
 }
 
-void DrawnPlaylist::scrollToItem(QUuid itemUuid)
+void DrawnPlaylist::scrollToItem(QUuid itemUuid, bool clickedInPlaylist)
 {
     auto items = findItems(itemUuid.toString(), Qt::MatchExactly);
     if (items.empty())
         return;
     auto item = items.first();
-    scrollTo(indexFromItem(item));
+    if (clickedInPlaylist)
+        scrollTo(indexFromItem(item), QAbstractItemView::EnsureVisible);
+    else
+        scrollTo(indexFromItem(item), QAbstractItemView::PositionAtCenter);
 }
 
 void DrawnPlaylist::setUuid(const QUuid &playlistUuid)
@@ -396,7 +401,7 @@ void DrawnPlaylist::self_currentItemChanged(QListWidgetItem *current,
 void DrawnPlaylist::self_itemDoubleClicked(QListWidgetItem *item)
 {
     PlayItem *playItem = reinterpret_cast<PlayItem*>(item);
-    emit itemDesired(playItem->playlistUuid(), playItem->uuid());
+    emit itemDesiredByDoubleClick(playItem->playlistUuid(), playItem->uuid());
 }
 
 void DrawnPlaylist::self_customContextMenuRequested(const QPoint &p)

--- a/widgets/drawnplaylist.h
+++ b/widgets/drawnplaylist.h
@@ -51,7 +51,7 @@ public:
     QList<QUuid> currentItemUuids() const;
     void traverseSelected(std::function<void(QUuid)> callback);
     void setCurrentItem(QUuid itemUuid);
-    void scrollToItem(QUuid itemUuid);
+    void scrollToItem(QUuid itemUuid, bool clickedInPlaylist);
     virtual void addItem(QUuid itemUuid);
     void addItems(const QList<QUuid> &items);
     void addItemsAfter(QUuid item, const QList<QUuid> &items);
@@ -94,9 +94,7 @@ private:
     QStringList currentFilterList;
 
 signals:
-    // for lack of a better term that doesn't conflict with what we already
-    // have, when an item is made hot by double clicking.
-    void itemDesired(QUuid playlistUuid, QUuid itemUuid);
+    void itemDesiredByDoubleClick(QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist = true);
     void searcher_filterPlaylist(QSharedPointer<Playlist>, QString text);
     void menuOpenItem(QUuid playlistUuid, QUuid itemUuid);
 


### PR DESCRIPTION
This allows seeing the items that come next.
The old behavior (just keeping the current item visible) is preserved when the new playing item is started by a double click on it or the context menu.