### PR TITLE
Disable mpv native clipboard support

### DIFF
--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -137,7 +137,8 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "ytdl", "yes" },
         { "audio-client-name", clientName },
         { "load-scripts", true },
-        { "scripts", scripts }
+        { "scripts", scripts },
+        { "clipboard-backends", "clr" }
     };
     QMetaObject::invokeMethod(ctrl, "create", Qt::BlockingQueuedConnection,
                               Q_ARG(MpvController::OptionList, earlyOptions));

--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -27,6 +27,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
     emit mpv->ctrlSetOptionVariant("ytdl-format", "worst");
+    emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 
     connect(mpv, &MpvObject::aspectChanged,
             this, &VideoPreview::updateWidth);


### PR DESCRIPTION
It doesn't make sense to have this enabled for libmpv in the first place.
And this triggers a bug in mpv 0.40.

Fixes #518 (CPU 100% When Copying Files in KDE while mpc-qt is open in either Wayland or XWayland).