### PR TITLE
Increase width of Open Network Stream dialog

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2342,6 +2342,7 @@ void MainWindow::on_actionFileOpenNetworkStream_triggered()
     qid->setWindowModality(Qt::WindowModal);
     qid->setWindowTitle(tr("Enter Network Stream"));
     qid->setLabelText(tr("Network Stream"));
+    qid->resize(500, qid->height());
     connect(qid, &QInputDialog::accepted, this, [=] () {
         emit streamOpened(QUrl::fromUserInput(qid->textValue()));
     });


### PR DESCRIPTION
The default width is much too narrow to show anything useful, and the size isn't remembered.