### PR TITLE
Add OpenSubtitles web search support

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1014,7 +1014,9 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->actionNavigateGoto->setEnabled(enabled);
     ui->actionFavoritesAdd->setEnabled(enabled);
 
-    ui->menuFileSubtitleDatabase->setEnabled(false);
+    ui->menuFileSubtitleDatabase->setEnabled(enabled);
+    ui->actionFileSubtitleDatabaseUpload->setEnabled(false);
+    ui->actionFileSubtitleDatabaseDownload->setEnabled(false);
     ui->menuPlayLoop->setEnabled(enabled);
     ui->menuPlayVolume->setEnabled(enabled);
     if (!enabled) {
@@ -2389,6 +2391,13 @@ void MainWindow::on_actionFileLoadSubtitle_triggered()
         return;
     lastUrl = url;
     emit subtitlesLoaded(url);
+}
+
+void MainWindow::on_actionFileSubtitleDatabaseSearch_triggered()
+{
+    QString fileNameNoExt = QFileInfo(currentFile.fileName()).completeBaseName();
+    QDesktopServices::openUrl(QUrl("https://www.opensubtitles.org/search2/moviename-" +
+                                   fileNameNoExt + "/sublanguageid-all"));
 }
 
 void MainWindow::on_actionFileClose_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -431,6 +431,8 @@ private slots:
 
     void on_actionFileLoadSubtitle_triggered();
 
+    void on_actionFileSubtitleDatabaseSearch_triggered();
+
     void on_actionFavoritesAdd_triggered();
 
     void on_actionFavoritesOrganize_triggered();


### PR DESCRIPTION
Implements the "Search..." entry in "File > Subtitle Database" to open a browser web page with the search results for the current video on opensubtitles.org.

The [new OpenSubtitles API](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started) (which is required to download subtitles from the player) limits usage to 5 downloads per day (or 10 when logged in). This limit can be reached very quickly when we have to download multiple subtitles to find a good one.
That significantly reduces the usefulness to add support for the API.

#110.