### PR TITLE
Upload debug symbols In Linux CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,14 +28,25 @@ jobs:
         fetch-depth: 1000
         fetch-tags: true
     - name: cmake
-      run: cmake -G Ninja -B build
+      run: cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja -B build
     - name: Build
       run: cmake --build build
-    - name: Upload
+    - name: Save, strip and link symbols
+      run: |
+        cd bin
+        objcopy --only-keep-debug mpc-qt mpc-qt.dbg
+        objcopy --strip-debug mpc-qt
+        objcopy --add-gnu-debuglink=mpc-qt.dbg mpc-qt
+    - name: Upload executable
       uses: actions/upload-artifact@v4
       with:
-        name: "mpc-qt"
+        name: "mpc-qt-x86_64"
         path: bin/mpc-qt
+    - name: Upload symbols file
+      uses: actions/upload-artifact@v4
+      with:
+        name: "mpc-qt-x86_64-debug_symbols"
+        path: bin/mpc-qt.dbg
 
   tests:
     name: Linux

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -13,6 +13,9 @@ jobs:
       uses: actions/checkout@v4
     - name: Download mpc-qt build
       uses: actions/download-artifact@v4
+      with:
+        path: mpc-qt
+        merge-multiple: true
     - name: Install packages
       run: |
         sudo apt-get update


### PR DESCRIPTION
So we can make them available to download for releases and dev builds.

By the way, we should probably upload the executable anyway because the [mpc-qt-bin AUR package](https://aur.archlinux.org/packages/mpc-qt-bin) has to download the AppImage and extract the executable.
This neither fast nor great to install a build made to run on older Ubuntu distributions.