### PR TITLE
main: Set application name

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,6 +44,7 @@ constexpr char optConsoleLogEx[] = "--log-to-console";
 
 int main(int argc, char *argv[])
 {
+    QCoreApplication::setApplicationName("MPC-QT");
     Logger::log("main", "starting logging");
     #if !defined(Q_OS_WIN)
     std::signal(SIGHUP, signalHandler);


### PR DESCRIPTION
We use this name to advertise the name of the app when inhibiting the screensaver on Unix OSes. When not set, it defaults to the executable name.