### PR TITLE
Render tinyicon in status bar correctly with screen scaling

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,6 +27,7 @@
 using namespace Helpers;
 constexpr char SKIPACTION[] = "Skip";
 constexpr char textWindowTitle[] = "Media Player Classic Qute Theater";
+constexpr char tinyIconPath[] = ":/images/icon/tinyicon.svg";
 
 
 MainWindow::MainWindow(QWidget *parent) :
@@ -793,6 +794,7 @@ void MainWindow::setupPlaylist()
 
 void MainWindow::setupStatus()
 {
+    ui->tinyicon->setPixmap(renderPixmapFromSvg(tinyIconPath));
     timePosition = new StatusTime();
     ui->statusbarLayout->insertWidget(2, timePosition);
     timeDuration = new StatusTime();
@@ -1314,6 +1316,18 @@ QIcon MainWindow::createIconFromSvg(const QString& svgPath, int maxSize) {
         icon.addPixmap(pixmap);
     }
     return icon;
+}
+
+QPixmap MainWindow::renderPixmapFromSvg(const QString &path) {
+    QSvgRenderer renderer(path);
+    qreal devicePixelRatio = this->devicePixelRatioF();
+    int iconSize = 16;
+    QPixmap pixmap(iconSize * devicePixelRatio, iconSize * devicePixelRatio);
+    pixmap.fill(Qt::transparent);
+    QPainter painter(&pixmap);
+    renderer.render(&painter);
+    pixmap.setDevicePixelRatio(devicePixelRatio);
+    return pixmap;
 }
 
 void MainWindow::httpQuickOpenFile()

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -27,6 +27,7 @@
 using namespace Helpers;
 constexpr char SKIPACTION[] = "Skip";
 constexpr char textWindowTitle[] = "Media Player Classic Qute Theater";
+constexpr char mpcQtIconPath[] = ":/images/icon/mpc-qt.svg";
 constexpr char tinyIconPath[] = ":/images/icon/tinyicon.svg";
 
 
@@ -660,7 +661,7 @@ void MainWindow::setupTrayIcon()
     trayIcon->setContextMenu(trayMenu);
     trayIcon->setToolTip(textWindowTitle);
     Logger::log("mainwindow", "rendering trayIcon sizes");
-    trayIcon->setIcon(createIconFromSvg(QStringLiteral(":/images/icon/mpc-qt.svg"), 64));
+    trayIcon->setIcon(createIconFromSvg(mpcQtIconPath, 64));
     Logger::log("mainwindow", "rendering trayIcon sizes done");
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -116,6 +116,7 @@ private:
     QList<QUrl> doQuickOpenFileDialog();
 
     QIcon createIconFromSvg(const QString& svgPath, int maxSize);
+    QPixmap renderPixmapFromSvg(const QString &path);
 
 signals:
     void instanceShouldQuit();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -705,11 +705,7 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QLabel" name="tinyicon">
-               <property name="pixmap">
-                <pixmap resource="build/.qt/rcc/res.qrc">:/images/icon/tinyicon.svg</pixmap>
-               </property>
-              </widget>
+              <widget class="QLabel" name="tinyicon" />
              </item>
              <item>
               <widget class="QLabel" name="status">


### PR DESCRIPTION
* mainwindow: Render tinyicon in status bar correctly with screen scaling
Qt doesn't take into account the device pixel ratio when rendering it automatically.
* mainwindow: Use a constexpr for the tray icon path