### PR TITLE
Don't show "Volume:" OSD message when opening mpc-qt

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -215,8 +215,7 @@ void MainWindow::setState(const QVariantMap &map)
 
     on_actionPlaySubtitlesEnabled_triggered(ui->actionPlaySubtitlesEnabled->isChecked());
     on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked(), true);
-    volumeSlider_->setValue(map.value("volume", 100).toInt());
-    volume_sliderMoved(volumeSlider_->value());
+    setVolume(map.value("volume", 100).toInt(), true);
     setOSDPage(map.value("shownStatsPage",0).toInt());
     updateOnTop();
 


### PR DESCRIPTION
Fixes regression caused by 7e8ea0289a023d13fa909a4413e72b2dc6a8bb07.
Originally fixed in 1a3f5289528863b51134ff1459dce705d4b5f768.