### PR TITLE
Keybinding fixes

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -510,7 +510,8 @@ SettingMap SettingsWindow::generateSettingMap(QWidget *root)
         QObject *item = toParse.takeFirst();
         if (Setting::classFetcher.contains(item->metaObject()->className())
             && !item->objectName().isEmpty()
-            && item->objectName() != "qt_spinbox_lineedit") {
+            && item->objectName() != "qt_spinbox_lineedit"
+            && item->objectName() != "qt_keysequenceedit_lineedit") {
             QString name = item->objectName();
             QString className = item->metaObject()->className();
             QVariant value = Setting::classFetcher[className](item);

--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -360,10 +360,11 @@ QKeySequence ShortcutWidget::keySequence()
 void ShortcutWidget::keyClear_clicked()
 {
     keyEditor->clear();
-    keyEditor->grabKeyboard();
+    keyEditor->setFocus();
 }
 
 void ShortcutWidget::editingFinished()
 {
+    keyEditor->releaseKeyboard();
     emit finishedEditing(this);
 }


### PR DESCRIPTION
* Don't save data for QKeySequenceEdit control in Settings
Its className() is QLineEdit so it was getting saved by classFetcher.
This fixes a crash (made easier to reproduce by 318d347d707ec66edb3b59f68c1a7b86d2afca69) when trying to restore its value after we double clicked in a QKeySequenceEdit then clicked Cancel, after first closing Options with OK.
* Fix keyboard grabbing in key editor
This ensures that key shortcuts don't get captured by the key editor once we close Options.
Follow-up to 318d347d707ec66edb3b59f68c1a7b86d2afca69.