### PR TITLE
Silence some warnings

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -289,7 +289,8 @@ QString Helpers::toDateFormatFixed(double time, Helpers::TimeFormat format)
 
 QDate Helpers::dateFromCFormat(const char date[])
 {
-    QStringList dates = QString(date).simplified().split(QRegularExpression("\\s+"));
+    static auto regexp = QRegularExpression("\\s+");
+    QStringList dates = QString(date).simplified().split(regexp);
     QStringList months = { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
                            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" };
     QDate d(dates[2].toInt(), months.indexOf(dates[0])+1, dates[1].toInt());
@@ -306,7 +307,7 @@ QTime Helpers::timeFromCFormat(const char time[])
 double Helpers::fromDateFormat(QString date)
 {
     QStringList times = date.split(':');
-    for (auto time : times) {
+    for (auto &time : std::as_const(times)) {
         if (time.toDouble() >= 60)
             return -1;
     }
@@ -575,7 +576,8 @@ QVariantMap Helpers::rectToVmap(const QRect &r) {
 template <class T>
 bool pairFromString(T &result, const QString &text)
 {
-    QStringList parts = text.split(QRegularExpression("[^\\d]+"));
+    static auto regexp = QRegularExpression("[^\\d]+");
+    QStringList parts = text.split(regexp);
     int a, b;
     if (parts.length() != 2)
         return false;

--- a/ipc/json.cpp
+++ b/ipc/json.cpp
@@ -168,7 +168,7 @@ void MpcQtServer::self_newConnection(QLocalSocket *socket)
 
     connect(socket, &QLocalSocket::readyRead, this, [=]() {
         QList<QByteArray> dataList = socket->readAll().split('\n');
-        for (const QByteArray &data : dataList) {
+        for (const QByteArray &data : std::as_const(dataList)) {
             if(data.size())
                 socket_payloadReceived(data, socket);
         }
@@ -212,7 +212,7 @@ void MpcQtServer::ipc_playFiles(const QVariantMap &map)
     QStringList filesAsText = map["files"].toStringList();
     bool important = !map.value("append", false).toBool();
     QList<QUrl> files;
-    for (const QString &s : filesAsText) {
+    for (const QString &s : std::as_const(filesAsText)) {
         files << QUrl::fromUserInput(s, workingDirectory);
     }
     if (!files.empty()) {

--- a/ipc/mpris.cpp
+++ b/ipc/mpris.cpp
@@ -459,7 +459,7 @@ bool MprisPlayerServer::maybeChangeMetadata()
 
     auto trackMangle = [](QString &key, QVariant &value) -> bool {
         key = "track";
-        QRegularExpression re("\\d+");
+        static QRegularExpression re("\\d+");
         value = re.match(value.toString()).captured().toInt();
         return true;
     };

--- a/logger.cpp
+++ b/logger.cpp
@@ -6,7 +6,12 @@
 class StdFileCopy {
 public:
     StdFileCopy(FILE *fp) {
-        ptr = fdopen(dup(fileno(fp)), "wt");
+        int handle = dup(fileno(fp));
+        if (handle == -1) {
+            ptr = fp;
+            return;
+        }
+        ptr = fdopen(handle, "wt");
         fclose(fp);
     }
     ~StdFileCopy() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1733,10 +1733,10 @@ void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDu
         Helpers::ControlHiding method = static_cast<Helpers::ControlHiding>(showWhen);
         if (method == Helpers::ShowWhenMoving && !showWhenDuration) {
             setBottomAreaBehavior(Helpers::ShowWhenHovering);
-            emit setBottomAreaHideTime(0);
+            setBottomAreaHideTime(0);
         } else {
             setBottomAreaBehavior(method);
-            emit setBottomAreaHideTime(showWhenDuration);
+            setBottomAreaHideTime(showWhenDuration);
         }
     } else
         setBottomAreaBehavior(Helpers::AlwaysShow);
@@ -2068,7 +2068,7 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
     ui->menuPlayAudio->addSeparator();
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackPrevious);
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackNext);
-    audioTracksGroup->actions()[0]->setChecked(true);
+    audioTracksGroup->actions().constFirst()->setChecked(true);
 }
 
 void MainWindow::setVideoTracks(QList<Track> tracks)
@@ -2103,7 +2103,7 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
     ui->menuPlayVideoPanScan->addAction(ui->actionIncreasePanScan);
     ui->menuPlayVideoPanScan->addAction(ui->actionMinPanScan);
     ui->menuPlayVideoPanScan->addAction(ui->actionMaxPanScan);
-    videoTracksGroup->actions()[0]->setChecked(true);
+    videoTracksGroup->actions().constFirst()->setChecked(true);
     updateOnTop();
 }
 
@@ -2139,7 +2139,7 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesCopy);
     ui->menuPlaySubtitles->addAction(ui->actionDecreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addAction(ui->actionIncreaseSubtitlesDelay);
-    subtitleTracksGroup->actions()[0]->setChecked(true);
+    subtitleTracksGroup->actions().constFirst()->setChecked(true);
 }
 
 void MainWindow::audioTrackSet(int64_t id)
@@ -2147,7 +2147,7 @@ void MainWindow::audioTrackSet(int64_t id)
     if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length()) {
         if (id <= 0)
             id = audioTracksGroup->actions().length();
-        audioTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+        audioTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
 
@@ -2156,7 +2156,7 @@ void MainWindow::videoTrackSet(int64_t id)
     if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length()) {
         if (id <= 0)
             id = videoTracksGroup->actions().length();
-        videoTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+        videoTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
 
@@ -2165,7 +2165,7 @@ void MainWindow::subtitleTrackSet(int64_t id)
     if (subtitleTracksGroup != nullptr && id <= subtitleTracksGroup->actions().length()) {
         if (id <= 0)
             id = subtitleTracksGroup->actions().length();
-        subtitleTracksGroup->actions()[static_cast <int> (id) -1]->setChecked(true);
+        subtitleTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
 
@@ -2667,7 +2667,6 @@ void MainWindow::on_actionViewOSDInputCacheStats_triggered()
 
 void MainWindow::on_actionViewOSDCycle_triggered()
 {
-    QActionGroup *osdActionGroup = ui->actionViewOSDMessages->actionGroup();
     QAction *nextOsdAction;
     int newpage;
 

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -689,7 +689,7 @@ void MpvObject::ctrl_mpvPropertyChanged(QString name, QVariant v)
 {
     QVariant vForLog = v;
     // Don't show more than 3 decimals or none if those are zero
-    if (vForLog.typeId() == QVariant::Double) {
+    if (vForLog.typeId() == QMetaType::Double) {
         vForLog = QString("%1").arg(QString::number(vForLog.toDouble(), 'f', 3));
         if (vForLog.toString().section('.', 1) == "000")
             vForLog = vForLog.toString().section('.', 0, 0);

--- a/openfiledialog.cpp
+++ b/openfiledialog.cpp
@@ -2,7 +2,6 @@
 #include "helpers.h"
 #include "openfiledialog.h"
 #include "ui_openfiledialog.h"
-#include "logger.h"
 
 OpenFileDialog::OpenFileDialog(QWidget *parent) :
     QDialog(parent),

--- a/playlist.cpp
+++ b/playlist.cpp
@@ -557,7 +557,7 @@ void Playlist::fromVMap(const QVariantMap &qvm)
     nowPlaying_ = qvm.contains(keyNowPlaying) ? qvm[keyNowPlaying].toUuid() : nowPlaying_;
     if (qvm.contains(keyItems)) {
         auto items = qvm[keyItems].toList();
-        for (const QVariant &v : items) {
+        for (const QVariant &v : std::as_const(items)) {
             QSharedPointer<Item> i(new Item());
             i->setPlaylistUuid(playlistUuid_);
             i->fromVMap(v.toMap());
@@ -586,7 +586,7 @@ PlaylistItem QueuePlaylist::first()
     QReadLocker lock(&listLock);
     if (items.isEmpty())
         return { QUuid(), QUuid() };
-    return { items.first()->playlistUuid(), items.first()->uuid() };
+    return { items.constFirst()->playlistUuid(), items.constFirst()->uuid() };
 }
 
 PlaylistItem QueuePlaylist::takeFirst()
@@ -802,7 +802,7 @@ QSharedPointer<QueuePlaylist> PlaylistCollection::queuePlaylist()
 
 void PlaylistCollection::iteratePlaylists(const std::function<void (QSharedPointer<Playlist>)> &callback)
 {
-    for (const auto &p : playlists) {
+    for (const auto &p : std::as_const(playlists)) {
         callback(p);
     }
 }
@@ -886,7 +886,7 @@ void PlaylistCollection::fromVList(const QVariantList &data)
 QVariantList PlaylistCollection::toVList()
 {
     QVariantList l;
-    for (const auto &p : playlists) {
+    for (const auto &p : std::as_const(playlists)) {
         l.append(p->toVMap());
     }
     return l;

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1321,7 +1321,7 @@ void SettingsWindow::on_shadersAddToShaders_clicked()
 {
     QList<QListWidgetItem *> items = ui->shadersFileList->selectedItems();
     QStringList files;
-    for (auto item : items)
+    for (auto item : std::as_const(items))
         files.append(item->text());
     ui->shadersActiveList->addItems(files);
 }


### PR DESCRIPTION
Silence some warnings by marking some things as const.  Properly handle the case of dup() failing.  In some places, clazy still complains about for(a:b) possibly detaching containers because the usual fix (wrapping b in std::as_const()) has been deleted and cannot be applied.  So it seems there are some false positives, but such is the nature of these checks.

Follow up to #508.