### PR TITLE
Tweak playback speed feature

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -380,14 +380,15 @@ void PlaybackManager::speedUp()
 {
     double speed = speedStepAdditive ? mpvSpeed + speedStep - 1.0
                                      : mpvSpeed * speedStep;
-    setPlaybackSpeed(std::min(8.0, speed));
+    setPlaybackSpeed(std::min(100.0, speed));
 }
 
 void PlaybackManager::speedDown()
 {
     double speed = speedStepAdditive ? mpvSpeed - speedStep + 1.0
                                      : mpvSpeed / speedStep;
-    setPlaybackSpeed(std::max(0.125, speed));
+    double minSpeed = std::max(0.01, speedStep - 1.0);
+    setPlaybackSpeed(std::max(minSpeed, speed));
 }
 
 void PlaybackManager::speedReset()

--- a/manager.h
+++ b/manager.h
@@ -223,8 +223,8 @@ private:
     double mpvTime = 0.0;
     double mpvLength = 0.0;
     double mpvSpeed = 1.0;
-    double speedStep = 2.0;
-    bool speedStepAdditive = false;
+    double speedStep = 1.25;
+    bool speedStepAdditive = true;
     bool eofReached_ = false;
     double stepTimeNormal = 5.0;
     double stepTimeLarge = 20.0;

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -744,7 +744,7 @@ void SettingsWindow::sendSignals()
     emit volumeStep(WIDGET_LOOKUP(ui->playbackVolumeStep).toInt());
     {
         int i = WIDGET_LOOKUP(ui->playbackSpeedStep).toInt();
-        emit speedStep(i > 0 ? 1.0 + i/100.0 : 2.0);
+        emit speedStep(i > 0 ? 1.0 + i/100.0 : 1.25);
         emit speedStepAdditive(WIDGET_LOOKUP(ui->playbackSpeedStepAdditive).toBool());
     }
     emit audioFilter("stereotools=balance_out=" +


### PR DESCRIPTION
Prevent the minimal speed from getting below the current speed step (with a 25% speed step, the minimal speed is 25%).
Otherwise, we wouldn't be able to get back to 100% speed when using additive speed step.

Set the default speed step to 25% (instead of 100%).
Fixes #448 (More playback speed options).

Use the full range of speed [allowed by mpv](https://mpv.io/manual/master/#options-speed) (1% speed to 100x speed).

Use additive speed step by default (reverts
4b62ed0af5ade1305312e3735354dbbe9d6eef15).
Reaching the minimal speed doesn't prevent us from getting back to 100% speed anymore.