### PR TITLE
Implement yt-dlp web video max height setting

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -161,6 +161,8 @@ QHash<QString, QStringList> SettingMap::indexedValueToText = {
     {"ccHdrMapper", {"clip", "mobius", "reinhard", "hable", "gamma", \
                      "linear"}},
     {"ccHdrCompute", {"auto", "yes", "no"}},
+    {"ytdlpMaxHeight", {"240", "360", "480", "720", "1080", "1440",
+                             "2160", "2880", "4320"}},
     {"audioChannels", {"auto-safe", "auto", "stereo"}},
     {"audioRenderer", {"pulse", "alsa", "oss", "null"}},
     {"audioAutoloadMatch", { "exact", "fuzzy", "all" }},
@@ -755,6 +757,8 @@ void SettingsWindow::sendSignals()
     emit option("image-display-duration", WIDGET_LOOKUP(ui->playbackLoopImages).toBool() ? QVariant("inf") : QVariant(1.0));
 
     emit afterPlaybackDefault(Helpers::AfterPlayback(WIDGET_LOOKUP(ui->afterPlaybackDefault).toInt()));
+
+    emit option("ytdl-format", QString("bestvideo[height<=%1]+bestaudio/best").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
 
     emit zoomCenter(WIDGET_LOOKUP(ui->playbackAutoCenterWindow).toBool());
     double factor = WIDGET_LOOKUP(ui->playbackAutoFitFactor).toInt() / 100.0;

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1510,6 +1510,74 @@ media file played</string>
              </layout>
             </widget>
            </item>
+           <item row="3" column="1">
+            <widget class="QGroupBox" name="ytdlpBox">
+             <property name="title">
+              <string>yt-dlp (web videos)</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_17">
+              <item>
+               <widget class="QLabel" name="ytdlpLabel">
+                <property name="text">
+                 <string>Max video height:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="ytdlpMaxHeight">
+                <property name="currentIndex">
+                 <number>4</number>
+                </property>
+                <item>
+                 <property name="text">
+                  <string notr="true">240</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">360</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">480</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">720</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">1080</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">1440</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">2160</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">2880</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string notr="true">4320</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="outputPage">

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4042,6 +4042,14 @@ media file played</source>
         <source>Show video preview</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4154,6 +4154,14 @@ arxiu multimèdia reproduït</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4154,6 +4154,14 @@ media file played</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation>Requires restarting the application to apply changes</translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4078,6 +4078,14 @@ archivo multimedia reproducido</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3972,6 +3972,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4074,6 +4074,14 @@ fichier média lu</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation>Le redémarrage de l&apos;application est nécessaire pour appliquer les changements</translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation>yt-dlp (vidéos web)</translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation>Hauteur maximale des vidéos :</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4062,6 +4062,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4046,6 +4046,14 @@ ogni file multimediale riprodotto</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4154,6 +4154,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4018,6 +4018,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4050,6 +4050,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4126,6 +4126,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4154,6 +4154,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4146,6 +4146,14 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4052,6 +4052,14 @@ media file played</source>
         <source>Requires restarting the application to apply changes</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>yt-dlp (web videos)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Max video height:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
In Playback options, defaults to 1080.
If already started, the video has to be stopped and resumed for changes to be applied.

Fixes #81.