### PR TITLE
Implement Player Title bar settings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -567,7 +567,7 @@ void Flow::setupMainWindowConnections()
 
     // propertieswindow -> mainwindow
     connect(propertiesWindow, &PropertiesWindow::artistAndTitleChanged,
-            mainWindow, &MainWindow::setMediaTitle);
+            mainWindow, &MainWindow::setMediaTitleWithFilename);
 
     // mainwindow -> playlistwindow
     connect(mainWindow, &MainWindow::playCurrentItemRequested,
@@ -675,6 +675,10 @@ void Flow::setupSettingsConnections()
     // settings -> mainwindow
     connect(settingsWindow, &SettingsWindow::trayIcon,
             mainWindow, &MainWindow::setTrayIcon);
+    connect(settingsWindow, &SettingsWindow::titleBarFormat,
+            mainWindow, &MainWindow::setTitleBarFormat);
+    connect(settingsWindow, &SettingsWindow::titleUseMediaTitle,
+            mainWindow, &MainWindow::setTitleUseMediaTitle);
     connect(settingsWindow, &SettingsWindow::mouseWindowedMap,
             mainWindow, &MainWindow::setWindowedMouseMap);
     connect(settingsWindow, &SettingsWindow::mouseFullscreenMap,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1668,6 +1668,16 @@ void MainWindow::setTrayIcon(bool enabled)
         trayIcon->hide();
 }
 
+void MainWindow::setTitleBarFormat(Helpers::TitlePrefix titlebarFormat)
+{
+    titlebarFormat_ = titlebarFormat;
+}
+
+void MainWindow::setTitleUseMediaTitle(bool enabled)
+{
+    titleUseMediaTitle = enabled;
+}
+
 void MainWindow::setWindowedMouseMap(const MouseStateMap &map)
 {
     mouseMapWindowed = map;
@@ -1792,13 +1802,25 @@ void MainWindow::setTime(double time, double length)
 
 void MainWindow::setMediaTitle(QString title)
 {
-    QString window_title(textWindowTitle);
+    setMediaTitleWithFilename(title, QString());
+}
 
+void MainWindow::setMediaTitleWithFilename(QString title, QString filename)
+{
+    QString window_title(textWindowTitle);
     if (freestanding_)
         window_title.append(tr(" [Freestanding]"));
-    if (!title.isEmpty())
-        window_title.prepend(" - ").prepend(title);
+
+    if (titlebarFormat_ != Helpers::NoPrefix) {
+        if (!titleUseMediaTitle && !filename.isEmpty())
+            title = filename;
+        else if (titlebarFormat_ == Helpers::PrefixFullPath)
+            title = this->currentFile.toString();
+        if (!title.isEmpty())
+            window_title.prepend(" - ").prepend(title);
+    }
     setWindowTitle(window_title);
+
     ui->title->setText(!title.isEmpty() ? title : "-");
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -229,6 +229,8 @@ public slots:
     void setFullscreenMode(bool fullscreenMode);
     void setNoVideoSize(const QSize &sz);
     void setTrayIcon(bool enabled);
+    void setTitleBarFormat(Helpers::TitlePrefix titlebarFormat);
+    void setTitleUseMediaTitle(bool enabled);
     void setWindowedMouseMap(const MouseStateMap &map);
     void setFullscreenMouseMap(const MouseStateMap &map);
     void setRecentDocuments(QList<TrackInfo> tracks);
@@ -239,6 +241,7 @@ public slots:
     void setInfoColors(const QColor &foreground, const QColor &background);
     void setTime(double time, double length);
     void setMediaTitle(QString title);
+    void setMediaTitleWithFilename(QString title, QString filename);
     void setChapterTitle(QString title);
     void setVideoSize(QSize size);
     void setVolumeStep(int stepSize);
@@ -458,6 +461,8 @@ private:
     QActionGroup* subtitleTracksGroup = nullptr;
 
     bool freestanding_ = false;
+    Helpers::TitlePrefix titlebarFormat_ = Helpers::PrefixFileName;
+    bool titleUseMediaTitle = true;
     bool mainwindowIsClosing = false; // Prevents toggleViewAction from affecting saved setting for actionViewHidePlaylist
     DecorationState decorationState_ = AllDecorations;
     QString fullscreenName;

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -155,7 +155,8 @@ void PropertiesWindow::setMetaData(QVariantMap data)
 
     metadataText = sectionText(tr("General"), data);
     if (data.contains("artist") && data.contains("title"))
-        emit artistAndTitleChanged(data["artist"].toString() + " - " + data["title"].toString());
+        emit artistAndTitleChanged(data["artist"].toString() + " - " + data["title"].toString(),
+                                   this->filename);
     updateLastTab();
 }
 

--- a/propertieswindow.h
+++ b/propertieswindow.h
@@ -19,7 +19,7 @@ public:
     ~PropertiesWindow();
 
 signals:
-    void artistAndTitleChanged(QString artistAndTitle);
+    void artistAndTitleChanged(QString artistAndTitle, QString filename);
 
 public slots:
     void setFileName(const QString &filename);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -465,7 +465,6 @@ void SettingsWindow::setupUnimplementedWidgets()
     ui->playerOSD->setVisible(false);
     ui->playerLimitProportions->setVisible(false);
     ui->playerDisableOpenDisc->setVisible(false);
-    ui->playerTitleBox->setVisible(false);
     ui->playerRememberPanScanZoom->setVisible(false);
 
     ui->formatPage->setEnabled(false);
@@ -1194,6 +1193,22 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
     restoreColorControls();
     restoreAudioSettings();
 }
+
+void SettingsWindow::on_playerTitleDisplayFullPath_clicked()
+{
+    ui->playerTitleReplaceName->setEnabled(true);
+}
+
+void SettingsWindow::on_playerTitleFileNameOnly_clicked()
+{
+    ui->playerTitleReplaceName->setEnabled(true);
+}
+
+void SettingsWindow::on_playerTitleDontPrefix_clicked()
+{
+    ui->playerTitleReplaceName->setEnabled(false);
+}
+
 
 void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state)
 {

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -219,6 +219,12 @@ private slots:
 
     void closeEvent(QCloseEvent *event) override;
 
+    void on_playerTitleDisplayFullPath_clicked();
+
+    void on_playerTitleFileNameOnly_clicked();
+
+    void on_playerTitleDontPrefix_clicked();
+
     void on_playerKeepHistory_checkStateChanged(Qt::CheckState state);
 
     void on_ccHdrMapper_currentIndexChanged(int index);


### PR DESCRIPTION
The current default behavior is kept: file name only, replaced by the title if available.
In file name (not replaced by title) mode, the title is used - when available - for network streams.