### PR TITLE
Always use pointing hand cursor for seekbar

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3115,6 +3115,8 @@ void MainWindow::position_sliderMoved(int position)
 
 void MainWindow::position_hoverValue(double position, QString chapterInfo, double x)
 {
+    setCursor(Qt::PointingHandCursor);
+
     if (!timeTooltipShown && !videoPreview)
         return;
 
@@ -3144,6 +3146,8 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
 
 void MainWindow::position_hoverEnd()
 {
+    setCursor(Qt::ArrowCursor);
+
     if (videoPreview)
         // The delay prevents flickering
         QTimer::singleShot(10, this, [this]() {


### PR DESCRIPTION
If the mouse pointer was on the seekbar before loading the first file, it wouldn't change to a pointing hand cursor even after moving it on the seekbar.
This has to be in MainWindow instead of in DrawnSlider to work.
Follow-up to ac98edd434c56f1f6c35cb07788046ecf4f0fc30.