### PR TITLE
Show more tracks information in submenus and fix tracks info formatting

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2198,7 +2198,7 @@ void MainWindow::setPlayAfterAlwaysDefault(Helpers::AfterPlayback action)
 
 void MainWindow::setFps(double fps)
 {
-    ui->framerate->setText(std::isnan(fps) ? "-" : QString::number(fps, 'f', 2));
+    ui->framerate->setText(std::isnan(fps) ? "-" : QString::number(fps, 'g', 6));
 }
 
 void MainWindow::setAvsync(double sync)

--- a/manager.h
+++ b/manager.h
@@ -28,6 +28,12 @@ public:
     int64_t trackId = 0;
     QString type;
     QString codec;
+    QString codecProfile;
+    int width = 0;
+    int height = 0;
+    int samplerate = 0;
+    QString channels;
+    int bitrate = 0;
     QString lang;
     QString title;
     bool isExternal = false;

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -106,9 +106,9 @@ void PropertiesWindow::setTracks(const QVariantList &tracks)
             line << QString("%1x%2").arg(QString::number(track["demux-w"].toInt()),
                                          QString::number(track["demux-h"].toInt()));
         if (track.contains("demux-fps"))
-            line << QString("%1fps").arg(QString::number(track["demux-fps"].toDouble(), 'g', 3));
+            line << QString("%1fps").arg(QString::number(track["demux-fps"].toDouble(), 'g', 6));
         if (track.contains("demux-samplerate"))
-            line << QString("%1Hz").arg(track["demux-samplerate"].toInt());
+            line << QString("%1kHz").arg(std::round(track["demux-samplerate"].toInt() / 100) / 10.0);
         if (track.contains("audio-channels"))
             line << QString("%1ch").arg(track["audio-channels"].toInt());
         lines << line.join(' ');


### PR DESCRIPTION
* Show more tracks information in submenus
Follows the same formatting as MPC-HC, except for the sample rate.
Examples:
for an audio track: "2: English [eng] (aac he-aac, 48 kHz, 5.1, 160 kb/s)"
for a subtitles track: "2: English [eng] (subrip)"
for a video track: "1: h264 high, 1868 kb/s, 1280x720"
The information shown depends on available metadata.

* Show maximum three decimals for fps and format sample rate in kHz
For some reason, QString::number with 'g' requires 6 instead of 3 to show 3 decimals instead of no decimal.