### PR TITLE
Don't hide mouse cursor in resize mode on Wayland either

### DIFF
--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -659,7 +659,7 @@ void MpvObject::hideCursor()
     if (!widget)
         return;
     auto w = widget->self()->window();
-    if (w->cursor() == Qt::ArrowCursor || w->isFullScreen()
+    if (widget->self()->cursor() == Qt::ArrowCursor || w->isFullScreen()
                                        || w->isMaximized()) {
         if (qApp->platformName().contains("wayland") && !w->isActiveWindow())
             return;


### PR DESCRIPTION
On Wayland, we need to use widget->self() instead of widget->self()->window() to make sure we don't hide the resizing cursor.

Follow-up to 835ec4dd2e94e310e65550868d66992891fa3578.