### PR TITLE
Support removing subtitles additions for deaf or hard-of-hearing (SDH)

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1019,6 +1019,7 @@ void SettingsWindow::sendSignals()
     emit subsPreferExternal(WIDGET_LOOKUP(ui->subtitlesPreferExternal).toBool());
     emit subsIgnoreEmbeded(WIDGET_LOOKUP(ui->subtitlesIgnoreEmbedded).toBool());
     bool subsAutoload = WIDGET_LOOKUP(ui->subtitlesAutoloadExternal).toBool();
+    emit option("sub-filter-sdh", WIDGET_LOOKUP(ui->subtitlesRemoveSdh).toBool());
     emit option("sub-auto", subsAutoload ? WIDGET_TO_TEXT(ui->subtitlesAutoloadMatch) : QString("no"));
     emit option("sub-file-paths", WIDGET_PLACEHOLD_LOOKUP(ui->subtitlesAutoloadPath).split(';'));
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6768,6 +6768,13 @@ media file played</string>
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="subtitlesRemoveSdh">
+             <property name="text">
+              <string>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QGroupBox" name="subtitlesAutoloadBox">
              <property name="title">
               <string>Autoload paths</string>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4134,6 +4134,10 @@ arxiu multimèdia reproduït</translation>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4134,6 +4134,10 @@ media file played</translation>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4078,6 +4078,10 @@ archivo multimedia reproducido</translation>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4016,6 +4016,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4042,6 +4042,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4038,6 +4038,10 @@ ogni file multimediale riprodotto</translation>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4134,6 +4134,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4094,6 +4094,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4118,6 +4118,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4106,6 +4106,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4134,6 +4134,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4126,6 +4126,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4032,6 +4032,10 @@ media file played</source>
         <source>400%</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
This pretty cool mpv feature removes the subtitles text like "[Screaming]" or "MAN:".
This obviously requires text-based subtitles to work.
Setting in "Subtitles > Misc", disabled by default.
mpv also has a feature to more aggressively remove SDH text and even supports regex filtering, but this should already cover most cases.