### PR TITLE
Draw VideoPreview on the main window

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1899,7 +1899,6 @@ void MainWindow::setVideoPreview(bool enable)
 {
     if (!videoPreview && enable) {
         videoPreview = new VideoPreview(this);
-        videoPreview->hide();
         setVideoPreviewItem(currentFile);
     }
     else if (videoPreview && !enable) {
@@ -3126,7 +3125,7 @@ void MainWindow::position_sliderMoved(int position)
     emit timeSelected(position);
 }
 
-void MainWindow::position_hoverValue(double position, QString chapterInfo, double x)
+void MainWindow::position_hoverValue(double position, QString chapterInfo, double mouseX)
 {
     setCursor(Qt::PointingHandCursor);
 
@@ -3139,33 +3138,22 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
     if (videoPreview && isVideo_) {
-        int tooltipWidth = videoPreview->width();
-        int xPos = x - std::round(tooltipWidth / 2);
-        // For some reason there's a different gap between left and right side
-        if (xPos + tooltipWidth + 26 > this->width())
-            xPos = this->width() - tooltipWidth - 26;
-        else if (xPos < 14)
-            xPos = 14;
-        QPoint where = positionSlider_->mapToGlobal(QPoint(int(xPos), -200));
-        videoPreview->move(where);
-        videoPreview->setTimeText(t, position);
         QToolTip::hideText();
-        videoPreview->show();
+        QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), 0));
+        videoPreview->show(t, position, where, this->width());
+        mpvw->update();
     } else {
-        QPoint where = positionSlider_->mapToGlobal(QPoint(int(x), timeTooltipAbove ? -40 : 0));
+        QPoint where = positionSlider_->mapToGlobal(QPoint(std::round(mouseX), timeTooltipAbove ? -40 : 0));
         QToolTip::showText(where, t, positionSlider_);
     }
 }
 
 void MainWindow::position_hoverEnd()
 {
-    setCursor(Qt::ArrowCursor);
-
     if (videoPreview)
-        // The delay prevents flickering
-        QTimer::singleShot(10, this, [this]() {
-            videoPreview->hide();
-        });
+        videoPreview->hide();
+
+    setCursor(Qt::ArrowCursor);
 }
 
 void MainWindow::on_play_clicked()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -421,7 +421,7 @@ private slots:
 
     void mpvw_customContextMenuRequested(const QPoint &pos);
     void position_sliderMoved(int position);
-    void position_hoverValue(double value, QString text, double x);
+    void position_hoverValue(double value, QString text, double mouseX);
     void position_hoverEnd();
     void on_play_clicked();
     void volume_sliderMoved(double position);

--- a/widgets/videopreview.h
+++ b/widgets/videopreview.h
@@ -1,7 +1,6 @@
 #ifndef VIDEOPREVIEW_H
 #define VIDEOPREVIEW_H
 
-#include <qboxlayout.h>
 #include <qlabel.h>
 #include "mpvwidget.h"
 
@@ -10,17 +9,20 @@ class VideoPreview : public QWidget {
         explicit VideoPreview(QWidget *parent = nullptr);
         ~VideoPreview();
         void openFile(const QUrl &fileUrl);
-        void setTimeText(const QString &text, double videoPosition);
-        void showEvent(QShowEvent *event) override;
-        void hideEvent(QHideEvent *event) override;
+        void show(const QString &text, double videoPosition, QPoint where, int mainWindowWidth);
+        void hide();
         
     private:
+        void setPreviewPosition(QPoint where, int mainWindowWidth);
+        void show();
+        void updateWidth(double newAspect);
+
         QLabel *textLabel;
-        QVBoxLayout *layout;
         MpvObject *mpv = nullptr;
         MpvGlWidget *videoWidget = nullptr;
         bool aspectRatioSet = false;
         bool shouldBeShown = false;
+        QPoint previewBottomLeft;
     };
     
 #endif // VIDEOPREVIEW_H


### PR DESCRIPTION
Avoids problems with Wayland (VideoPreview non moveable) and on Windows (VideoPreview not visible in fullscreen). Also fixes some issues and quirks we had to work around.

We move the VideoPreview widgets outside the screen to hide them. That's because after being made invisible, they can't be made visible again.

The code is hopefully more readable now.