### PR TITLE
Add a 1px margin at top of MediaSlider

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3146,7 +3146,7 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
                                       chapterInfo);
     if (videoPreview && isVideo_) {
         QToolTip::hideText();
-        QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), 0));
+        QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), -1));
         videoPreview->show(t, position, where, this->width());
         mpvw->update();
     } else {

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -109,7 +109,7 @@
               <number>6</number>
              </property>
              <property name="topMargin">
-              <number>0</number>
+              <number>1</number>
              </property>
              <property name="rightMargin">
               <number>6</number>

--- a/widgets/drawnslider.cpp
+++ b/widgets/drawnslider.cpp
@@ -294,7 +294,7 @@ void DrawnSlider::mouseMoveEvent(QMouseEvent *ev)
 }
 
 MediaSlider::MediaSlider(QWidget *parent) :
-    DrawnSlider(parent, QSize(11, 12), QSize(5, 3), 9)
+    DrawnSlider(parent, QSize(11, 12), QSize(5, 3), 8)
 {
 }
 


### PR DESCRIPTION
Fixes a bug in Wayland mode where the pointer sometimes stays in pointing hand mode in fullscreen even while over the video. Which also means that it then never gets hidden.

This bug was a regression caused by the combination of ac98edd434c56f1f6c35cb07788046ecf4f0fc30 and
be267c475ebe8f41c6e0e6414cdaa5399c521b24.

Also fixes a cosmetic bug with screen scaling enabled (reproduced at 125%) where the seekbar bottom border is taller than the top border.

Here's before:
![without fix 125%_crop](https://github.com/user-attachments/assets/35e1061b-8bac-42e8-b10e-dfdf6eb62c94)


And after:
![with fix 125%_crop](https://github.com/user-attachments/assets/3f6e772a-2d28-47ee-9469-a272f1a8a948)

