### PR TITLE
Improve Player Title bar settings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -578,8 +578,8 @@ void Flow::setupMainWindowConnections()
     // manager -> mainwindow
     connect(playbackManager, &PlaybackManager::timeChanged,
             mainWindow, &MainWindow::setTime);
-    connect(playbackManager, &PlaybackManager::titleChanged,
-            mainWindow, &MainWindow::setMediaTitle);
+    connect(playbackManager, &PlaybackManager::titleChangedWithFilename,
+            mainWindow, &MainWindow::setMediaTitleWithFilename);
     connect(playbackManager, &PlaybackManager::videoSizeChanged,
             mainWindow, &MainWindow::setVideoSize);
     connect(playbackManager, &PlaybackManager::stateChanged,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1666,7 +1666,7 @@ void MainWindow::httpAfterPlaybackLock()
 void MainWindow::setFreestanding(bool freestanding)
 {
     freestanding_ = freestanding;
-    setMediaTitle(QString());
+    setMediaTitleWithFilename(QString(), QString());
 }
 
 void MainWindow::setNoVideoSize(const QSize &size)
@@ -1691,6 +1691,7 @@ void MainWindow::setTitleBarFormat(Helpers::TitlePrefix titlebarFormat)
 void MainWindow::setTitleUseMediaTitle(bool enabled)
 {
     titleUseMediaTitle = enabled;
+    setMediaTitleWithFilename(currentTitle, currentFilename);
 }
 
 void MainWindow::setWindowedMouseMap(const MouseStateMap &map)
@@ -1815,22 +1816,21 @@ void MainWindow::setTime(double time, double length)
     updateTime();
 }
 
-void MainWindow::setMediaTitle(QString title)
-{
-    setMediaTitleWithFilename(title, QString());
-}
-
 void MainWindow::setMediaTitleWithFilename(QString title, QString filename)
 {
+    currentTitle = title;
+    currentFilename = filename;
     QString window_title(textWindowTitle);
     if (freestanding_)
         window_title.append(tr(" [Freestanding]"));
 
     if (titlebarFormat_ != Helpers::NoPrefix) {
-        if (!titleUseMediaTitle && !filename.isEmpty())
-            title = filename;
-        else if (titlebarFormat_ == Helpers::PrefixFullPath)
-            title = this->currentFile.toString();
+        if (!titleUseMediaTitle) {
+            if (titlebarFormat_ == Helpers::PrefixFullPath)
+                title = this->currentFile.toString();
+            else if (!filename.isEmpty())
+                title = filename;
+        }
         if (!title.isEmpty())
             window_title.prepend(" - ").prepend(title);
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -241,7 +241,6 @@ public slots:
     void setHighContrastWidgets(bool yes);
     void setInfoColors(const QColor &foreground, const QColor &background);
     void setTime(double time, double length);
-    void setMediaTitle(QString title);
     void setMediaTitleWithFilename(QString title, QString filename);
     void setChapterTitle(QString title);
     void setVideoSize(QSize size);
@@ -507,6 +506,8 @@ private:
     double videoBitrate = 0;
     double panScan = 0;
     QUrl currentFile;
+    QString currentFilename;
+    QString currentTitle;
 
     IconThemer themer;
     QList<QAction *> menuFavoritesTail;

--- a/manager.cpp
+++ b/manager.cpp
@@ -940,6 +940,8 @@ void PlaybackManager::mpvw_mediaTitleChanged(QString title)
 {
     nowPlayingTitle = title;
     emit titleChanged(title);
+    emit titleChangedWithFilename(title,
+                                  nowPlaying().isLocalFile() ? nowPlaying().fileName() : QString());
 }
 
 void PlaybackManager::mpvw_chaptersChanged(QVariantList chapters)

--- a/manager.h
+++ b/manager.h
@@ -63,6 +63,7 @@ signals:
     void timeChanged(double time, double length);
     void playLengthChanged();
     void titleChanged(QString title);
+    void titleChangedWithFilename(QString title, QString filename);
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
     void stateChanged(PlaybackManager::PlaybackState state);


### PR DESCRIPTION
Makes the filename options work for videos.
Makes the "Display full path" setting work.
Updates the title bar when saving options instead of on next file load.

Follow-up to 221cb40b06d2caa745d8ae276add20eaff307627.