### PR TITLE
Add support for custom mpv options

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1061,6 +1061,12 @@ void SettingsWindow::sendSignals()
     emit option("gamma", WIDGET_LOOKUP(ui->miscGamma).toInt());
     emit option("hue", WIDGET_LOOKUP(ui->miscHue).toInt());
     emit option("saturation", WIDGET_LOOKUP(ui->miscSaturation).toInt());
+    if (ui->tweaksMpvOptionsText->isEnabled()) {
+        QList<MpvOption> mpvOptions = parseMpvOptions(ui->tweaksMpvOptionsText->text());
+        for (const auto &mpvOption : mpvOptions) {
+            emit option(mpvOption.name, mpvOption.value);
+        }
+    }
 }
 
 void SettingsWindow::sendAcceptedSettings()
@@ -1180,6 +1186,23 @@ void SettingsWindow::colorPick_clicked(QLineEdit *colorValue)
 void SettingsWindow::colorPick_changed(QLineEdit *colorValue, QPushButton *colorPick)
 {
     colorPick->setStyleSheet(QString("background: #%1").arg(colorValue->text()));
+}
+
+QList<MpvOption> SettingsWindow::parseMpvOptions(const QString& optionsInline)
+{
+    QList<MpvOption> mpvOptions;
+    const QStringList options = optionsInline.split(' ', Qt::SkipEmptyParts);
+    for (const QString& option : options) {
+        int equalPos = option.indexOf('=');
+        if (equalPos > 0) {
+            QString name = option.left(equalPos).trimmed();
+            QString value = option.mid(equalPos + 1).trimmed();
+            mpvOptions.append(MpvOption{name, value});
+        } else {
+            mpvOptions.append(MpvOption{option.trimmed(), QString()});
+        }
+    }
+    return mpvOptions;
 }
 
 void SettingsWindow::on_pageTree_itemSelectionChanged()
@@ -1448,6 +1471,11 @@ void SettingsWindow::on_tweaksOsdFontChkBox_toggled(bool checked)
 {
     ui->tweaksOsdFont->setEnabled(checked);
     ui->tweaksOsdSize->setEnabled(checked);
+}
+
+void SettingsWindow::on_tweaksMpvOptionsChkBox_toggled(bool checked)
+{
+    ui->tweaksMpvOptionsText->setEnabled(checked);
 }
 
 void SettingsWindow::on_loggingEnabled_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -43,6 +43,11 @@ public:
     void fromVMap(const QVariantMap &m);
 };
 
+struct MpvOption {
+    QString name;
+    QString value;
+};
+
 namespace Ui {
 class SettingsWindow;
 }
@@ -215,6 +220,7 @@ private slots:
     void restoreAudioSettings();
     void colorPick_clicked(QLineEdit *colorValue);
     void colorPick_changed(QLineEdit *colorValue, QPushButton *colorPick);
+    QList<MpvOption> parseMpvOptions(const QString& optionsInline);
 
     void on_pageTree_itemSelectionChanged();
 
@@ -289,6 +295,8 @@ private slots:
     void on_tweaksTimeTooltip_toggled(bool checked);
 
     void on_tweaksOsdFontChkBox_toggled(bool checked);
+
+    void on_tweaksMpvOptionsChkBox_toggled(bool checked);
 
     void on_loggingEnabled_toggled(bool checked);
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7821,6 +7821,37 @@ media file played</string>
              </item>
             </layout>
            </item>
+           <item row="13" column="0">
+            <layout class="QHBoxLayout" name="tweaksMpvOptionsLayout" stretch="1">
+             <item>
+              <widget class="QCheckBox" name="tweaksMpvOptionsChkBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Custom mpv options:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="13" column="1">
+            <layout class="QHBoxLayout" name="tweaksMpvOptionsTextLayout" stretch="1,0">
+             <item>
+              <widget class="QLineEdit" name="tweaksMpvOptionsText">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="placeholderText">
+                <string notr="true">hwdec=auto interpolation=yes</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
           </layout>
          </widget>
          <widget class="QWidget" name="loggingPage">

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4086,6 +4086,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4218,6 +4218,10 @@ arxiu multimèdia reproduït</translation>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4214,6 +4214,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4218,6 +4218,10 @@ media file played</translation>
         <source>Max video height:</source>
         <translation>Max video height:</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4130,6 +4130,10 @@ archivo multimedia reproducido</translation>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4036,6 +4036,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4138,6 +4138,10 @@ fichier média lu</translation>
         <source>Max video height:</source>
         <translation>Hauteur maximale des vidéos&#xa0;:</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4118,6 +4118,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4098,6 +4098,10 @@ ogni file multimediale riprodotto</translation>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4218,6 +4218,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation>ビデオの最大高さ :</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4062,6 +4062,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4094,6 +4094,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4190,6 +4190,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation>Максимальная высота видео:</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4218,6 +4218,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation>அதிகபட்ச வீடியோ உயரம்:</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4210,6 +4210,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Max video height:</source>
         <translation>En çok video yüksekliği:</translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4116,6 +4116,10 @@ media file played</source>
         <source>Max video height:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
In Tweaks, options entered as option_name=value with a space between different options.
These custom options override all other options with the same name.
I haven't found a way to left align the checkbox and text (same thing for the "Show time tooltip" and "Change OSD font" settings).