### PR TITLE
mainwindow: Show in About if running under Wayland or XWayland/X11

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3093,11 +3093,20 @@ void MainWindow::on_actionHelpAbout_triggered()
     dateLine = "<br>" + dateLineFmt.arg(QLocale().toString(buildDate, dateFormat),
                                         QLocale().toString(buildTime, timeFormat));
 #endif
-
+QString displayMode = tr("(Unknown)");
+#if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
+    if (qApp->nativeInterface<QNativeInterface::QX11Application>())
+        displayMode = tr("XWayland or X11");
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+    else if (qApp->nativeInterface<QNativeInterface::QWaylandApplication>())
+        displayMode = "Wayland";
+#endif // is qt >= 6.5
+#endif // is Linux
     QMessageBox::about(this, tr("About Media Player Classic Qute Theater"),
       "<h2>" + tr("Media Player Classic Qute Theater") + "</h2>" +
       "<p>" +  tr("A clone of Media Player Classic written in Qt") +
       "<br>" + tr("Based on Qt %1 and %2").arg(QT_VERSION_STR, mpvObject_->mpvVersion()) +
+      (Platform::isUnix ? "<br>" + tr("Running under %1").arg(displayMode) : "") +
       "<p>" +  BUILD_VERSION_STR +
       dateLine +
       "<h3>LICENSE</h3>"

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -978,7 +978,7 @@ void MpvGlWidget::initializeGL()
     }
 #if defined(Q_OS_UNIX) && !defined(Q_OS_DARWIN)
     else if (auto x11App = qApp->nativeInterface<QNativeInterface::QX11Application>()) {
-        Logger::log("glwidget", "assigning x11 display");
+        Logger::log("glwidget", "assigning v display");
         params[2].type = MPV_RENDER_PARAM_X11_DISPLAY;
         params[2].data = x11App->display();
     }

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1372,6 +1372,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1472,6 +1472,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1472,6 +1472,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 kb/s, a: 0kb/s</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1420,6 +1420,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1372,6 +1372,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1396,6 +1396,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v&#xa0;: 0 ko/s, a&#xa0;: 0 ko/s</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1444,6 +1444,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1416,6 +1416,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1472,6 +1472,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 kb/s, a: 0kb/s</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1372,6 +1372,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1380,6 +1380,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1452,6 +1452,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 кбит/с, a: 0 кбит/с</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1472,6 +1472,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 kb/s, a: 0kb/s</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1472,6 +1472,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 kb/sn, s: 0 kb/sn</translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1444,6 +1444,18 @@
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>XWayland or X11</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Makes it easier than checking the log for "assigning [x11|wayland] display".