### PR TITLE
Output stacktrace in log and handle SIGABRT

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Install packages
       run: |
         for i in 1 2 3; do
-          sudo apt install linguist-qt6 qt6-tools-dev qmake6 qt6-base-dev libqt6svg6-dev && break || sleep 60
+          sudo apt install linguist-qt6 qt6-tools-dev qmake6 qt6-base-dev libboost-all-dev libqt6svg6-dev && break || sleep 60
         done
         for i in 1 2 3; do
           sudo apt install devscripts equivs git libunwind-dev && break || sleep 60

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,7 +13,16 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get -y install build-essential cmake linguist-qt6 qt6-tools-dev qt6-base-dev libqt6svg6-dev libgl-dev libmpv-dev
+        sudo apt-get -y install \
+        build-essential \
+        cmake \
+        linguist-qt6 \
+        qt6-tools-dev \
+        qt6-base-dev \
+        libboost-all-dev \
+        libqt6svg6-dev \
+        libgl-dev \
+        libmpv-dev
     - uses: actions/checkout@v4
       with:
         fetch-depth: 1000
@@ -27,6 +36,7 @@ jobs:
       with:
         name: "mpc-qt"
         path: bin/mpc-qt
+
   tests:
     name: Linux
     needs: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ if(UNIX)
     )
     find_package(Qt6 REQUIRED COMPONENTS DBus)
     target_link_libraries(mpc-qt PRIVATE Qt::DBus)
+    add_compile_definitions(BOOST_STACKTRACE_USE_ADDR2LINE)
 endif()
 
 if(WIN32)


### PR DESCRIPTION
Uses addr2line, so it will only output the address on Windows.

On Linux, it will output the function names if it's not a debug build.

On Windows, drmemory's symquery can output function names, but Boost doesn't (yet?) support it.

Killing the app will also output the stacktrace in the log, which is useful in case it hangs.