### PR TITLE
Use worst quality for ytdl video preview

### DIFF
--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -29,6 +29,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("sub-visibility", "no");
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
+    emit mpv->ctrlSetOptionVariant("ytdl-format", "worst");
 
     connect(mpv, &MpvObject::aspectChanged, this, [this](double newAspect) {
         if (newAspect == 0) {


### PR DESCRIPTION
This speeds up downloading online videos to show a preview.

Fixes #414.