### PR TITLE
Implement window resize in minimal and compact modes

### DIFF
--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -270,6 +270,7 @@ private:
     bool drawLogo = true;
     int glWidth = 0, glHeight = 0;
     bool windowDragging = false;
+    int resizeEdge = 0;
     QPointF mousePressPosition;
 };
 


### PR DESCRIPTION
It's also enabled in normal mode, as it makes it easier to resize the window.
It works in X11, Wayland and Windows, but not in the Flatpak version (which may require a manual resize instead of using the Qt startSystemMove() method).
Fixes #385.