### PR TITLE
Use Consolas as monospace font on Windows

### DIFF
--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -1,5 +1,6 @@
 #include "helpers.h"
 #include "propertieswindow.h"
+#include "platform/unify.h"
 #include "ui_propertieswindow.h"
 
 #include <QMimeDatabase>
@@ -13,6 +14,11 @@ PropertiesWindow::PropertiesWindow(QWidget *parent) :
 {
     ui->setupUi(this);
     ui->tabWidget->setCurrentIndex(0);
+    if (Platform::isWindows) {
+        QFont monoFont;
+        monoFont.setFamily("Consolas");
+        ui->mediaInfoText->setFont(monoFont);
+    }
     setMetaData(QVariantMap());
     updateSaveVisibility();
     connect(ui->tabWidget, &QTabWidget::currentChanged,


### PR DESCRIPTION
Monospace isn't mapped to a monospace font on Windows.

Fixes https://github.com/mpc-qt/mpc-qt/issues/439 (Align the colon signs on MediaInfo).