### PR TITLE
Fix Thumbnailer on Windows and center MPC-QT's name vertically

### DIFF
--- a/thumbnailerwindow.cpp
+++ b/thumbnailerwindow.cpp
@@ -259,7 +259,7 @@ void MpvThumbnailer::renderImage()
     QFontMetrics selfMetrics(selfFont);
     QString self = "MPC-QT";
     QRect selfRect = captionArea.adjusted(0, -selfMetrics.descent(),
-                                          -pageMargin, selfMetrics.descent()*2);
+                                          -pageMargin, selfMetrics.descent());
 
     // Create new image with size.
     // h = captionbottom + margin-thumbmargin + (thumb+thumbmargin)*rows


### PR DESCRIPTION
* Don't set thumbState to AvailableState in MpvThumbnailer::mpv_playTimeChanged
At least on Windows, mpv_playTimeChanged can be called with time == -1 instead of 0 when opening a new file.
When mpv_playTimeChanged then gets called again with time == 0, if thumbState != StartedState, the thumbnailing never happens.
Fixes https://github.com/mpc-qt/mpc-qt/issues/52.

* Add more logging in MpvThumbnailer::mpv_playTimeChanged

* Disable audio playback for thumbnailer

* Center MPC-QT's name vertically in thumbnails image
Prevents the bottom of the name from getting cut off. The Q still isn't whole on Windows when Helvetica isn't installed, but at least it doesn't look like a O.