### PR TITLE
Change shortcuts for volume up and volume down

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@
 *.ico
 
 # QtCreator
-
+*.user
 *.autosave
 
 #QtCtreator Qml

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>679</width>
+    <width>779</width>
     <height>362</height>
    </rect>
   </property>
@@ -122,7 +122,7 @@
           </item>
           <item>
            <widget class="QWidget" name="controlbar" native="true">
-            <layout class="QHBoxLayout" name="controlbarLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0">
+            <layout class="QHBoxLayout" name="controlbarLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0">
              <property name="leftMargin">
               <number>6</number>
              </property>
@@ -223,7 +223,7 @@
                 </size>
                </property>
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
               </widget>
              </item>
@@ -340,7 +340,7 @@
                 </size>
                </property>
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
               </widget>
              </item>
@@ -380,14 +380,14 @@
              </item>
              <item>
               <widget class="QPushButton" name="stepForward">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="maximumSize">
                 <size>
                  <width>31</width>
                  <height>40</height>
                 </size>
-               </property>
-               <property name="enabled">
-                <bool>false</bool>
                </property>
                <property name="toolTip">
                 <string>Step Forward</string>
@@ -427,7 +427,7 @@
                 </size>
                </property>
                <property name="orientation">
-                <enum>Qt::Vertical</enum>
+                <enum>Qt::Orientation::Vertical</enum>
                </property>
               </widget>
              </item>
@@ -526,10 +526,9 @@
                 <string>Mute</string>
                </property>
                <property name="icon">
-                <iconset resource="res.qrc">
+                <iconset resource="build/.qt/rcc/res.qrc">
                  <normaloff>:/images/theme/black/player-volume.svg</normaloff>
-                 <normalon>:/images/theme/black/player-volume-muted.svg</normalon>
-                </iconset>
+                 <normalon>:/images/theme/black/player-volume-muted.svg</normalon>:/images/theme/black/player-volume.svg</iconset>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -597,7 +596,7 @@
                <property name="text">
                 <string notr="true">-</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -614,7 +613,7 @@
                <property name="text">
                 <string notr="true">-</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -631,7 +630,7 @@
                <property name="text">
                 <string notr="true">-</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -648,7 +647,7 @@
                <property name="text">
                 <string notr="true">-</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -665,7 +664,7 @@
                <property name="text">
                 <string>vo: 0, decoder: 0</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -682,7 +681,7 @@
                <property name="text">
                 <string notr="true">v: 0 kb/s, a: 0kb/s</string>
                </property>
-               <property name="leftMargin">
+               <property name="leftMargin" stdset="0">
                 <number>10</number>
                </property>
               </widget>
@@ -708,7 +707,7 @@
              <item>
               <widget class="QLabel" name="tinyicon">
                <property name="pixmap">
-                <pixmap resource="res.qrc">:/images/icon/tinyicon.svg</pixmap>
+                <pixmap resource="build/.qt/rcc/res.qrc">:/images/icon/tinyicon.svg</pixmap>
                </property>
               </widget>
              </item>
@@ -742,7 +741,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>679</width>
+     <width>779</width>
      <height>23</height>
     </rect>
    </property>
@@ -921,7 +920,9 @@
       <addaction name="actionMinPanScan"/>
       <addaction name="actionMaxPanScan"/>
      </widget>
-      <addaction name="separator"/>
+     <addaction name="separator"/>
+     <addaction name="menuPlayVideoAspect"/>
+     <addaction name="menuPlayVideoPanScan"/>
     </widget>
     <widget class="QMenu" name="menuPlayVolume">
      <property name="title">
@@ -1505,7 +1506,7 @@
     <string>&amp;Up</string>
    </property>
    <property name="shortcut">
-    <string>0</string>
+    <string notr="true">Ctrl+Shift+Up</string>
    </property>
   </action>
   <action name="actionPlayVolumeDown">
@@ -1513,7 +1514,7 @@
     <string>&amp;Down</string>
    </property>
    <property name="shortcut">
-    <string>9</string>
+    <string notr="true">Ctrl+Shift+Down</string>
    </property>
   </action>
   <action name="actionPlayVolumeMute">
@@ -2285,7 +2286,7 @@
   </action>
  </widget>
  <resources>
-  <include location="res.qrc"/>
+  <include location="build/.qt/rcc/res.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -681,10 +681,6 @@
         <translation>S&amp;ubir</translation>
     </message>
     <message>
-        <source>0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Down</source>
         <translation>&amp;Bajar</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -673,10 +673,6 @@
         <translation>&amp;Ylös</translation>
     </message>
     <message>
-        <source>0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Down</source>
         <translation>&amp;Alas</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -674,7 +674,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -681,10 +681,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Down</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -681,10 +681,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>0</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Down</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -682,7 +682,7 @@
     </message>
     <message>
         <source>0</source>
-        <translation>0</translation>
+        <translation type="vanished">0</translation>
     </message>
     <message>
         <source>&amp;Down</source>


### PR DESCRIPTION
Change shortcuts of volume up and volume down to ctrl+shift+up and ctrl+shift+down.  Ever since #330 the disable aspect ratio shortcut and the volume down shortcut have been the same.  The results was that the key did nothing.  Mpc-hc has these shortcuts as Up and Down.  However, using these keys as shortcuts breaks keyboard navigation of the playlist.  So update these modifiers to the ones in mpc-hc, with extra modifiers so as to not conflict with other entries.

The volume shortcut keycombo is now marked as not-translatable and so its entry is gone from the translations.

Other things in mainwindow.ui file changed when I loaded it in.  Most notably qtcreator's form editor keeps crying out for a resource file. (Resources are now in the cmake file.)  I manually edited it to look at the res file under the build directory.  Hope it doesn't break anything. I tested it with a cmake build as described in the README and it all still seems to work, so fingers crossed.