### PR TITLE
Prevent assert failure in qBound call in DrawnSlider

### DIFF
--- a/widgets/drawnslider.cpp
+++ b/widgets/drawnslider.cpp
@@ -107,7 +107,9 @@ double DrawnSlider::valueToX(double value)
     double stride = sliderArea.right() - sliderArea.left();
     double x = sliderArea.left() + (((value-minimum()) * stride)
                                  / std::max(1.0, maximum() - minimum()));
-    return qBound(sliderArea.left(), x, sliderArea.right());
+    return qBound(sliderArea.left(),
+                 x,
+                 sliderArea.right() > sliderArea.left() ? sliderArea.right() : sliderArea.left());
 }
 
 double DrawnSlider::xToValue(double x)


### PR DESCRIPTION
This happens with Qt 6.9 when hiding the controls.

qBound max argument can't be lower than min argument. That assert isn't new so something changed in Qt.
DrawnSlider::valueToX is called by MediaSlider::updateLoopArea

When controls are shown back, they don't correctly fit the available space: they either overflow or let an empty space on the right.