### PR TITLE
Don't show "Subtitles:" OSD message when opening mpc-qt

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -213,7 +213,7 @@ void MainWindow::setState(const QVariantMap &map)
     UNWRAP(ui->actionPlaySubtitlesEnabled, true);
     UNWRAP(ui->actionPlayVolumeMute, false);
 
-    on_actionPlaySubtitlesEnabled_triggered(ui->actionPlaySubtitlesEnabled->isChecked());
+    setSubtitlesEnabled(ui->actionPlaySubtitlesEnabled->isChecked(), true);
     on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked(), true);
     volumeSlider_->setValue(map.value("volume", 100).toInt());
     volume_sliderMoved(volumeSlider_->value());
@@ -2148,6 +2148,13 @@ void MainWindow::setVolumeMax(int level)
     volumeSlider_->setMaximum(level);
 }
 
+void MainWindow::setSubtitlesEnabled(bool enabled, bool onInit)
+{
+    emit subtitlesEnabled(enabled, onInit);
+    ui->actionPlaySubtitlesEnabled->setChecked(enabled);
+    ui->subs->setChecked(!enabled);
+}
+
 void MainWindow::setSubtitlesDelayStep(int subtitlesDelayStep)
 {
     this->subtitlesDelayStep = subtitlesDelayStep;
@@ -2889,9 +2896,7 @@ void MainWindow::on_actionPlayAudioTrackPrevious_triggered()
 
 void MainWindow::on_actionPlaySubtitlesEnabled_triggered(bool checked)
 {
-    emit subtitlesEnabled(checked);
-    ui->actionPlaySubtitlesEnabled->setChecked(checked);
-    ui->subs->setChecked(!checked);
+    setSubtitlesEnabled(checked);
 }
 
 void MainWindow::on_actionPlaySubtitlesNext_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -150,7 +150,7 @@ signals:
     void videoTrackSelected(int64_t id, bool userSelected);
     void nextAudioTrackSelected();
     void previousAudioTrackSelected();
-    void subtitlesEnabled(bool enabled);
+    void subtitlesEnabled(bool enabled, bool onInit);
     void nextSubtitleSelected();
     void previousSubtitleSelected();
     void volumeChanged(int64_t volume, bool onInit = false);
@@ -272,6 +272,7 @@ public slots:
     void setVolume(int level, bool onInit = false);
     void setVolumeDouble(double level);
     void setVolumeMax(int level);
+    void setSubtitlesEnabled(bool enabled, bool onInit = false);
     void setSubtitlesDelayStep(int subtitlesDelayStep);
     void setTimeShortMode(bool shortened);
     void resetPlayAfterOnce();

--- a/manager.cpp
+++ b/manager.cpp
@@ -443,11 +443,12 @@ void PlaybackManager::selectPrevAudioTrack()
     mpvObject_->showMessage(tr("Audio track: ") + audioList[previousAudioTrack - 1].title);
 }
 
-void PlaybackManager::setSubtitleEnabled(bool enabled)
+void PlaybackManager::setSubtitleEnabled(bool enabled, bool onInit)
 {
     subtitleEnabled = enabled;
     updateSubtitleTrack();
-    mpvObject_->showMessage(subtitleEnabled ? tr("Subtitles: on") : tr("Subtitles: off"));
+    if (!onInit)
+        mpvObject_->showMessage(subtitleEnabled ? tr("Subtitles: on") : tr("Subtitles: off"));
 }
 
 void PlaybackManager::selectNextSubtitle()

--- a/manager.h
+++ b/manager.h
@@ -142,7 +142,7 @@ public slots:
     void setVideoTrack(int64_t id, bool userSelected);
     void selectNextAudioTrack();
     void selectPrevAudioTrack();
-    void setSubtitleEnabled(bool enabled);
+    void setSubtitleEnabled(bool enabled, bool onInit = false);
     void selectNextSubtitle();
     void selectPrevSubtitle();
     void setVolume(int64_t volume, bool onInit = false);


### PR DESCRIPTION
Follow-up to 9d6e96cfad0a8f0bfbf55f5038173b98c67c5afc.