### PR TITLE
Improve keybinding workflow

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1171,9 +1171,12 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
     QDialogButtonBox::ButtonRole buttonRole;
     buttonRole = ui->buttonBox->buttonRole(button);
     if (buttonRole == QDialogButtonBox::ApplyRole ||
-            buttonRole == QDialogButtonBox::AcceptRole) {\
+            buttonRole == QDialogButtonBox::AcceptRole) {
+        QString keysSearchText = ui->keysSearchField->text();
+        ui->keysSearchField->clear();
         updateAcceptedSettings();
         sendAcceptedSettings();
+        ui->keysSearchField->setText(keysSearchText);
         actionEditor->updateActions();
         sendSignals();
     }

--- a/widgets/actioneditor.h
+++ b/widgets/actioneditor.h
@@ -34,7 +34,7 @@ signals:
     void mouseFullscreenMap(MouseStateMap map);
     void mouseWindowedMap(MouseStateMap map);
 
-    public slots:
+public slots:
     void filterActions(const QString &text);
 
 private:
@@ -51,8 +51,12 @@ public:
     void setKeySequence(const QKeySequence &keySequence);
     QKeySequence keySequence();
 
+signals:
+    void finishedEditing(ShortcutWidget *editor);
+
 private slots:
     void keyClear_clicked();
+    void editingFinished();
 
 private:
     QKeySequenceEdit *keyEditor = nullptr;


### PR DESCRIPTION
* Improve keybinding workflow
This fixes several issues with the keys editor:
* * The key editor wasn't getting closed when closing Options, so sometimes using a key shortcut ended up saving it as the key shortcut in the last selected action in Keys.
* * Selecting a key in the keys editor wasn't enough to be ready to enter a new one, we had to click again in the field.
* * Same thing when clearing a key with the clear key (<) button.
* * There was an annoying quirk mentioned in 0204f25bef98d65f194d224fecf1c9e29425d429 which is that we had to deselect a shortcut for it to get saved.

* Clear the Keys search field when closing Options
Follow-up to https://github.com/mpc-qt/mpc-qt/commit/2f1adab6b1e319547e04adb9c6985642312badba.