### PR TITLE
Don't use the same ui layout name twice

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1515,7 +1515,7 @@ media file played</string>
              <property name="title">
               <string>yt-dlp (web videos)</string>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_17">
+             <layout class="QVBoxLayout" name="verticalLayout_18">
               <item>
                <widget class="QLabel" name="ytdlpLabel">
                 <property name="text">


### PR DESCRIPTION
verticalLayout_17 is already used by playerLanguageBox, which causes a warning during build.

Follow-up to 7dc821b6d9de6cebef0df9194bcb788d44d447d1.