### PR TITLE
mainwindow: Use 1 to 20 numbering for recent files

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1721,7 +1721,7 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
     for (int i = 0; i < tracks.count() && i < 20; i++) {
         TrackInfo track = tracks[i];
         QString displayString = track.url.fileName();
-        QAction *a = new QAction(QString("%1 - %2").arg(i).arg(displayString),
+        QAction *a = new QAction(QString("%1 - %2").arg(i + 1).arg(displayString),
                                  this);
         connect(a, &QAction::triggered, this, [=]() {
             emit recentOpened(track, true);


### PR DESCRIPTION
This is purely cosmetic, but users probably start counting from 1 instead of 0.