### PR TITLE
Replace compiler parameter with version.h for versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,11 @@ else()
     endif()
 endif()
 
-# Define version as a preprocessor definition
-add_compile_definitions(MPCQT_VERSION_STR="${VERSTR}")
+# Generate version.h with version information
+configure_file(
+    ${CMAKE_SOURCE_DIR}/version.h.in
+    ${CMAKE_BINARY_DIR}/version.h
+)
 
 message(STATUS "The version appears to be ${VERSTR}, and the Windows manifest would say this is ${VERSTR_WIN}.")
 
@@ -117,6 +120,8 @@ set(SOURCES
 )
 
 qt_add_executable(mpc-qt WIN32 MACOSX_BUNDLE ${SOURCES})
+
+target_include_directories(mpc-qt PRIVATE ${CMAKE_BINARY_DIR})
 
 set(TS_FILES
     translations/mpc-qt_ar.ts

--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -3,6 +3,7 @@
 #include <QFileInfo>
 #include <QTcpSocket>
 #include "helpers.h"
+#include "version.h"
 #include "ipc/http.h"
 #include "platform/devicemanager.h"
 #include "platform/unify.h"

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,7 @@
 #include "settingswindow.h"
 #include "mpvwidget.h"
 #include "propertieswindow.h"
+#include "version.h"
 #include "ipc/mpris.h"
 #include "platform/devicemanager.h"
 #include "platform/unify.h"

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include "openfiledialog.h"
 #include "helpers.h"
 #include "logger.h"
+#include "version.h"
 #include "platform/unify.h"
 #include "platform/devicemanager.h"
 #include <QActionGroup>

--- a/version.h.in
+++ b/version.h.in
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define MPCQT_VERSION_STR "@VERSTR@"
+
+#endif // VERSION_H


### PR DESCRIPTION
This means that only files using MPCQT_VERSION_STR will have to be rebuilt.

We used to set a build command parameter, which triggered a full rebuild on version change (like after a commit) since the switch to CMake. Qmake didn't trigger a rebuild and just showed a wrong version.

clangd will complain about version.h being not found until the first build. But clangd isn't useful until the first build anyway.