### PR TITLE
Add 'Move File to Trash' feature

### DIFF
--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -458,6 +458,7 @@ void MpcHcServer::setupWmCommands()
         { 894, "Decreate Rate",             [&](){ emit decreaseRate(); } },
         { 920, "Next File",                 [&](){ emit nextFile(false); } },
         { 919, "Previous File",             [&](){ emit previousFile(false); } },
+        { 921, "Move to Recycle Bin",       [&](){ emit moveToRecycleBin(); } },
         { 975, "Quick add favorite",        [&](){ emit quickAddFavorite(); } },
         { 937, "Organize Favorites...",     [&](){ emit organizeFavorites(); } },
         { 817, "Toggle Caption&amp;Menu",   [&](){ emit toggleCaptionMenu(); } },

--- a/ipc/http.h
+++ b/ipc/http.h
@@ -113,6 +113,7 @@ signals:
     void decreaseRate();
     void nextFile(bool forceFolderFallback);
     void previousFile(bool forceFolderFallback);
+    void moveToRecycleBin();
     void quickAddFavorite();
     void organizeFavorites();
     void toggleCaptionMenu();

--- a/main.cpp
+++ b/main.cpp
@@ -550,6 +550,8 @@ void Flow::setupMainWindowConnections()
             playbackManager, &PlaybackManager::playPrev);
     connect(mainWindow, &MainWindow::fileNext,
             playbackManager, &PlaybackManager::playNext);
+    connect(mainWindow, &MainWindow::moveToRecycleBin,
+            playbackManager, &PlaybackManager::moveToRecycleBin);
     connect(mainWindow, &MainWindow::chapterSelected,
             playbackManager, &PlaybackManager::navigateToChapter);
     connect(mainWindow, &MainWindow::timeSelected,
@@ -612,6 +614,10 @@ void Flow::setupMainWindowConnections()
             mainWindow, &MainWindow::setVideoPreviewItem);
     connect(playbackManager, &PlaybackManager::isVideo,
             mainWindow, &MainWindow::setIsVideo);
+
+    // manager -> playlistwindow
+    connect(playbackManager, &PlaybackManager::removePlaylistItemRequested,
+            mainWindow->playlistWindow(), &PlaylistWindow::removePlaylistItem);
 
     // mainwindow -> favorites
     connect(mainWindow, &MainWindow::organizeFavorites,
@@ -1141,6 +1147,8 @@ void Flow::setupMpcHc()
             playbackManager, &PlaybackManager::playNext);
     connect(mpcHcServer, &MpcHcServer::previousFile,
             playbackManager, &PlaybackManager::playPrev);
+    connect(mpcHcServer, &MpcHcServer::moveToRecycleBin,
+            playbackManager, &PlaybackManager::moveToRecycleBin);
 
     // mainWindow -> mpcHcServer
     connect(mainWindow, &MainWindow::volumeChanged,

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1026,6 +1026,7 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->actionNavigateChaptersNext->setEnabled(enabled);
     ui->actionNavigateFilesPrevious->setEnabled(enabled);
     ui->actionNavigateFilesNext->setEnabled(enabled);
+    ui->actionFileMoveToRecycleBin->setEnabled(enabled);
     ui->actionNavigateGoto->setEnabled(enabled);
     ui->actionFavoritesAdd->setEnabled(enabled);
 
@@ -3133,6 +3134,11 @@ void MainWindow::on_actionNavigateFilesPrevious_triggered()
 void MainWindow::on_actionNavigateFilesNext_triggered()
 {
     emit fileNext(true);
+}
+
+void MainWindow::on_actionFileMoveToRecycleBin_triggered()
+{
+    emit moveToRecycleBin();
 }
 
 void MainWindow::on_actionNavigateGoto_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -162,6 +162,7 @@ signals:
     void chapterNext();
     void filePrevious(bool forceFolderFallback);
     void fileNext(bool forceFolderFallback);
+    void moveToRecycleBin();
     void showGoToWindow(double playTime, double playLength, double fps);
     void chapterSelected(int64_t id);
     void timeSelected(double time);
@@ -421,6 +422,7 @@ private slots:
 
     void on_actionNavigateFilesPrevious_triggered();
     void on_actionNavigateFilesNext_triggered();
+    void on_actionFileMoveToRecycleBin_triggered();
 
     void on_actionNavigateGoto_triggered();
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -775,6 +775,7 @@
     <addaction name="menuFileOpenDisc"/>
     <addaction name="menuFileRecent"/>
     <addaction name="actionFileClose"/>
+    <addaction name="actionFileMoveToRecycleBin"/>
     <addaction name="separator"/>
     <addaction name="actionFileSaveCopy"/>
     <addaction name="actionFileSaveImage"/>
@@ -1113,6 +1114,14 @@
    <property name="shortcut">
     <string>Ctrl+W</string>
    </property>
+  </action>
+  <action name="actionFileMoveToRecycleBin">
+    <property name="text">
+      <string>Move File to Recycle Bin</string>
+    </property>
+    <property name="shortcut">
+      <string notr="true">Del</string>
+    </property>
   </action>
   <action name="actionFileSaveCopy">
    <property name="text">

--- a/manager.h
+++ b/manager.h
@@ -92,6 +92,7 @@ signals:
     void currentTrackInfo(TrackInfo track);
     void openingNewFile();
     void startingPlayingFile(QUrl url);
+    void removePlaylistItemRequested(QUuid itemUuid);
     void stoppedPlaying();
 
     void fpsChanged(double fps);
@@ -124,8 +125,9 @@ public slots:
     void stepForward();
     void navigateToNextChapter();
     void navigateToPrevChapter();
-    void playNext(bool forceFolderFallback);
+    bool playNext(bool forceFolderFallback);
     void playPrev(bool forceFolderFallback);
+    void moveToRecycleBin();
     void repeatThisFile();
     void deltaExtraPlaytimes(int delta);
     void navigateToChapter(int64_t chapter);
@@ -180,10 +182,10 @@ private:
     void updateSubtitleTrack();
     void updateChapters();
     void checkAfterPlayback();
-    void playNextTrack();
+    bool playNextTrack();
     void playPrevTrack();
     bool playNextFileUrl(QUrl url, int delta = 1);
-    void playNextFile(int delta = 1);
+    bool playNextFile(int delta = 1);
     void playPrevFile();
     void playHalt();
 

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -832,6 +832,16 @@ void PlaylistWindow::playlist_removeItemRequested()
     updatePlaylistHasItems();
 }
 
+void PlaylistWindow::removePlaylistItem(const QUuid &itemUuid)
+{
+    auto qdp = currentPlaylistWidget();
+    if (!qdp)
+        return;
+
+    qdp->removeItem(itemUuid);
+    updatePlaylistHasItems();
+}
+
 void PlaylistWindow::playlist_removeAllRequested()
 {
     auto qdp = currentPlaylistWidget();

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -89,6 +89,7 @@ public slots:
     void addSimplePlaylist(QStringList data);
     void addPlaylistByUuid(QUuid playlistUuid);
     void setDisplayFormatSpecifier(QString fmt);
+    void removePlaylistItem(const QUuid &itemUuid);
     void dockLocationMaybeChanged();
 
     void newTab();

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1400,6 +1400,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1633,6 +1637,14 @@
     </message>
     <message>
         <source>Subtitles track: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1746,6 +1750,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>Subtítols: desactivats</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1745,6 +1749,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation>&amp;Compressor</translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1746,6 +1750,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>Subtitles: off</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1448,6 +1448,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1681,6 +1685,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1412,6 +1412,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1645,6 +1649,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1436,6 +1436,10 @@
         <source>&amp;Compressor</source>
         <translation>&amp;Compresseur</translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1670,6 +1674,14 @@
     <message>
         <source>Subtitles track: </source>
         <translation>Piste de sous-titres : </translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1484,6 +1484,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1717,6 +1721,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1444,6 +1444,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1677,6 +1681,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation>コンプレッサー(&amp;C)</translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1746,6 +1750,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>字幕 : off</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1400,6 +1400,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1633,6 +1637,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1408,6 +1408,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1641,6 +1645,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1492,6 +1492,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1726,6 +1730,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>Субтитры: выключены</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1746,6 +1750,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>வசன வரிகள்: ஆஃப்</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1512,6 +1512,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1746,6 +1750,14 @@
     <message>
         <source>Subtitles: off</source>
         <translation>Altyazılar: Kapalı</translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1484,6 +1484,10 @@
         <source>&amp;Compressor</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Move File to Recycle Bin</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>
@@ -1717,6 +1721,14 @@
     </message>
     <message>
         <source>Subtitles: off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File moved to recycle bin: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to move file to recycle bin: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This commit adds a new feature that allows users to delete the currently playing file from the filesystem and automatically move to the next playable file in the same directory.

Key features:
- New action 'Delete Current File and Next'
- Works with both direct files and playlist items
- Uses existing playNextFileUrl() logic for consistency
- Safe deletion: finds next file first, then deletes current
- HTTP remote control support (command 921)
- Appears in Settings → Keys for custom binding

Files modified:
- mainwindow.ui: Added action definition and menu integration
- mainwindow.h/cpp: UI integration and signal/slot handling
- manager.h/cpp: Core file deletion and next file logic
- main.cpp: Signal connections between components
- ipc/http.h/cpp: HTTP command support

This addresses the user request for a command that removes the currently played file and moves to the next one, even when only the playback window is active.

References #374 