### PR TITLE
Show OSD message on track change by shortcut or subtitles enabling/disabling

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -426,9 +426,10 @@ void PlaybackManager::selectNextAudioTrack()
     if (audioList.isEmpty())
         return;
     int64_t nextAudioTrack = audioTrackSelected + 1;
-    if (nextAudioTrack > audioList.count())
+    if (nextAudioTrack > audioList.count() || nextAudioTrack < 1)
         nextAudioTrack = 1;
     setAudioTrack(nextAudioTrack, true);
+    mpvObject_->showMessage(tr("Audio track: ") + audioList[nextAudioTrack - 1].title);
 }
 
 void PlaybackManager::selectPrevAudioTrack()
@@ -439,12 +440,14 @@ void PlaybackManager::selectPrevAudioTrack()
     if (previousAudioTrack < 1)
         previousAudioTrack = audioList.count();
     setAudioTrack(previousAudioTrack, true);
+    mpvObject_->showMessage(tr("Audio track: ") + audioList[previousAudioTrack - 1].title);
 }
 
 void PlaybackManager::setSubtitleEnabled(bool enabled)
 {
     subtitleEnabled = enabled;
     updateSubtitleTrack();
+    mpvObject_->showMessage(subtitleEnabled ? tr("Subtitles: on") : tr("Subtitles: off"));
 }
 
 void PlaybackManager::selectNextSubtitle()
@@ -455,6 +458,7 @@ void PlaybackManager::selectNextSubtitle()
     if (nextSubs >= subtitleList.count())
         nextSubs = 0;
     setSubtitleTrack(nextSubs, true);
+    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[nextSubs].title);
 }
 
 void PlaybackManager::selectPrevSubtitle()
@@ -465,6 +469,7 @@ void PlaybackManager::selectPrevSubtitle()
     if (previousSubs < 0)
         previousSubs = subtitleList.count() - 1;
     setSubtitleTrack(previousSubs, true);
+    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[previousSubs].title);
 }
 
 void PlaybackManager::setVolume(int64_t volume, bool onInit)

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation>Ràtio d&apos;Aspecte: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation>Aspect ratio: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1619,6 +1619,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1615,6 +1615,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1619,6 +1619,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1603,6 +1603,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation>アスペクト比 : %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1627,6 +1627,22 @@
         <source>Aspect ratio: %1</source>
         <translation type="unfinished">Соотношение сторон: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation>விகித விகிதம்: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1647,6 +1647,22 @@
         <source>Aspect ratio: %1</source>
         <translation>En–boy oranı: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1619,6 +1619,22 @@
         <source>Aspect ratio: %1</source>
         <translation>长宽比: %1</translation>
     </message>
+    <message>
+        <source>Audio track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: on</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaylistCollection</name>


### PR DESCRIPTION
If the Next Audio Track command is called just after the video is started, `audioTrackSelected` can still be at its default -1 value.
In that case, `nextAudioTrack - 1` will have a value of -1, triggering a segmentation fault when accessing `audioList`.
So we need to check the value of `nextAudioTrack`.