### PR TITLE
Add a video preview to the seekbar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(SOURCES
     widgets/logowidget.cpp widgets/logowidget.h
     widgets/paletteeditor.cpp widgets/paletteeditor.h
     widgets/screencombo.cpp widgets/screencombo.h
+    widgets/videopreview.cpp widgets/videopreview.h
 )
 
 qt_add_executable(mpc-qt WIN32 MACOSX_BUNDLE ${SOURCES})

--- a/main.cpp
+++ b/main.cpp
@@ -589,6 +589,10 @@ void Flow::setupMainWindowConnections()
             mainWindow, &MainWindow::setVideoBitrate);
     connect(playbackManager, &PlaybackManager::afterPlaybackReset,
             mainWindow, &MainWindow::resetPlayAfterOnce);
+    connect(playbackManager, &PlaybackManager::nowPlayingChanged,
+            mainWindow, &MainWindow::setVideoPreviewItem);
+    connect(playbackManager, &PlaybackManager::isVideo,
+            mainWindow, &MainWindow::setIsVideo);
 
     // mainwindow -> favorites
     connect(mainWindow, &MainWindow::organizeFavorites,
@@ -690,6 +694,8 @@ void Flow::setupSettingsConnections()
             mainWindow, &MainWindow::setSubtitlesDelayStep);
     connect(settingsWindow, &SettingsWindow::timeShorten,
             mainWindow, &MainWindow::setTimeShortMode);
+    connect(settingsWindow, &SettingsWindow::videoPreview,
+            mainWindow, &MainWindow::setVideoPreview);
     connect(settingsWindow, &SettingsWindow::timeTooltip,
             mainWindow, &MainWindow::setTimeTooltip);
     connect(settingsWindow, &SettingsWindow::osdTimerOnSeek,

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -9,6 +9,7 @@
 #include "helpers.h"
 #include "widgets/drawnslider.h"
 #include "widgets/drawnstatus.h"
+#include "widgets/videopreview.h"
 #include "manager.h"
 #include "playlistwindow.h"
 #include "platform/screensaver.h"
@@ -253,6 +254,7 @@ public slots:
     void setMouseHideTimeWindowed(int msec);
     void setBottomAreaBehavior(Helpers::ControlHiding method);
     void setBottomAreaHideTime(int milliseconds);
+    void setVideoPreview(bool enable);
     void setTimeTooltip(bool show, bool above);
     void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
@@ -283,6 +285,8 @@ public slots:
     void setPlaylistQuickQueueMode(bool yes);
     void setAudioBitrate(double bitrate);
     void setVideoBitrate(double bitrate);
+    void setIsVideo(bool isVideo);
+    void setVideoPreviewItem(QUrl itemUrl);
     void logWindowClosed();
     void libraryWindowClosed();
 
@@ -417,6 +421,7 @@ private slots:
     void mpvw_customContextMenuRequested(const QPoint &pos);
     void position_sliderMoved(int position);
     void position_hoverValue(double value, QString text, double x);
+    void position_hoverEnd();
     void on_play_clicked();
     void volume_sliderMoved(double position);
     void playlistWindow_windowDocked();
@@ -437,6 +442,7 @@ private:
     //MpvGlCbWidget *mpvw = nullptr;
     MediaSlider *positionSlider_ = nullptr;
     VolumeSlider *volumeSlider_ = nullptr;
+    VideoPreview *videoPreview = nullptr;
     StatusTime *timePosition = nullptr;
     StatusTime *timeDuration = nullptr;
     PlaylistWindow *playlistWindow_ = nullptr;
@@ -473,6 +479,7 @@ private:
     bool hasVideo = false;
     bool hasAudio = false;
     bool hasSubs = false;
+    bool isVideo_ = false;
     QString subtitleText;
     int subtitlesDelayStep = 100;
     int volumeStep = 10;
@@ -490,6 +497,7 @@ private:
     double audioBitrate = 0;
     double videoBitrate = 0;
     double panScan = 0;
+    QUrl currentFile;
 
     IconThemer themer;
     QList<QAction *> menuFavoritesTail;

--- a/manager.cpp
+++ b/manager.cpp
@@ -945,6 +945,7 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
     emit hasNoVideo(videoList.empty());
     emit hasNoAudio(audioList.empty());
     emit hasNoSubtitles(subtitleList.empty());
+    emit isVideo(!videoList.isEmpty() && !videoListData[1].isImage);
 }
 
 void PlaybackManager::mpvw_videoSizeChanged(QSize size)

--- a/manager.h
+++ b/manager.h
@@ -72,6 +72,7 @@ signals:
     void hasNoVideo(bool empty);
     void hasNoAudio(bool empty);
     void hasNoSubtitles(bool empty);
+    void isVideo(bool isVideo);
     void subtitlesVisible(bool visible);
     void nowPlayingChanged(QUrl itemUrl, QUuid listUuid, QUuid itemUuid, bool clickedInPlaylist = false);
     void finishedPlaying(QUuid item);

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -677,6 +677,7 @@ void MpvObject::hideCursor()
 void MpvObject::self_aspectChanged(double newAspect)
 {
     aspect = newAspect;
+    emit aspectChanged(newAspect);
 }
 
 void MpvObject::ctrl_mpvPropertyChanged(QString name, QVariant v)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -134,6 +134,7 @@ signals:
     void decoderFramedropsChanged(int64_t cout);
     void audioBitrateChanged(double bitrate);
     void videoBitrateChanged(double bitrate);
+    void aspectChanged(double newAspect);
     void aspectNameChanged(QString newAspectName);
     void fileNameChanged(QString filename);
     void fileFormatChanged(QString format);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1050,6 +1050,7 @@ void SettingsWindow::sendSignals()
     emit mpvMouseEvents(WIDGET_LOOKUP(ui->tweaksMpvMouseEvents).toBool());
     emit mpvKeyEvents(WIDGET_LOOKUP(ui->tweaksMpvKeyEvents).toBool());
     emit timeShorten(WIDGET_LOOKUP(ui->tweaksTimeShort).toBool());
+    emit videoPreview(WIDGET_LOOKUP(ui->tweaksVideoPreview).toBool());
     emit timeTooltip(WIDGET_LOOKUP(ui->tweaksTimeTooltip).toBool(),
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);
     emit osdTimerOnSeek(WIDGET_LOOKUP(ui->tweaksOsdTimerOnSeek).toBool());
@@ -1383,6 +1384,12 @@ void SettingsWindow::on_tweaksPreferWayland_toggled(bool checked)
 {
     if (checked && QGuiApplication::platformName() == "wayland")
         ui->playbackAutoZoom->setChecked(false);
+}
+
+void SettingsWindow::on_tweaksVideoPreview_toggled(bool checked)
+{
+    ui->tweaksTimeTooltip->setEnabled(!checked);
+    ui->tweaksTimeTooltipLocation->setEnabled(!checked);
 }
 
 void SettingsWindow::on_tweaksTimeTooltip_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -174,6 +174,7 @@ signals:
     void timeShorten(bool yes);
     void mpvMouseEvents(bool yes);
     void mpvKeyEvents(bool yes);
+    void videoPreview(bool enable);
     void timeTooltip(bool yes, bool above);
     void osdTimerOnSeek(bool yes);
     void osdFont(const QString &family, const QString &size);
@@ -274,6 +275,8 @@ private slots:
     void on_ccICCBrowse_clicked();
 
     void on_tweaksPreferWayland_toggled(bool checked);
+
+    void on_tweaksVideoPreview_toggled(bool checked);
 
     void on_tweaksTimeTooltip_toggled(bool checked);
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>896</width>
-    <height>605</height>
+    <height>638</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -177,7 +177,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>8</number>
+          <number>20</number>
          </property>
          <widget class="QWidget" name="playerPage">
           <layout class="QGridLayout" name="playerPageLayout">
@@ -497,7 +497,7 @@ media file played</string>
           </layout>
          </widget>
          <widget class="QWidget" name="keysPage">
-          <layout class="QVBoxLayout" name="keysPageLayout" stretch="1,0">
+          <layout class="QVBoxLayout" name="keysPageLayout" stretch="1,0,0">
            <item>
             <widget class="QLineEdit" name="keysSearchField">
              <property name="placeholderText">
@@ -514,7 +514,7 @@ media file played</string>
            <item>
             <layout class="QHBoxLayout" name="keysBottomLayout" stretch="1,0">
              <item>
-              <layout class="QVBoxLayout" name="ipcLayout" stretch="0,0,1">
+              <layout class="QVBoxLayout" name="ipcLayout" stretch="0,0">
                <item>
                 <widget class="QLabel" name="ipcNotice">
                  <property name="text">
@@ -538,7 +538,7 @@ media file played</string>
               </layout>
              </item>
              <item>
-              <layout class="QVBoxLayout" name="keysLayout" stretch="0,1">
+              <layout class="QVBoxLayout" name="keysLayout" stretch="0">
                <item>
                 <widget class="QPushButton" name="keysReset">
                  <property name="text">
@@ -763,8 +763,8 @@ media file played</string>
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>677</width>
-                   <height>70</height>
+                   <width>68</width>
+                   <height>16</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_6"/>
@@ -4490,11 +4490,11 @@ media file played</string>
                     </item>
                     <item>
                      <widget class="QPushButton" name="ccICCBrowse">
-                      <property name="text">
-                       <string>Browse</string>
-                      </property>
                       <property name="enabled">
                        <bool>false</bool>
+                      </property>
+                      <property name="text">
+                       <string>Browse</string>
                       </property>
                      </widget>
                     </item>
@@ -5608,7 +5608,7 @@ media file played</string>
          </widget>
          <widget class="QWidget" name="audioPage">
           <layout class="QGridLayout" name="audioPageLayout">
-           <item row="0" column="0" colspan="2">>
+           <item row="0" column="0" colspan="2">
             <widget class="QGroupBox" name="audioBox">
              <property name="title">
               <string>Audio Renderer</string>
@@ -6043,7 +6043,7 @@ media file played</string>
               <string>Audio balance</string>
              </property>
              <layout class="QGridLayout" name="audioBalanceBoxLayout" columnstretch="1,1">
-              <item colspan="2">>
+              <item row="0" column="0" colspan="2">
                <widget class="QScrollBar" name="audioBalance">
                 <property name="cursor">
                  <cursorShape>PointingHandCursor</cursorShape>
@@ -6062,7 +6062,7 @@ media file played</string>
              </layout>
             </widget>
            </item>
-           <item>
+           <item row="0" column="0">
             <spacer name="verticalSpacer_3">
              <property name="orientation">
               <enum>Qt::Orientation::Vertical</enum>
@@ -7627,7 +7627,17 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
+           <item row="9" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksVideoPreview">
+             <property name="text">
+              <string>Show video preview</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
             <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="1">
              <item>
               <widget class="QCheckBox" name="tweaksTimeTooltip">
@@ -7640,6 +7650,9 @@ media file played</string>
                <property name="text">
                 <string>Show time tooltip:</string>
                </property>
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
                <property name="checked">
                 <bool>true</bool>
                </property>
@@ -7647,7 +7660,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="9" column="1">
+           <item row="10" column="1">
             <widget class="QComboBox" name="tweaksTimeTooltipLocation">
              <property name="enabled">
               <bool>true</bool>
@@ -7670,14 +7683,14 @@ media file played</string>
              </item>
             </widget>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="11" colspan="2">
             <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
              <property name="text">
               <string>Show OSD timer on seek</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="0">
+           <item row="12" column="0">
             <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="1">
              <item>
               <widget class="QCheckBox" name="tweaksOsdFontChkBox">
@@ -7694,7 +7707,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="11" column="1">
+           <item row="12" column="1">
             <layout class="QHBoxLayout" name="tweaksOsdLayout" stretch="1,0">
              <item>
               <widget class="QFontComboBox" name="tweaksOsdFont">

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4066,6 +4066,10 @@ arxiu multimèdia reproduït</translation>
         <source>Search...</source>
         <translation>Buscar…</translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4066,6 +4066,10 @@ media file played</translation>
         <source>Search...</source>
         <translation>Search…</translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4010,6 +4010,10 @@ archivo multimedia reproducido</translation>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3948,6 +3948,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3974,6 +3974,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3970,6 +3970,10 @@ ogni file multimediale riprodotto</translation>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4066,6 +4066,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4026,6 +4026,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4050,6 +4050,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4038,6 +4038,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4066,6 +4066,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4058,6 +4058,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Search...</source>
         <translation>Ara…</translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3964,6 +3964,10 @@ media file played</source>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show video preview</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -1,0 +1,88 @@
+#include <QToolTip>
+#include "videopreview.h"
+
+VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
+{
+    mpv = new MpvObject(this);
+    videoWidget = new MpvGlWidget(mpv, this);
+    mpv->setWidgetType(Helpers::CustomWidget, videoWidget);
+    videoWidget->setFixedSize(1, 1);
+    textLabel = new QLabel(this);
+    textLabel->setAlignment(Qt::AlignCenter);
+    layout = new QVBoxLayout(this);
+    layout->setSpacing(0);
+    layout->setContentsMargins(0,0,0,0);
+    layout->addWidget(videoWidget);
+    layout->addWidget(textLabel);
+    setLayout(layout);
+    setWindowFlags(Qt::ToolTip);
+
+    textLabel->setAutoFillBackground(true);
+    QPalette tooltipPalette = QToolTip::palette();
+    QPalette customPalette = this->palette();
+    customPalette.setColor(QPalette::Window, tooltipPalette.color(QPalette::ToolTipBase));
+    customPalette.setColor(QPalette::WindowText, tooltipPalette.color(QPalette::ToolTipText));
+    textLabel->setPalette(customPalette);
+
+    emit mpv->ctrlSetOptionVariant("vo", "libmpv");
+    emit mpv->ctrlSetOptionVariant("keep-open", true);
+    emit mpv->ctrlSetOptionVariant("sub-visibility", "no");
+    emit mpv->ctrlSetOptionVariant("hr-seek", "no");
+    emit mpv->ctrlSetOptionVariant("audio-display", "no");
+
+    connect(mpv, &MpvObject::aspectChanged, this, [this](double newAspect) {
+        if (newAspect == 0) {
+            aspectRatioSet = false;
+            return;
+        }
+        int baseHeight = 180;
+        int newWidth = int(baseHeight * newAspect);
+        videoWidget->setFixedSize(newWidth, baseHeight);
+        aspectRatioSet = true;
+        if (shouldBeShown)
+            show();
+    });
+
+    show();
+    shouldBeShown = false;
+}
+
+VideoPreview::~VideoPreview()
+{
+    if (!mpv)
+        return;
+    mpv->setWidgetType(Helpers::NullWidget);
+    videoWidget = nullptr;
+    delete mpv;
+    mpv = nullptr;
+}
+
+void VideoPreview::openFile(const QUrl &fileUrl)
+{
+    mpv->urlOpen(fileUrl);
+    mpv->setPaused(true);
+    aspectRatioSet = false;
+}
+
+void VideoPreview::setTimeText(const QString &text, double videoPosition)
+{
+    textLabel->setText(text);
+    mpv->setTime(videoPosition);
+    mpv->setPaused(true);
+    videoWidget->update();
+}
+
+void VideoPreview::showEvent(QShowEvent *event)
+{
+    if (!aspectRatioSet) {
+        shouldBeShown = true;
+        return;
+    }
+    QWidget::showEvent(event);
+}
+
+void VideoPreview::hideEvent(QHideEvent *event)
+{
+    shouldBeShown = false;
+    QWidget::hideEvent(event);
+}

--- a/widgets/videopreview.h
+++ b/widgets/videopreview.h
@@ -1,0 +1,27 @@
+#ifndef VIDEOPREVIEW_H
+#define VIDEOPREVIEW_H
+
+#include <qboxlayout.h>
+#include <qlabel.h>
+#include "mpvwidget.h"
+
+class VideoPreview : public QWidget {
+    public:
+        explicit VideoPreview(QWidget *parent = nullptr);
+        ~VideoPreview();
+        void openFile(const QUrl &fileUrl);
+        void setTimeText(const QString &text, double videoPosition);
+        void showEvent(QShowEvent *event) override;
+        void hideEvent(QHideEvent *event) override;
+        
+    private:
+        QLabel *textLabel;
+        QVBoxLayout *layout;
+        MpvObject *mpv = nullptr;
+        MpvGlWidget *videoWidget = nullptr;
+        bool aspectRatioSet = false;
+        bool shouldBeShown = false;
+    };
+    
+#endif // VIDEOPREVIEW_H
+    


### PR DESCRIPTION
The video preview, enabled by default, is centered on the mouse cursor and is restricted from extending beyond the window boundaries.
The background and text colors of the video preview can be customized similarly to the regular tooltip, though changes only take effect after a restart.
For audio files, a standard tooltip is used as reusing the same widget for audio files would add complexity without adding value.
On Windows, it doesn't seem to show in fullscreen, like tooltips.

Fixes #4.