### PR TITLE
Mark shortcut strings containing only key names as untranslatable

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1162,7 +1162,7 @@
     <string>P&amp;roperties</string>
    </property>
    <property name="shortcut">
-    <string>Shift+F10</string>
+    <string notr="true">Shift+F10</string>
    </property>
   </action>
   <action name="actionFileExit">
@@ -1327,7 +1327,7 @@
     <string>F&amp;ullscreen</string>
    </property>
    <property name="shortcut">
-    <string>Alt+Return</string>
+    <string notr="true">Alt+Return</string>
    </property>
   </action>
   <action name="actionViewZoom050">
@@ -1450,7 +1450,7 @@
     <string>&amp;Pause</string>
    </property>
    <property name="shortcut">
-    <string>Space</string>
+    <string notr="true">Space</string>
    </property>
   </action>
   <action name="actionPlayStop">
@@ -1466,7 +1466,7 @@
     <string>Fra&amp;me Step Backward</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Left</string>
+    <string notr="true">Ctrl+Left</string>
    </property>
   </action>
   <action name="actionPlayFrameForward">
@@ -1474,7 +1474,7 @@
     <string>F&amp;rame Step Forward</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Right</string>
+    <string notr="true">Ctrl+Right</string>
    </property>
   </action>
   <action name="actionPlayRateDecrease">
@@ -1482,7 +1482,7 @@
     <string>&amp;Decrease Rate</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Down</string>
+    <string notr="true">Ctrl+Down</string>
    </property>
   </action>
   <action name="actionPlayRateIncrease">
@@ -1490,7 +1490,7 @@
     <string>&amp;Increase Rate</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Up</string>
+    <string notr="true">Ctrl+Up</string>
    </property>
   </action>
   <action name="actionPlayRateReset">
@@ -1592,7 +1592,7 @@
     <string>&amp;Previous</string>
    </property>
    <property name="shortcut">
-    <string>PgUp</string>
+    <string notr="true">PgUp</string>
    </property>
   </action>
   <action name="actionNavigateChaptersNext">
@@ -1600,7 +1600,7 @@
     <string>&amp;Next</string>
    </property>
    <property name="shortcut">
-    <string>PgDown</string>
+    <string notr="true">PgDown</string>
    </property>
   </action>
   <action name="actionNavigateFilesPrevious">
@@ -1608,7 +1608,7 @@
     <string>&amp;Previous File</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+PgUp</string>
+    <string notr="true">Ctrl+PgUp</string>
    </property>
   </action>
   <action name="actionNavigateFilesNext">
@@ -1616,7 +1616,7 @@
     <string>&amp;Next File</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+PgDown</string>
+    <string notr="true">Ctrl+PgDown</string>
    </property>
   </action>
   <action name="actionNavigateGoto">
@@ -1711,7 +1711,7 @@
     <string>Save I&amp;mage (Auto)</string>
    </property>
    <property name="shortcut">
-    <string>F5</string>
+    <string notr="true">F5</string>
    </property>
   </action>
   <action name="actionViewZoomAutofitSmaller">
@@ -1730,7 +1730,7 @@
     <string>&amp;Play Current</string>
    </property>
    <property name="shortcut">
-    <string>Return</string>
+    <string notr="true">Return</string>
    </property>
   </action>
   <action name="actionPlaySeekForwardsNormal">
@@ -1738,7 +1738,7 @@
     <string>Seek Forwards (normal step)</string>
    </property>
    <property name="shortcut">
-    <string>Right</string>
+    <string notr="true">Right</string>
    </property>
   </action>
   <action name="actionPlaySeekBackwardsNormal">
@@ -1746,7 +1746,7 @@
     <string>Seek Backwards (normal step)</string>
    </property>
    <property name="shortcut">
-    <string>Left</string>
+    <string notr="true">Left</string>
    </property>
   </action>
   <action name="actionPlaySeekForwardsLarge">
@@ -1754,7 +1754,7 @@
     <string>Seek Forwards (large step)</string>
    </property>
    <property name="shortcut">
-    <string>Shift+Right</string>
+    <string notr="true">Shift+Right</string>
    </property>
   </action>
   <action name="actionPlaySeekBackwardsLarge">
@@ -1762,7 +1762,7 @@
     <string>Seek Backwards (large step)</string>
    </property>
    <property name="shortcut">
-    <string>Shift+Left</string>
+    <string notr="true">Shift+Left</string>
    </property>
   </action>
   <action name="actionPlayLoopStart">
@@ -1770,7 +1770,7 @@
     <string>&amp;Set Loop Start</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Home</string>
+    <string notr="true">Ctrl+Home</string>
    </property>
   </action>
   <action name="actionPlayLoopEnd">
@@ -1778,7 +1778,7 @@
     <string>Set &amp;Loop End</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+End</string>
+    <string notr="true">Ctrl+End</string>
    </property>
   </action>
   <action name="actionPlayLoopUse">
@@ -1789,7 +1789,7 @@
     <string>&amp;Repeat</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+Backspace</string>
+    <string notr="true">Ctrl+Backspace</string>
    </property>
   </action>
   <action name="actionPlayLoopClear">
@@ -1797,7 +1797,7 @@
     <string>&amp;Clear Loop</string>
    </property>
    <property name="shortcut">
-    <string>Backspace</string>
+    <string notr="true">Backspace</string>
    </property>
   </action>
   <action name="actionPlaylistSearch">
@@ -1989,7 +1989,7 @@
     <string>Save Plain Ima&amp;ge (Auto)</string>
    </property>
    <property name="shortcut">
-    <string>Shift+F5</string>
+    <string notr="true">Shift+F5</string>
    </property>
   </action>
   <action name="actionFileExportEncode">
@@ -1997,7 +1997,7 @@
     <string>Export Encode...</string>
    </property>
    <property name="shortcut">
-    <string>F12</string>
+    <string notr="true">F12</string>
    </property>
   </action>
   <action name="actionPlaylistShowQuickQueue">
@@ -2027,7 +2027,7 @@
     <string>Save Window Image (Auto)</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+F5</string>
+    <string notr="true">Ctrl+F5</string>
    </property>
   </action>
   <action name="actionPlayAfterOnceNothing">

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Espai</translation>
+        <translation type="vanished">Espai</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Dreta</translation>
+        <translation type="vanished">Ctrl+Dreta</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+Esquerra</translation>
+        <translation type="vanished">Ctrl+Esquerra</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+Avall</translation>
+        <translation type="vanished">Ctrl+Avall</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+Amunt</translation>
+        <translation type="vanished">Ctrl+Amunt</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>Re Pàg</translation>
+        <translation type="vanished">Re Pàg</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>Av Pàg</translation>
+        <translation type="vanished">Av Pàg</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Entrar</translation>
+        <translation type="vanished">Entrar</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Dreta</translation>
+        <translation type="vanished">Dreta</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Esquerra</translation>
+        <translation type="vanished">Esquerra</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+Dreta</translation>
+        <translation type="vanished">Shift+Dreta</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+Esquerra</translation>
+        <translation type="vanished">Shift+Esquerra</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Inici</translation>
+        <translation type="vanished">Ctrl+Inici</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+Final</translation>
+        <translation type="vanished">Ctrl+Final</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Retrocés</translation>
+        <translation type="vanished">Ctrl+Retrocés</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Retrocés</translation>
+        <translation type="vanished">Retrocés</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1282,7 +1282,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+RePàg</translation>
+        <translation type="vanished">Ctrl+RePàg</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1290,7 +1290,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+AvPàg</translation>
+        <translation type="vanished">Ctrl+AvPàg</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Space</translation>
+        <translation type="vanished">Space</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Right</translation>
+        <translation type="vanished">Ctrl+Right</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+Left</translation>
+        <translation type="vanished">Ctrl+Left</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+Down</translation>
+        <translation type="vanished">Ctrl+Down</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+Up</translation>
+        <translation type="vanished">Ctrl+Up</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgUp</translation>
+        <translation type="vanished">PgUp</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgDown</translation>
+        <translation type="vanished">PgDown</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Return</translation>
+        <translation type="vanished">Return</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Right</translation>
+        <translation type="vanished">Right</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Left</translation>
+        <translation type="vanished">Left</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+Right</translation>
+        <translation type="vanished">Shift+Right</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+Left</translation>
+        <translation type="vanished">Shift+Left</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Home</translation>
+        <translation type="vanished">Ctrl+Home</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+End</translation>
+        <translation type="vanished">Ctrl+End</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1282,7 +1282,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+PgUp</translation>
+        <translation type="vanished">Ctrl+PgUp</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1290,7 +1290,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+PgDown</translation>
+        <translation type="vanished">Ctrl+PgDown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Mayús+F10</translation>
+        <translation type="vanished">Mayús+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Entrar</translation>
+        <translation type="vanished">Alt+Entrar</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Espacio</translation>
+        <translation type="vanished">Espacio</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Derecha</translation>
+        <translation type="vanished">Ctrl+Derecha</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+Izquierda</translation>
+        <translation type="vanished">Ctrl+Izquierda</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+Abajo</translation>
+        <translation type="vanished">Ctrl+Abajo</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+Arriba</translation>
+        <translation type="vanished">Ctrl+Arriba</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -734,7 +734,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>Re Pág</translation>
+        <translation type="vanished">Re Pág</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -742,7 +742,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>Av Pág</translation>
+        <translation type="vanished">Av Pág</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -809,10 +809,6 @@
         <translation>Guardar imagen (automático)</translation>
     </message>
     <message>
-        <source>F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
         <translation>Autoajustar (&amp;solo si es menor)</translation>
     </message>
@@ -826,7 +822,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Entrar</translation>
+        <translation type="vanished">Entrar</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -834,7 +830,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Derecha</translation>
+        <translation type="vanished">Derecha</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -842,7 +838,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Izquierda</translation>
+        <translation type="vanished">Izquierda</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -850,7 +846,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Mayús+Derecha</translation>
+        <translation type="vanished">Mayús+Derecha</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -858,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Mayús+Izquierda</translation>
+        <translation type="vanished">Mayús+Izquierda</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -866,7 +862,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Inicio</translation>
+        <translation type="vanished">Ctrl+Inicio</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -874,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+Fin</translation>
+        <translation type="vanished">Ctrl+Fin</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -882,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Retroceso</translation>
+        <translation type="vanished">Ctrl+Retroceso</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -890,7 +886,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Retroceso</translation>
+        <translation type="vanished">Retroceso</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1042,15 +1038,11 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Mayús+F5</translation>
+        <translation type="vanished">Mayús+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
         <translation>Exportar codificación...</translation>
-    </message>
-    <message>
-        <source>F12</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1075,10 +1067,6 @@
     <message>
         <source>Save Window Image (Auto)</source>
         <translation>Guardar imagen de la ventana (automático)</translation>
-    </message>
-    <message>
-        <source>Ctrl+F5</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1265,15 +1253,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -425,10 +425,6 @@
         <translation>Ominaisuudet</translation>
     </message>
     <message>
-        <source>Shift+F10</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>E&amp;xit</source>
         <translation>P&amp;oistu</translation>
     </message>
@@ -545,10 +541,6 @@
         <translation>Koko Näyttö</translation>
     </message>
     <message>
-        <source>Alt+Return</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -618,7 +610,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Välilyönti</translation>
+        <translation type="vanished">Välilyönti</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -633,32 +625,16 @@
         <translation>K&amp;ehysaskel eteenpäin</translation>
     </message>
     <message>
-        <source>Ctrl+Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fra&amp;me Step Backward</source>
         <translation>K&amp;ehysaskel taaksepäin</translation>
-    </message>
-    <message>
-        <source>Ctrl+Left</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
         <translation>&amp;Pienennä Nopeutta</translation>
     </message>
     <message>
-        <source>Ctrl+Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Increase Rate</source>
         <translation>&amp;Nosta Nopeutta</translation>
-    </message>
-    <message>
-        <source>Ctrl+Up</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -721,16 +697,8 @@
         <translation>&amp;Edellinen</translation>
     </message>
     <message>
-        <source>PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next</source>
         <translation>&amp;Seuraava</translation>
-    </message>
-    <message>
-        <source>PgDown</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -793,10 +761,6 @@
         <translation>Tallenna kuva (automaattisesti)</translation>
     </message>
     <message>
-        <source>F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
         <translation>Automaattinen Sovitus (Vain &amp;Pienemmät)</translation>
     </message>
@@ -810,7 +774,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Takaisin</translation>
+        <translation type="vanished">Takaisin</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -818,7 +782,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Oikea</translation>
+        <translation type="vanished">Oikea</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -826,7 +790,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Vasen</translation>
+        <translation type="vanished">Vasen</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -834,7 +798,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+Oikea</translation>
+        <translation type="vanished">Shift+Oikea</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -842,27 +806,19 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+Vasen</translation>
+        <translation type="vanished">Shift+Vasen</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
         <translation>&amp;Aseta Syklin Aloitus</translation>
     </message>
     <message>
-        <source>Ctrl+Home</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Set &amp;Loop End</source>
         <translation>Aseta &amp;Syklin Loppu</translation>
     </message>
     <message>
-        <source>Ctrl+End</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Askelpalautin</translation>
+        <translation type="vanished">Ctrl+Askelpalautin</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -870,7 +826,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Askelpalautin</translation>
+        <translation type="vanished">Askelpalautin</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1021,16 +977,8 @@
         <translation>Tallenna Yksinkertainen Ku&amp;va (Automaattisesti)</translation>
     </message>
     <message>
-        <source>Shift+F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Export Encode...</source>
         <translation>Vie Koodaus...</translation>
-    </message>
-    <message>
-        <source>F12</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1055,10 +1003,6 @@
     <message>
         <source>Save Window Image (Auto)</source>
         <translation>Tallenna Ikkunan Kuva (automaattisesti)</translation>
-    </message>
-    <message>
-        <source>Ctrl+F5</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1245,16 +1189,8 @@
         <translation>&amp;Edellinen Tiedosto</translation>
     </message>
     <message>
-        <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next File</source>
         <translation>&amp;Seuraava Tiedosto</translation>
-    </message>
-    <message>
-        <source>Ctrl+PgDown</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Ruang kosong</translation>
+        <translation type="vanished">Ruang kosong</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+→</translation>
+        <translation type="vanished">Ctrl+→</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+←</translation>
+        <translation type="vanished">Ctrl+←</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+↓</translation>
+        <translation type="vanished">Ctrl+↓</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+↑</translation>
+        <translation type="vanished">Ctrl+↑</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgUp</translation>
+        <translation type="vanished">PgUp</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgDn</translation>
+        <translation type="vanished">PgDn</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -810,7 +810,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -826,7 +826,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Kembali</translation>
+        <translation type="vanished">Kembali</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -834,7 +834,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Kanan</translation>
+        <translation type="vanished">Kanan</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -842,7 +842,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Kiri</translation>
+        <translation type="vanished">Kiri</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -850,7 +850,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+→</translation>
+        <translation type="vanished">Shift+→</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -858,7 +858,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+←</translation>
+        <translation type="vanished">Shift+←</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -866,7 +866,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Home</translation>
+        <translation type="vanished">Ctrl+Home</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -874,11 +874,11 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+End</translation>
+        <translation type="vanished">Ctrl+End</translation>
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1038,7 +1038,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1074,7 +1074,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1270,7 +1270,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+PgUp</translation>
+        <translation type="vanished">Ctrl+PgUp</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1278,7 +1278,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+PgDown</translation>
+        <translation type="vanished">Ctrl+PgDown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -426,7 +426,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Maiusc+F10</translation>
+        <translation type="vanished">Maiusc+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -546,7 +546,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Invio</translation>
+        <translation type="vanished">Alt+Invio</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -618,7 +618,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Spazio</translation>
+        <translation type="vanished">Spazio</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -634,7 +634,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Destra</translation>
+        <translation type="vanished">Ctrl+Destra</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+Sinistra</translation>
+        <translation type="vanished">Ctrl+Sinistra</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+Giù</translation>
+        <translation type="vanished">Ctrl+Giù</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+Su</translation>
+        <translation type="vanished">Ctrl+Su</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -730,7 +730,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgSu</translation>
+        <translation type="vanished">PgSu</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgGiù</translation>
+        <translation type="vanished">PgGiù</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -806,7 +806,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -822,7 +822,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Invio</translation>
+        <translation type="vanished">Invio</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Destra</translation>
+        <translation type="vanished">Destra</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Sinistra</translation>
+        <translation type="vanished">Sinistra</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+Destra</translation>
+        <translation type="vanished">Shift+Destra</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+Sinistra</translation>
+        <translation type="vanished">Shift+Sinistra</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Inizio</translation>
+        <translation type="vanished">Ctrl+Inizio</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+Fine</translation>
+        <translation type="vanished">Ctrl+Fine</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1038,7 +1038,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Maiusc+F5</translation>
+        <translation type="vanished">Maiusc+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1070,10 +1070,6 @@
     </message>
     <message>
         <source>Save Window Image (Auto)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1253,15 +1249,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>スペース</translation>
+        <translation type="vanished">スペース</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Right</translation>
+        <translation type="vanished">Ctrl+Right</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+左</translation>
+        <translation type="vanished">Ctrl+左</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+下</translation>
+        <translation type="vanished">Ctrl+下</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+上</translation>
+        <translation type="vanished">Ctrl+上</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgUp</translation>
+        <translation type="vanished">PgUp</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgDown</translation>
+        <translation type="vanished">PgDown</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>戻る</translation>
+        <translation type="vanished">戻る</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>右</translation>
+        <translation type="vanished">右</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>左</translation>
+        <translation type="vanished">左</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+右</translation>
+        <translation type="vanished">Shift+右</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+左</translation>
+        <translation type="vanished">Shift+左</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Home</translation>
+        <translation type="vanished">Ctrl+Home</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+End</translation>
+        <translation type="vanished">Ctrl+End</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1282,7 +1282,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+PgUp</translation>
+        <translation type="vanished">Ctrl+PgUp</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1290,7 +1290,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+PgDown</translation>
+        <translation type="vanished">Ctrl+PgDown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -433,10 +433,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shift+F10</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -553,10 +549,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Alt+Return</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -625,10 +617,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Space</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Stop</source>
         <translation type="unfinished"></translation>
     </message>
@@ -641,15 +629,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fra&amp;me Step Backward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -657,15 +637,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Increase Rate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,15 +705,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -809,10 +773,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,47 +785,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Return</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Seek Forwards</source>
         <translation type="vanished">Seek Forwards</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Seek Backwards</source>
         <translation type="vanished">Seek Backwards</translation>
     </message>
     <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Seek Forwards Finely</source>
         <translation type="vanished">Seek Forwards Finely</translation>
-    </message>
-    <message>
-        <source>Shift+Right</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
         <translation type="vanished">Seek Backwards Finely</translation>
     </message>
     <message>
-        <source>Shift+Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Set Loop Start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -873,23 +809,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+End</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Use Loop Points</source>
         <translation type="vanished">&amp;Use Loop Points</translation>
     </message>
     <message>
-        <source>Ctrl+Backspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Clear Loop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1041,15 +965,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shift+F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Export Encode...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1074,10 +990,6 @@
     </message>
     <message>
         <source>Save Window Image (Auto)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1277,15 +1189,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -433,10 +433,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shift+F10</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>E&amp;xit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -554,7 +550,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Enter</translation>
+        <translation type="vanished">Alt+Enter</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +622,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Espaço</translation>
+        <translation type="vanished">Espaço</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -641,15 +637,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+Right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Fra&amp;me Step Backward</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -657,15 +645,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+Down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Increase Rate</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -733,15 +713,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -809,10 +781,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,47 +793,23 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Return</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Seek Forwards</source>
         <translation type="vanished">Seek Forwards</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Seek Backwards</source>
         <translation type="vanished">Seek Backwards</translation>
     </message>
     <message>
-        <source>Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Seek Forwards Finely</source>
         <translation type="vanished">Seek Forwards Finely</translation>
-    </message>
-    <message>
-        <source>Shift+Right</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
         <translation type="vanished">Seek Backwards Finely</translation>
     </message>
     <message>
-        <source>Shift+Left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Set Loop Start</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -873,23 +817,11 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+End</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Use Loop Points</source>
         <translation type="vanished">&amp;Use Loop Points</translation>
     </message>
     <message>
-        <source>Ctrl+Backspace</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Clear Loop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1041,15 +973,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shift+F5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Export Encode...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>F12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1074,10 +998,6 @@
     </message>
     <message>
         <source>Save Window Image (Auto)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1277,15 +1197,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Next File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ctrl+PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Пробел</translation>
+        <translation type="vanished">Пробел</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+Вправо</translation>
+        <translation type="vanished">Ctrl+Вправо</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+Влево</translation>
+        <translation type="vanished">Ctrl+Влево</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+Вниз</translation>
+        <translation type="vanished">Ctrl+Вниз</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+Вверх</translation>
+        <translation type="vanished">Ctrl+Вверх</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgUp</translation>
+        <translation type="vanished">PgUp</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgDown</translation>
+        <translation type="vanished">PgDown</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Возврат</translation>
+        <translation type="vanished">Возврат</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Вправо</translation>
+        <translation type="vanished">Вправо</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Влево</translation>
+        <translation type="vanished">Влево</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+Вправо</translation>
+        <translation type="vanished">Shift+Вправо</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+Влево</translation>
+        <translation type="vanished">Shift+Влево</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Home</translation>
+        <translation type="vanished">Ctrl+Home</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+End</translation>
+        <translation type="vanished">Ctrl+End</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1278,7 +1278,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+PgUp</translation>
+        <translation type="vanished">Ctrl+PgUp</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1286,7 +1286,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+PgDown</translation>
+        <translation type="vanished">Ctrl+PgDown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>சிப்ட்+எஃப் 10</translation>
+        <translation type="vanished">சிப்ட்+எஃப் 10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+திரும்ப</translation>
+        <translation type="vanished">Alt+திரும்ப</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>இடைவெளி</translation>
+        <translation type="vanished">இடைவெளி</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+சரி</translation>
+        <translation type="vanished">Ctrl+சரி</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+இடது</translation>
+        <translation type="vanished">Ctrl+இடது</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+down</translation>
+        <translation type="vanished">Ctrl+down</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+up</translation>
+        <translation type="vanished">Ctrl+up</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>Pgup</translation>
+        <translation type="vanished">Pgup</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>Pgdown</translation>
+        <translation type="vanished">Pgdown</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>எஃப் 5</translation>
+        <translation type="vanished">எஃப் 5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>திரும்ப</translation>
+        <translation type="vanished">திரும்ப</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>வலது</translation>
+        <translation type="vanished">வலது</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>இடது</translation>
+        <translation type="vanished">இடது</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>சிப்ட்+சரியானது</translation>
+        <translation type="vanished">சிப்ட்+சரியானது</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>சிப்ட்+இடது</translation>
+        <translation type="vanished">சிப்ட்+இடது</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+வீடு</translation>
+        <translation type="vanished">Ctrl+வீடு</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+end</translation>
+        <translation type="vanished">Ctrl+end</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+பேக்ச்பேச்</translation>
+        <translation type="vanished">Ctrl+பேக்ச்பேச்</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>பேக்ச்பேச்</translation>
+        <translation type="vanished">பேக்ச்பேச்</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>சிப்ட்+எஃப் 5</translation>
+        <translation type="vanished">சிப்ட்+எஃப் 5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>எஃப் 12</translation>
+        <translation type="vanished">எஃப் 12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1282,7 +1282,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+pgup</translation>
+        <translation type="vanished">Ctrl+pgup</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1290,7 +1290,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+pgdown</translation>
+        <translation type="vanished">Ctrl+pgdown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Üst Karakter+F10</translation>
+        <translation type="vanished">Üst Karakter+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Seçenek+Dönüş</translation>
+        <translation type="vanished">Seçenek+Dönüş</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>Boşluk</translation>
+        <translation type="vanished">Boşluk</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Kontrol+Sağ</translation>
+        <translation type="vanished">Kontrol+Sağ</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Kontrol+Sol</translation>
+        <translation type="vanished">Kontrol+Sol</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Kontrol+Aşağı</translation>
+        <translation type="vanished">Kontrol+Aşağı</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Kontrol+Yukarı</translation>
+        <translation type="vanished">Kontrol+Yukarı</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>Sayfa Yukarı</translation>
+        <translation type="vanished">Sayfa Yukarı</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>Sayfa Aşağı</translation>
+        <translation type="vanished">Sayfa Aşağı</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>Dönüş</translation>
+        <translation type="vanished">Dönüş</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>Sağ</translation>
+        <translation type="vanished">Sağ</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>Sol</translation>
+        <translation type="vanished">Sol</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Üst Karakter+Sağ</translation>
+        <translation type="vanished">Üst Karakter+Sağ</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Üst Karakter+Sol</translation>
+        <translation type="vanished">Üst Karakter+Sol</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Kontrol+Baş</translation>
+        <translation type="vanished">Kontrol+Baş</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Kontrol+Son</translation>
+        <translation type="vanished">Kontrol+Son</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Kontrol+Geri Sil</translation>
+        <translation type="vanished">Kontrol+Geri Sil</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Geri Sil</translation>
+        <translation type="vanished">Geri Sil</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Üst Karakter+F5</translation>
+        <translation type="vanished">Üst Karakter+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Kontrol+F5</translation>
+        <translation type="vanished">Kontrol+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1282,7 +1282,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Kontrol+Sayfa Yukarı</translation>
+        <translation type="vanished">Kontrol+Sayfa Yukarı</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1290,7 +1290,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Kontrol+Sayfa Aşağı</translation>
+        <translation type="vanished">Kontrol+Sayfa Aşağı</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -434,7 +434,7 @@
     </message>
     <message>
         <source>Shift+F10</source>
-        <translation>Shift+F10</translation>
+        <translation type="vanished">Shift+F10</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -554,7 +554,7 @@
     </message>
     <message>
         <source>Alt+Return</source>
-        <translation>Alt+Return</translation>
+        <translation type="vanished">Alt+Return</translation>
     </message>
     <message>
         <source>Alt+1</source>
@@ -626,7 +626,7 @@
     </message>
     <message>
         <source>Space</source>
-        <translation>空格</translation>
+        <translation type="vanished">空格</translation>
     </message>
     <message>
         <source>&amp;Stop</source>
@@ -642,7 +642,7 @@
     </message>
     <message>
         <source>Ctrl+Right</source>
-        <translation>Ctrl+→</translation>
+        <translation type="vanished">Ctrl+→</translation>
     </message>
     <message>
         <source>Fra&amp;me Step Backward</source>
@@ -650,7 +650,7 @@
     </message>
     <message>
         <source>Ctrl+Left</source>
-        <translation>Ctrl+←</translation>
+        <translation type="vanished">Ctrl+←</translation>
     </message>
     <message>
         <source>&amp;Decrease Rate</source>
@@ -658,7 +658,7 @@
     </message>
     <message>
         <source>Ctrl+Down</source>
-        <translation>Ctrl+↓</translation>
+        <translation type="vanished">Ctrl+↓</translation>
     </message>
     <message>
         <source>&amp;Increase Rate</source>
@@ -666,7 +666,7 @@
     </message>
     <message>
         <source>Ctrl+Up</source>
-        <translation>Ctrl+↑</translation>
+        <translation type="vanished">Ctrl+↑</translation>
     </message>
     <message>
         <source>R&amp;eset Rate</source>
@@ -738,7 +738,7 @@
     </message>
     <message>
         <source>PgUp</source>
-        <translation>PgUp</translation>
+        <translation type="vanished">PgUp</translation>
     </message>
     <message>
         <source>&amp;Next</source>
@@ -746,7 +746,7 @@
     </message>
     <message>
         <source>PgDown</source>
-        <translation>PgDown</translation>
+        <translation type="vanished">PgDown</translation>
     </message>
     <message>
         <source>&amp;Go To...</source>
@@ -814,7 +814,7 @@
     </message>
     <message>
         <source>F5</source>
-        <translation>F5</translation>
+        <translation type="vanished">F5</translation>
     </message>
     <message>
         <source>Auto Fit (&amp;Smaller Only)</source>
@@ -830,7 +830,7 @@
     </message>
     <message>
         <source>Return</source>
-        <translation>回车</translation>
+        <translation type="vanished">回车</translation>
     </message>
     <message>
         <source>Seek Forwards</source>
@@ -838,7 +838,7 @@
     </message>
     <message>
         <source>Right</source>
-        <translation>→</translation>
+        <translation type="vanished">→</translation>
     </message>
     <message>
         <source>Seek Backwards</source>
@@ -846,7 +846,7 @@
     </message>
     <message>
         <source>Left</source>
-        <translation>←</translation>
+        <translation type="vanished">←</translation>
     </message>
     <message>
         <source>Seek Forwards Finely</source>
@@ -854,7 +854,7 @@
     </message>
     <message>
         <source>Shift+Right</source>
-        <translation>Shift+→</translation>
+        <translation type="vanished">Shift+→</translation>
     </message>
     <message>
         <source>Seek Backwards Finely</source>
@@ -862,7 +862,7 @@
     </message>
     <message>
         <source>Shift+Left</source>
-        <translation>Shift+←</translation>
+        <translation type="vanished">Shift+←</translation>
     </message>
     <message>
         <source>&amp;Set Loop Start</source>
@@ -870,7 +870,7 @@
     </message>
     <message>
         <source>Ctrl+Home</source>
-        <translation>Ctrl+Home</translation>
+        <translation type="vanished">Ctrl+Home</translation>
     </message>
     <message>
         <source>Set &amp;Loop End</source>
@@ -878,7 +878,7 @@
     </message>
     <message>
         <source>Ctrl+End</source>
-        <translation>Ctrl+End</translation>
+        <translation type="vanished">Ctrl+End</translation>
     </message>
     <message>
         <source>&amp;Use Loop Points</source>
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Ctrl+Backspace</source>
-        <translation>Ctrl+Backspace</translation>
+        <translation type="vanished">Ctrl+Backspace</translation>
     </message>
     <message>
         <source>&amp;Clear Loop</source>
@@ -894,7 +894,7 @@
     </message>
     <message>
         <source>Backspace</source>
-        <translation>Backspace</translation>
+        <translation type="vanished">Backspace</translation>
     </message>
     <message>
         <source>&amp;Search Playlist</source>
@@ -1046,7 +1046,7 @@
     </message>
     <message>
         <source>Shift+F5</source>
-        <translation>Shift+F5</translation>
+        <translation type="vanished">Shift+F5</translation>
     </message>
     <message>
         <source>Export Encode...</source>
@@ -1054,7 +1054,7 @@
     </message>
     <message>
         <source>F12</source>
-        <translation>F12</translation>
+        <translation type="vanished">F12</translation>
     </message>
     <message>
         <source>S&amp;how Quick Queue</source>
@@ -1082,7 +1082,7 @@
     </message>
     <message>
         <source>Ctrl+F5</source>
-        <translation>Ctrl+F5</translation>
+        <translation type="vanished">Ctrl+F5</translation>
     </message>
     <message>
         <source>Do No&amp;thing</source>
@@ -1270,7 +1270,7 @@
     </message>
     <message>
         <source>Ctrl+PgUp</source>
-        <translation>Ctrl+PgUp</translation>
+        <translation type="vanished">Ctrl+PgUp</translation>
     </message>
     <message>
         <source>&amp;Next File</source>
@@ -1278,7 +1278,7 @@
     </message>
     <message>
         <source>Ctrl+PgDown</source>
-        <translation>Ctrl+PgDown</translation>
+        <translation type="vanished">Ctrl+PgDown</translation>
     </message>
     <message>
         <source>Play next &amp;file</source>


### PR DESCRIPTION
They don't change the way the shortcut keys are displayed.
They get translated by Qt, except in the shortcut editor where we may have to fix that.
So there's no point in wasting the translators' time.