### PR TITLE
Remove redundant color and audio restore commands on Options close

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1177,10 +1177,6 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
         actionEditor->updateActions();
         sendSignals();
     }
-    else {
-        restoreColorControls();
-        restoreAudioSettings();
-    }
     if (buttonRole == QDialogButtonBox::AcceptRole ||
             buttonRole == QDialogButtonBox::RejectRole)
         close();


### PR DESCRIPTION
These aren't needed anymore since d08afd7459e1a749d087c53fc8381f74b69e3528.