### PR TITLE
mainwindow: Rename Previous and Next Subtitle commands

### DIFF
--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -2131,7 +2131,7 @@
   </action>
   <action name="actionPlaySubtitlesPrevious">
    <property name="text">
-    <string>&amp;Previous Subtitle</string>
+    <string>&amp;Previous Subtitles track</string>
    </property>
    <property name="shortcut">
     <string notr="true">Shift+S</string>
@@ -2139,7 +2139,7 @@
   </action>
   <action name="actionPlaySubtitlesNext">
    <property name="text">
-    <string>&amp;Next Subtitle</string>
+    <string>&amp;Next Subtitles track</string>
    </property>
    <property name="shortcut">
     <string notr="true">S</string>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1033,14 +1033,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Next Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Previous Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Lo&amp;g</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1382,6 +1374,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>S&amp;egüent subtítol</translation>
+        <translation type="vanished">S&amp;egüent subtítol</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp;Anterior subtítol</translation>
+        <translation type="vanished">&amp;Anterior subtítol</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp;Nächster Untertitel</translation>
+        <translation type="vanished">&amp;Nächster Untertitel</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp;Voriger Untertitel</translation>
+        <translation type="vanished">&amp;Voriger Untertitel</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp;Next Subtitle</translation>
+        <translation type="vanished">&amp;Next Subtitle</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp;Previous Subtitle</translation>
+        <translation type="vanished">&amp;Previous Subtitle</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1109,14 +1109,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Next Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Previous Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Lo&amp;g</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1430,6 +1422,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1050,11 +1050,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp;Seuraava Tekstitys</translation>
+        <translation type="vanished">&amp;Seuraava Tekstitys</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp;Edellinen Tekstitys</translation>
+        <translation type="vanished">&amp;Edellinen Tekstitys</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1386,6 +1386,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1090,11 +1090,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>Sous-titres &amp;suivants</translation>
+        <translation type="vanished">Sous-titres &amp;suivants</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>Sous-titres &amp;précédents</translation>
+        <translation type="vanished">Sous-titres &amp;précédents</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1410,6 +1410,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1122,11 +1122,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>Takarir Selanjut&amp;nya</translation>
+        <translation type="vanished">Takarir Selanjut&amp;nya</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>Takarir Sebelumnya (&amp;p)</translation>
+        <translation type="vanished">Takarir Sebelumnya (&amp;p)</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1458,6 +1458,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1105,14 +1105,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Next Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Previous Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Lo&amp;g</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1426,6 +1418,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>次の字幕(&amp;N)</translation>
+        <translation type="vanished">次の字幕(&amp;N)</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>前の字幕(&amp;P)</translation>
+        <translation type="vanished">前の字幕(&amp;P)</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1033,14 +1033,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Next Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Previous Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Lo&amp;g</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1382,6 +1374,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1041,14 +1041,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Next Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Previous Subtitle</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Lo&amp;g</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1390,6 +1382,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp;Следующие субтитры</translation>
+        <translation type="vanished">&amp;Следующие субтитры</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp;Предыдущие субтитры</translation>
+        <translation type="vanished">&amp;Предыдущие субтитры</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1466,6 +1466,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp; அடுத்த வசன வரிகள்</translation>
+        <translation type="vanished">&amp; அடுத்த வசன வரிகள்</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>&amp; முந்தைய வசன வரிகள்</translation>
+        <translation type="vanished">&amp; முந்தைய வசன வரிகள்</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>&amp;Sonraki Altyazı</translation>
+        <translation type="vanished">&amp;Sonraki Altyazı</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>Ön&amp;ceki Altyazı</translation>
+        <translation type="vanished">Ön&amp;ceki Altyazı</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1486,6 +1486,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1130,11 +1130,11 @@
     </message>
     <message>
         <source>&amp;Next Subtitle</source>
-        <translation>下一个字幕(&amp;N)</translation>
+        <translation type="vanished">下一个字幕(&amp;N)</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitle</source>
-        <translation>上一个字幕(&amp;P)</translation>
+        <translation type="vanished">上一个字幕(&amp;P)</translation>
     </message>
     <message>
         <source>Lo&amp;g</source>
@@ -1458,6 +1458,14 @@
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Previous Subtitles track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Their names were confusing with the "Copy Subtitle" only copying the subtitle sentence(s) currently shown.
The OSD already uses the new "Subtitles track" phrasing.