### PR TITLE
Fix subtitles tracks list index to show correct name in osd

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -458,7 +458,10 @@ void PlaybackManager::selectNextSubtitle()
     if (nextSubs >= subtitleList.count())
         nextSubs = 0;
     setSubtitleTrack(nextSubs, true);
-    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[nextSubs].title);
+    int64_t nextSubsRealIdx = nextSubs - 1;
+    if (nextSubsRealIdx < 0)
+        nextSubsRealIdx = subtitleList.count() - 1;
+    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[nextSubsRealIdx].title);
 }
 
 void PlaybackManager::selectPrevSubtitle()
@@ -469,7 +472,10 @@ void PlaybackManager::selectPrevSubtitle()
     if (previousSubs < 0)
         previousSubs = subtitleList.count() - 1;
     setSubtitleTrack(previousSubs, true);
-    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[previousSubs].title);
+    int64_t previousSubsRealIdx = previousSubs - 1;
+    if (previousSubsRealIdx < 0)
+        previousSubsRealIdx = subtitleList.count() - 1;
+    mpvObject_->showMessage(tr("Subtitles track: ") + subtitleList[previousSubsRealIdx].title);
 }
 
 void PlaybackManager::setVolume(int64_t volume, bool onInit)


### PR DESCRIPTION
Because the "0: None" subtitles track is added at the end of the list, the first subtitles track is "1:". So we have to adjust the list index to show the correct track name.
Follow-up to 9d6e96cfad0a8f0bfbf55f5038173b98c67c5afc.