### PR TITLE
Fix playlist hidden on start

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -390,6 +390,7 @@ void MainWindow::closeEvent(QCloseEvent *event)
     bool showPlaylist = ui->actionViewHidePlaylist->isChecked();
     playlistWindow_->close();
     ui->actionViewHidePlaylist->setChecked(showPlaylist);
+    mainwindowIsClosing = true;
     event->accept();
     emit instanceShouldQuit();
 }
@@ -2185,9 +2186,7 @@ void MainWindow::libraryWindowClosed()
 }
 
 void MainWindow::setPlaylistVisibleState(bool yes) {
-    if (fullscreenMode_)
-        return;
-    if (!ui)
+    if (fullscreenMode_ || !ui || mainwindowIsClosing)
         return;
     ui->actionFileOpenQuick->setText(yes ? tr("&Quick Add To Playlist")
                                          : tr("&Quick Open File"));

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2186,6 +2186,7 @@ void MainWindow::libraryWindowClosed()
 }
 
 void MainWindow::setPlaylistVisibleState(bool yes) {
+    Logger::log("mainwindow", "setPlaylistVisibleState");
     if (fullscreenMode_ || !ui || mainwindowIsClosing)
         return;
     ui->actionFileOpenQuick->setText(yes ? tr("&Quick Add To Playlist")
@@ -2397,16 +2398,15 @@ void MainWindow::on_actionViewHideSubresync_toggled(bool checked)
 
 void MainWindow::on_actionViewHidePlaylist_toggled(bool checked)
 {
+    Logger::log("mainwindow", "on_actionViewHidePlaylist_toggled");
     if (fullscreenMode_ && fullscreenHidePanels)
         return;
 
     if (isMinimized())
         return;
 
-    if (checked && playlistWindow_->isHidden())
-        playlistWindow_->show();
-    else if (!checked && playlistWindow_->isVisible())
-        playlistWindow_->hide();
+    if (checked != playlistWindow_->isVisible())
+        playlistWindow_->setVisible(checked);
 
     if (fullscreenMode_ && !fullscreenHidePanels)
         updateBottomAreaGeometry();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -440,6 +440,7 @@ private:
     QActionGroup* subtitleTracksGroup = nullptr;
 
     bool freestanding_ = false;
+    bool mainwindowIsClosing = false; // Prevents toggleViewAction from affecting saved setting for actionViewHidePlaylist
     DecorationState decorationState_ = AllDecorations;
     QString fullscreenName;
     FullscreenMemory fullscreenMemory;


### PR DESCRIPTION
* Don't uncheck actionViewHidePlaylist if MainWindow is closing
Otherwise, the playlist is always hidden on start.
The PlaylistWindow is automatically being closed with the MainWindow.
Because of this, PlaylistWindow::toggleViewAction is getting called and calls MainWindow::setPlaylistVisibleState.
There, actionViewHidePlaylist gets unchecked.
And since ba8d01c105972076ac3799f486c0cce76cdc6446, we save settings after (instead of before) the playlist has been automatically closed.
This means that actionViewHidePlaylist is already unchecked when we save its state.
By not unchecking it when the window is closing, we prevent that.
Note: 5c778bf3c4c4d2dfafbe4ab59bc8a7655cb07f79 doesn't have any role in this regression.
Note 2: MainWindow::setPlaylistVisibleState seems to get called twice at the same time when the auto zoom is enabled. That's probably why this bug wasn't reproduceable with auto zoom enabled.
Fixes #392.
* Add logging and simplify MainWindow::on_actionViewHidePlaylist_toggled