### PR TITLE
Add pre-defined audio and video filters support

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -656,10 +656,6 @@ void Flow::setupManagerConnections()
     connect(playbackManager, &PlaybackManager::currentTrackInfo,
             favoritesWindow, &FavoritesWindow::addTrack);
 
-    // manager -> settings
-    connect(playbackManager, &PlaybackManager::playerSettingsRequested,
-            settingsWindow, &SettingsWindow::sendSignals);
-
     // goto -> manager
     connect(gotoWindow, &GoToWindow::goTo,
             playbackManager, &PlaybackManager::navigateToTime);

--- a/main.cpp
+++ b/main.cpp
@@ -671,6 +671,10 @@ void Flow::setupSettingsConnections()
     // mainwindow -> settings
     connect(mainWindow, &MainWindow::zoomPresetChanged,
             settingsWindow, &SettingsWindow::setZoomPreset);
+    connect(mainWindow, &MainWindow::audioFilter,
+            settingsWindow, &SettingsWindow::setAudioFilter);
+    connect(mainWindow, &MainWindow::videoFilter,
+            settingsWindow, &SettingsWindow::setVideoFilter);
 
     // settings -> mainwindow
     connect(settingsWindow, &SettingsWindow::trayIcon,
@@ -787,8 +791,10 @@ void Flow::setupMpvObjectConnections()
             mpvObject, &MpvObject::setLogoUrl);
     connect(settingsWindow, &SettingsWindow::option,
             mpvObject, &MpvObject::setCachedMpvOption);
-    connect(settingsWindow, &SettingsWindow::audioFilter,
-            mpvObject, &MpvObject::setAudioFilter);
+    connect(settingsWindow, &SettingsWindow::audioFilters,
+            mpvObject, &MpvObject::setAudioFilters);
+    connect(settingsWindow, &SettingsWindow::videoFilters,
+            mpvObject, &MpvObject::setVideoFilters);
     connect(settingsWindow, &SettingsWindow::clientDebuggingMessages,
             mpvObject, &MpvObject::setClientDebuggingMessages);
     connect(settingsWindow, &SettingsWindow::mpvLogLevel,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -181,6 +181,8 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionViewOntopPlaying) },
         { WRAP(ui->actionViewOntopVideo) },
         { WRAP(ui->actionViewFullscreen) },
+        { WRAP(ui->actionAudioFilterExtrastereo) },
+        { WRAP(ui->actionAudioFilterAcompressor) },
         { WRAP(ui->actionPlaySubtitlesEnabled) },
         { WRAP(ui->actionPlayVolumeMute) },
         { "volume", volumeSlider_->value() },
@@ -213,9 +215,13 @@ void MainWindow::setState(const QVariantMap &map)
     UNWRAP(ui->actionViewOntopPlaying, false);
     UNWRAP(ui->actionViewOntopVideo, false);
     UNWRAP(ui->actionViewFullscreen, false);
+    UNWRAP(ui->actionAudioFilterExtrastereo, false);
+    UNWRAP(ui->actionAudioFilterAcompressor, false);
     UNWRAP(ui->actionPlaySubtitlesEnabled, true);
     UNWRAP(ui->actionPlayVolumeMute, false);
 
+    ui->actionAudioFilterExtrastereo->isChecked() ? on_actionAudioFilterExtrastereo_triggered(true) : qt_noop();
+    ui->actionAudioFilterAcompressor->isChecked() ? on_actionAudioFilterAcompressor_triggered(true) : qt_noop();
     setSubtitlesEnabled(ui->actionPlaySubtitlesEnabled->isChecked(), true);
     on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked(), true);
     setVolume(map.value("volume", 100).toInt(), true);
@@ -2066,6 +2072,9 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
         ui->menuPlayAudio->addAction(action);
     }
     ui->menuPlayAudio->addSeparator();
+    ui->menuPlayAudio->addMenu(ui->menuPlayAudioFilters);
+    ui->menuPlayAudioFilters->addAction(ui->actionAudioFilterExtrastereo);
+    ui->menuPlayAudioFilters->addAction(ui->actionAudioFilterAcompressor);
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackPrevious);
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackNext);
     audioTracksGroup->actions().constFirst()->setChecked(true);
@@ -2093,6 +2102,8 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
         ui->menuPlayVideo->addAction(action);
     }
     ui->menuPlayVideo->addSeparator();
+    ui->menuPlayVideo->addMenu(ui->menuPlayVideoFilters);
+    ui->menuPlayVideoFilters->addAction(ui->actionVideoFilterDeinterlace);
     ui->menuPlayVideo->addMenu(ui->menuPlayVideoAspect);
     ui->menuPlayVideoAspect->addAction(ui->actionDecreaseVideoAspect);
     ui->menuPlayVideoAspect->addAction(ui->actionIncreaseVideoAspect);
@@ -2941,6 +2952,25 @@ void MainWindow::on_actionPlaySeekBackwardsLarge_triggered()
 {
     emit relativeSeek(false, true);
     showOsdTimer(true);
+}
+
+void MainWindow::on_actionAudioFilterExtrastereo_triggered(bool checked)
+{
+    emit audioFilter("extrastereo", "", checked);
+}
+
+void MainWindow::on_actionAudioFilterAcompressor_triggered(bool checked)
+{
+    emit audioFilter("acompressor", "", checked);
+}
+
+void MainWindow::on_actionVideoFilterDeinterlace_triggered(bool checked)
+{
+    // Deinterlacing doesn't work with hardware acceleration
+    if (checked)
+        mpvObject_->setCachedMpvOption("hwdec", "no");
+
+    emit videoFilter("yadif", "mode=1", checked);
 }
 
 void MainWindow::on_actionPlayAudioTrackNext_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -173,6 +173,8 @@ signals:
     void fullscreenHideControls(bool checked);
     void timeShortModeSet(bool timeShortMode);
     void repeatAfter();
+    void audioFilter(QString filter, QString options, bool add);
+    void videoFilter(QString filter, QString options, bool add);
 
 public slots:
     void httpQuickOpenFile();
@@ -380,6 +382,11 @@ private slots:
     void on_actionPlaySeekBackwardsNormal_triggered();
     void on_actionPlaySeekForwardsLarge_triggered();
     void on_actionPlaySeekBackwardsLarge_triggered();
+
+    void on_actionAudioFilterExtrastereo_triggered(bool checked);
+    void on_actionAudioFilterAcompressor_triggered(bool checked);
+
+    void on_actionVideoFilterDeinterlace_triggered(bool checked);
 
     void on_actionPlayAudioTrackNext_triggered();
     void on_actionPlayAudioTrackPrevious_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -879,6 +879,13 @@
      <property name="title">
       <string>&amp;Audio</string>
      </property>
+     <widget class="QMenu" name="menuPlayAudioFilters">
+      <property name="title">
+       <string>&amp;Filters</string>
+      </property>
+      <addaction name="actionAudioFilterExtrastereo"/>
+      <addaction name="actionAudioFilterAcompressor"/>
+     </widget>
      <addaction name="actionPlayAudioTrackPrevious"/>
      <addaction name="actionPlayAudioTrackNext"/>
     </widget>
@@ -898,6 +905,12 @@
      <property name="title">
       <string>&amp;Video</string>
      </property>
+     <widget class="QMenu" name="menuPlayVideoFilters">
+      <property name="title">
+       <string>&amp;Filters</string>
+      </property>
+      <addaction name="actionVideoFilterDeinterlace"/>
+     </widget>
      <widget class="QMenu" name="menuPlayVideoAspect">
       <property name="title">
        <string>&amp;Aspect ratio</string>
@@ -2099,6 +2112,22 @@
     <string notr="true">`</string>
    </property>
   </action>
+  <action name="actionAudioFilterExtrastereo">
+   <property name="text">
+    <string>&amp;Extra Stereo</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </action>
+  <action name="actionAudioFilterAcompressor">
+   <property name="text">
+    <string>&amp;Compressor</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </action>
   <action name="actionPlayAudioTrackPrevious">
    <property name="text">
     <string>&amp;Previous Audio Track</string>
@@ -2159,6 +2188,14 @@
    </property>
    <property name="shortcut">
     <string notr="true">F2</string>
+   </property>
+  </action>
+  <action name="actionVideoFilterDeinterlace">
+   <property name="text">
+    <string>&amp;Deinterlace</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
    </property>
   </action>
   <action name="actionDecreaseVideoAspect">

--- a/manager.cpp
+++ b/manager.cpp
@@ -881,7 +881,6 @@ void PlaybackManager::mpvw_playbackStarted()
 {
     playbackState_ = playbackStartState;
     emit stateChanged(playbackState_);
-    emit playerSettingsRequested();
 }
 
 void PlaybackManager::mpvw_pausedChanged(bool yes)

--- a/manager.h
+++ b/manager.h
@@ -59,7 +59,6 @@ public:
     bool eofReached();
 
 signals:
-    void playerSettingsRequested();
     void timeChanged(double time, double length);
     void playLengthChanged();
     void titleChanged(QString title);

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -406,12 +406,24 @@ void MpvObject::setLogoBackground(const QColor &color)
         widget->setLogoBackground(color);
 }
 
-void MpvObject::setAudioFilter(QString filter, bool add)
+void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersList)
 {
-    if (add)
-        setMpvPropertyVariant("af", filter);
-    else
-        setMpvPropertyVariant("af", "");
+    emit ctrlCommand("no-osd af set \"" + formatFiltersList(filtersList) + "\"");
+}
+
+void MpvObject::setVideoFilters(const QList<QPair<QString, QString>> &filtersList)
+{
+    emit ctrlCommand("no-osd vf set \"" + formatFiltersList(filtersList) + "\"");
+}
+
+QString MpvObject::formatFiltersList(const QList<QPair<QString, QString>> &filtersList)
+{
+    QString filters;
+    for (auto filterPair : filtersList) {
+        filters.append(filterPair.first).append("=").append(filterPair.second).append(",");
+    }
+    filters.chop(1);
+    return filters;
 }
 
 void MpvObject::setSubFile(QString filename)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -64,7 +64,9 @@ public:
     void setMouseHideTime(int msec);
     void setLogoUrl(const QString &filename);
     void setLogoBackground(const QColor &color);
-    void setAudioFilter(QString filter, bool add);
+    void setAudioFilters(const QList<QPair<QString, QString>> &filtersList);
+    void setVideoFilters(const QList<QPair<QString, QString>> &filtersList);
+    QString formatFiltersList(const QList<QPair<QString, QString>> &filtersList);
     void setSubFile(QString filename);
     void addSubFile(QString filename);
     void setSubtitlesDelay(int subDelayStep);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -746,7 +746,7 @@ void SettingsWindow::sendSignals()
         emit speedStep(i > 0 ? 1.0 + i/100.0 : 1.25);
         emit speedStepAdditive(WIDGET_LOOKUP(ui->playbackSpeedStepAdditive).toBool());
     }
-    emit audioFilter("stereotools=balance_out=" +
+    setAudioFilter("stereotools", "balance_out=" +
         QString().number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
     emit stepTimeNormal(WIDGET_LOOKUP(ui->playbackNormalStep).toInt());
     emit stepTimeLarge(WIDGET_LOOKUP(ui->playbackLargeStep).toInt());
@@ -1121,6 +1121,37 @@ void SettingsWindow::setHidePanels(bool hidden)
     emit settingsData(acceptedSettings.toVMap());
 }
 
+void SettingsWindow::setAudioFilter(QString filter, QString options, bool add)
+{
+    setFilter(audioFiltersList, filter, options, add);
+    emit audioFilters(audioFiltersList);
+}
+
+void SettingsWindow::setVideoFilter(QString filter, QString options, bool add)
+{
+    setFilter(videoFiltersList, filter, options, add);
+    emit videoFilters(videoFiltersList);
+}
+
+void SettingsWindow::setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add)
+{
+    auto it = std::find_if(filtersList.begin(),
+                                     filtersList.end(),
+                                     [&](const QPair<QString, QString> &pair) {
+        return pair.first == filter;
+    });
+
+    if (it != filtersList.end()) { // Filter found
+        int i = std::distance(filtersList.begin(), it);
+        if (add)
+            filtersList.replace(i, QPair<QString, QString>(filter, options));
+        else
+            filtersList.erase(it);
+    }
+    else
+        filtersList.append(QPair<QString, QString>(filter, options));
+}
+
 void SettingsWindow::restoreColorControls()
 {
     emit option("brightness", acceptedSettings.value("miscBrightness").value.toInt());
@@ -1131,7 +1162,7 @@ void SettingsWindow::restoreColorControls()
 }
 void SettingsWindow::restoreAudioSettings()
 {
-    emit audioFilter("stereotools=balance_out=" +
+    setAudioFilter("stereotools", "balance_out=" +
         QString().number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
 }
 
@@ -1351,7 +1382,7 @@ void SettingsWindow::on_fullscreenHideControls_toggled(bool checked)
 void SettingsWindow::on_audioBalance_valueChanged(int value)
 {
     QToolTip::showText(QCursor::pos(), QString().number(value), ui->audioBalance);
-    emit audioFilter("stereotools=balance_out=" + QString().number((double) value/100), true);
+    setAudioFilter("stereotools", "balance_out=" + QString().number((double) value/100), true);
 }
 
 void SettingsWindow::on_playbackAutoZoom_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -188,8 +188,8 @@ signals:
     void logDelay(int msecs);
     void logHistory(int lines);
 
-    void videoFilter(const QString &s);
-    void audioFilter(QString filter, const bool add);
+    void audioFilters(const QList<QPair<QString, QString>> &audioFiltersList);
+    void videoFilters(const QList<QPair<QString, QString>> &videoFiltersList);
 
 public slots:
     void takeActions(const QList<QAction*> actions);
@@ -197,6 +197,8 @@ public slots:
     void takeKeyMap(const QVariantMap &payload);
     void setMouseMapDefaults(const QVariantMap &payload);
     void setAudioDevices(const QList<AudioDevice> &devices);
+    void setAudioFilter(QString filter, QString options, bool add);
+    void setVideoFilter(QString filter, QString options, bool add);
     void sendSignals();
     void sendAcceptedSettings();
 
@@ -208,6 +210,7 @@ public slots:
     void setHidePanels(bool hidden);
 
 private slots:
+    void setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add);
     void restoreColorControls();
     void restoreAudioSettings();
     void colorPick_clicked(QLineEdit *colorValue);
@@ -325,6 +328,8 @@ private:
     QVariantMap acceptedKeyMap;
     QVariantMap defaultKeyMap;
     QList<AudioDevice> audioDevices;
+    QList<QPair<QString, QString>> audioFiltersList;
+    QList<QPair<QString, QString>> videoFiltersList;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1384,6 +1384,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation>&amp;Next Subtitles track</translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1432,6 +1432,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1396,6 +1396,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1420,6 +1420,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1468,6 +1468,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1428,6 +1428,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1384,6 +1384,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1392,6 +1392,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1476,6 +1476,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1496,6 +1496,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1468,6 +1468,22 @@
         <source>&amp;Next Subtitles track</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Filters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Deinterlace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Extra Stereo</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Compressor</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
* Add pre-defined audio and video filters support
Adds:
 2 ffmpeg audio filters: extrastereo (adds some sort of "live" effect to playback by increasing the stereo effect) and acompressor (audio dynamic range compressor). Their state is kept across sessions.
 1 ffmpeg video filter: yadif (deinterlacer) in the mode that doubles the framerate instead of discarding half the frames. Its state isn't kept across sessions. It doesn't work when hardware acceleration is enabled, so we temporarily disable it.

Using the mpv commands to add and remove single filters didn't work, so the filter set command is used instead and the filters state is also kept on our side.

Fixes https://github.com/mpc-qt/mpc-qt/issues/327 (Extrastereo ffmpeg audio filter support).
* manager: Don't request the settings signals on file load
We temporarily disable hardware decoding in MainWindow::on_actionVideoFilterDeinterlace_triggered to make software deinterlacing work.
But this gets reset in SettingsWindow::sendSignals(), which sends the settings signals.
Though this function is already called when saving settings, so it shouldn't be needed to call it again on each file load.

That signal was added in https://github.com/mpc-qt/mpc-qt/commit/963091464d2735fbe6f368d80c3e07da629d1dfe.
The signals requested from settings in that commit were rewired to mpvwidget in https://github.com/mpc-qt/mpc-qt/commit/1c37ef3a554cf5af6b976e6941d414a2cc761ad5 so this playerSettingsRequested() signal is probably useless now and shouldn't cause a regression.

Follow-up to f8c35f2b678918e969c6b2b99f997fed0463e9c3.