### PR TITLE
Add Previous and Next Audio track shortcuts

### DIFF
--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -483,6 +483,8 @@ void MpcHcServer::setupWmCommands()
         { 907, "Volume Up",                 [&](){ emit volumeUp(); } },
         { 908, "Volume Down",               [&](){ emit volumeDown(); } },
         { 909, "Volume Mute",               [&](){ emit volumeMute(); } },
+        { 952, "Next Audio Track",          [&](){ emit nextAudioTrack(); } },
+        { 953, "Prev Audio Track",          [&](){ emit previousAudioTrack(); } },
         { 954, "Next Subtitle Track",       [&](){ emit nextSubtitleTrack(); } },
         { 955, "Prev Subtitle Track",       [&](){ emit previousSubtitleTrack(); } },
         { 956, "On/Off Subtitles",          [&](){ emit onOffSubtitles(); } },

--- a/ipc/http.h
+++ b/ipc/http.h
@@ -135,6 +135,8 @@ signals:
     void volumeUp();
     void volumeDown();
     void volumeMute();
+    void nextAudioTrack();
+    void previousAudioTrack();
     void nextSubtitleTrack();
     void previousSubtitleTrack();
     void onOffSubtitles();

--- a/main.cpp
+++ b/main.cpp
@@ -503,6 +503,10 @@ void Flow::setupMainWindowConnections()
             playbackManager, &PlaybackManager::setSubtitleTrack);
     connect(mainWindow, &MainWindow::videoTrackSelected,
             playbackManager, &PlaybackManager::setVideoTrack);
+    connect(mainWindow, &MainWindow::nextAudioTrackSelected,
+            playbackManager, &PlaybackManager::selectNextAudioTrack);
+    connect(mainWindow, &MainWindow::previousAudioTrackSelected,
+            playbackManager, &PlaybackManager::selectPrevAudioTrack);
     connect(mainWindow, &MainWindow::subtitlesEnabled,
             playbackManager, &PlaybackManager::setSubtitleEnabled);
     connect(mainWindow, &MainWindow::nextSubtitleSelected,
@@ -1076,6 +1080,10 @@ void Flow::setupMpcHc()
             mainWindow, &MainWindow::httpVolumeDown);
     connect(mpcHcServer, &MpcHcServer::volumeMute,
             mainWindow, &MainWindow::httpVolumeMute);
+    connect(mpcHcServer, &MpcHcServer::nextAudioTrack,
+            mainWindow, &MainWindow::httpNextAudio);
+    connect(mpcHcServer, &MpcHcServer::previousAudioTrack,
+            mainWindow, &MainWindow::httpPrevAudio);
     connect(mpcHcServer, &MpcHcServer::nextSubtitleTrack,
             mainWindow, &MainWindow::httpNextSubtitle);
     connect(mpcHcServer, &MpcHcServer::previousSubtitleTrack,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1542,6 +1542,18 @@ void MainWindow::httpVolumeMute()
         ui->actionPlayVolumeMute->toggle();
 }
 
+void MainWindow::httpNextAudio()
+{
+    if (ui->actionPlayAudioTrackNext->isEnabled())
+        ui->actionPlayAudioTrackNext->trigger();
+}
+
+void MainWindow::httpPrevAudio()
+{
+    if (ui->actionPlayAudioTrackPrevious->isEnabled())
+        ui->actionPlayAudioTrackPrevious->trigger();
+}
+
 void MainWindow::httpNextSubtitle()
 {
     if (ui->actionPlaySubtitlesNext->isEnabled())
@@ -1979,10 +1991,15 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
     ui->menuPlayAudio->setEnabled(false);
     audioTracksGroup = nullptr;
     hasAudio = !tracks.isEmpty();
+    ui->actionPlayAudioTrackPrevious->setEnabled(hasAudio);
+    ui->actionPlayAudioTrackNext->setEnabled(hasAudio);
     if (!hasAudio)
         return;
     ui->menuPlayAudio->setEnabled(true);
     audioTracksGroup = new QActionGroup(this);
+    ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackPrevious);
+    ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackNext);
+    ui->menuPlayAudio->addSeparator();
     for (const Track &track : tracks) {
         QAction *action = new QAction(this);
         action->setText(track.title);
@@ -2831,6 +2848,16 @@ void MainWindow::on_actionPlaySeekBackwardsLarge_triggered()
 {
     emit relativeSeek(false, true);
     showOsdTimer(true);
+}
+
+void MainWindow::on_actionPlayAudioTrackNext_triggered()
+{
+    emit nextAudioTrackSelected();
+}
+
+void MainWindow::on_actionPlayAudioTrackPrevious_triggered()
+{
+    emit previousAudioTrackSelected();
 }
 
 void MainWindow::on_actionPlaySubtitlesEnabled_triggered(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -147,6 +147,8 @@ signals:
     void audioTrackSelected(int64_t id, bool userSelected);
     void subtitleTrackSelected(int64_t id, bool userSelected);
     void videoTrackSelected(int64_t id, bool userSelected);
+    void nextAudioTrackSelected();
+    void previousAudioTrackSelected();
     void subtitlesEnabled(bool enabled);
     void nextSubtitleSelected();
     void previousSubtitleSelected();
@@ -208,6 +210,8 @@ public slots:
     void httpVolumeUp();
     void httpVolumeDown();
     void httpVolumeMute();
+    void httpNextAudio();
+    void httpPrevAudio();
     void httpNextSubtitle();
     void httpPrevSubtitle();
     void httpOnOffSubtitles();
@@ -369,6 +373,9 @@ private slots:
     void on_actionPlaySeekForwardsLarge_triggered();
     void on_actionPlaySeekBackwardsLarge_triggered();
 
+    void on_actionPlayAudioTrackNext_triggered();
+    void on_actionPlayAudioTrackPrevious_triggered();
+    
     void on_actionPlaySubtitlesEnabled_triggered(bool checked);
     void on_actionPlaySubtitlesNext_triggered();
     void on_actionPlaySubtitlesPrevious_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -884,6 +884,8 @@
      <property name="title">
       <string>&amp;Audio</string>
      </property>
+     <addaction name="actionPlayAudioTrackPrevious"/>
+     <addaction name="actionPlayAudioTrackNext"/>
     </widget>
     <widget class="QMenu" name="menuPlaySubtitles">
      <property name="title">
@@ -2098,6 +2100,22 @@
    </property>
    <property name="shortcut">
     <string notr="true">`</string>
+   </property>
+  </action>
+  <action name="actionPlayAudioTrackPrevious">
+   <property name="text">
+    <string>&amp;Previous Audio Track</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">Shift+A</string>
+   </property>
+  </action>
+  <action name="actionPlayAudioTrackNext">
+   <property name="text">
+    <string>&amp;Next Audio Track</string>
+   </property>
+   <property name="shortcut">
+    <string notr="true">A</string>
    </property>
   </action>
   <action name="actionPlaySubtitlesEnabled">

--- a/manager.cpp
+++ b/manager.cpp
@@ -421,6 +421,26 @@ void PlaybackManager::setVideoTrack(int64_t id, bool userSelected)
         mpvObject_->setVideoTrack(id);
 }
 
+void PlaybackManager::selectNextAudioTrack()
+{
+    if (audioList.isEmpty())
+        return;
+    int64_t nextAudioTrack = audioTrackSelected + 1;
+    if (nextAudioTrack > audioList.count())
+        nextAudioTrack = 1;
+    setAudioTrack(nextAudioTrack, true);
+}
+
+void PlaybackManager::selectPrevAudioTrack()
+{
+    if (audioList.isEmpty())
+        return;
+    int64_t previousAudioTrack = audioTrackSelected - 1;
+    if (previousAudioTrack < 1)
+        previousAudioTrack = audioList.count();
+    setAudioTrack(previousAudioTrack, true);
+}
+
 void PlaybackManager::setSubtitleEnabled(bool enabled)
 {
     subtitleEnabled = enabled;

--- a/manager.h
+++ b/manager.h
@@ -139,6 +139,8 @@ public slots:
     void setAudioTrack(int64_t id, bool userSelected);
     void setSubtitleTrack(int64_t id, bool userSelected);
     void setVideoTrack(int64_t id, bool userSelected);
+    void selectNextAudioTrack();
+    void selectPrevAudioTrack();
     void setSubtitleEnabled(bool enabled);
     void selectNextSubtitle();
     void selectPrevSubtitle();

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1392,6 +1392,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1388,6 +1388,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -2161,10 +2169,6 @@ media file played</source>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3922,6 +3926,10 @@ media file played</source>
     </message>
     <message>
         <source>Audio balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1392,6 +1392,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -2159,10 +2167,6 @@ media file played</source>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -3944,6 +3948,10 @@ media file played</source>
     </message>
     <message>
         <source>Audio balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1376,6 +1376,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -2187,10 +2195,6 @@ media file played</source>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4000,6 +4004,10 @@ media file played</source>
     </message>
     <message>
         <source>Audio balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1723,11 +1731,11 @@
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remover</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Limpar</translation>
     </message>
     <message>
         <source>Copy To clipboard</source>
@@ -1751,7 +1759,7 @@
     </message>
     <message>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Restaurar</translation>
     </message>
     <message>
         <source>Shuffle</source>
@@ -2009,7 +2017,7 @@
     </message>
     <message>
         <source>1</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">1</translation>
     </message>
     <message>
         <source>Player</source>
@@ -2191,10 +2199,6 @@ media file played</source>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2551,7 +2555,7 @@ media file played</source>
     </message>
     <message>
         <source>2</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">2</translation>
     </message>
     <message>
         <source>Anti-ring</source>
@@ -3039,7 +3043,7 @@ media file played</source>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Remover</translation>
     </message>
     <message>
         <source>Add to shaders</source>
@@ -3051,7 +3055,7 @@ media file played</source>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Salvar</translation>
     </message>
     <message>
         <source>Delete</source>
@@ -4024,6 +4028,10 @@ media file played</source>
     </message>
     <message>
         <source>Audio balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1400,6 +1400,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1420,6 +1420,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -2193,10 +2201,6 @@ media file played</source>
     </message>
     <message>
         <source>All</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4026,6 +4030,10 @@ media file played</source>
     </message>
     <message>
         <source>Audio balance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a href=&quot;https://github.com/mpc-qt/mpc-qt/blob/master/DOCS/ipc.md&quot;&gt;JSON IPC&lt;/a&gt; available at %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1392,6 +1392,14 @@
         <source>M</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Previous Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Audio Track</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Uses the same shortcuts (A and Shift+A) and IPC IDs as MPC-HC.
Like for subtitles tracks, triggering Previous or Next Audio track repeatedly loops trough the entries.

Fixes #333.