### PR TITLE
Disable audio playback in the video preview

### DIFF
--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -24,6 +24,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("keep-open", true);
     emit mpv->ctrlSetOptionVariant("sub-visibility", "no");
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
+    emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
     emit mpv->ctrlSetOptionVariant("ytdl-format", "worst");
 


### PR DESCRIPTION
Otherwise, a second mpc-qt application entity would show up in the DE volume control "Applications" tab (at least on KDE). And when increasing/decreasing volume or muting through the taskbar controls, the volume would only decrease and mute couldn't be disabled.