### PR TITLE
Add a music mode

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -111,6 +111,7 @@ private:
     void updateMouseHideTime();
     void updateDiscList();
     void showOsdTimer(bool onSeek);
+    void resizePlaylistToFit();
     QList<QUrl> doQuickOpenFileDialog();
 
     QIcon createIconFromSvg(const QString& svgPath, int maxSize);
@@ -310,6 +311,7 @@ private slots:
     void on_actionViewHideLog_toggled(bool checked);
     void on_actionViewHideLibrary_toggled(bool checked);
     void on_actionViewHideControlsInFullscreen_toggled(bool checked);
+    void on_actionViewMusicMode_triggered(bool checked);
 
     void on_actionViewOSDNone_triggered();
     void on_actionViewOSDMessages_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -865,6 +865,7 @@
     <addaction name="actionViewHideLog"/>
     <addaction name="actionViewHideLibrary"/>
     <addaction name="actionViewHideControlsInFullscreen"/>
+    <addaction name="actionViewMusicMode"/>
     <addaction name="menuOSD"/>
     <addaction name="menuViewPresets"/>
     <addaction name="separator"/>
@@ -2243,6 +2244,17 @@
    </property>
    <property name="shortcut">
     <string>C</string>
+   </property>
+  </action>
+  <action name="actionViewMusicMode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Music Mode</string>
+   </property>
+   <property name="shortcut">
+    <string>M</string>
    </property>
   </action>
   <action name="actionPlaySubtitlesCopy">

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation>Pan and Scan Mà&amp;xim</translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation>M&amp;aximum Pan and Scan</translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1384,6 +1384,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1380,6 +1380,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1384,6 +1384,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1368,6 +1368,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation>最大限のパンとスキャン(&amp;A)</translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1392,6 +1392,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation>எம் &amp; ஆக்சிமம் பான் மற்றும் ச்கேன்</translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1412,6 +1412,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1384,6 +1384,14 @@
         <source>M&amp;aximum Pan and Scan</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Music Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>M</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
The purpose is to use all the available space for the playlist and make it possible to keep a small window size.

This enables the playlist, makes it use the full width and height, and prevents resizing, moving or undocking it.
As the playlist uses all the space (apart from the menus and buttons), resizing the window resizes the playlist.
This also disables cover art to prevent the window from getting resized if auto zoom is enabled.
A few buttons are also hidden: step backward and forward, and subtitles.

QApplication::processEvents() is needed to prevent the playlist from playing catch-up with the window on resize.

Fixes #220.