### PR TITLE
Don't set ToolTip window flag for VideoPreview on Wayland

### DIFF
--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -1,3 +1,4 @@
+#include <QApplication>
 #include <QToolTip>
 #include "videopreview.h"
 
@@ -15,7 +16,10 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     layout->addWidget(videoWidget);
     layout->addWidget(textLabel);
     setLayout(layout);
-    setWindowFlags(Qt::ToolTip);
+    if (QApplication::platformName() == "wayland")
+        setWindowFlags(Qt::Tool | Qt::FramelessWindowHint);
+    else
+        setWindowFlags(Qt::ToolTip);
 
     textLabel->setAutoFillBackground(true);
     QPalette tooltipPalette = QToolTip::palette();


### PR DESCRIPTION
Prevents the app from closing with an exception. But the video preview isstuck in the center of the window, unlike in XWayland mode with the ToolTip flag.

Fixes #435 (Crash when hovering over seek bar with Wayland & Show video preview enabled).