### PR TITLE
settingswindow: Close Options window on Escape key press

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1248,6 +1248,14 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
     restoreAudioSettings();
 }
 
+void SettingsWindow::keyPressEvent(QKeyEvent *event)
+{
+    if (event->key() == Qt::Key_Escape)
+        this->close();
+    else
+        QWidget::keyPressEvent(event);
+}
+
 void SettingsWindow::on_playerTitleDisplayFullPath_clicked()
 {
     ui->playerTitleReplaceName->setEnabled(true);

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -227,6 +227,7 @@ private slots:
     void on_buttonBox_clicked(QAbstractButton *button);
 
     void closeEvent(QCloseEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
 
     void on_playerTitleDisplayFullPath_clicked();
 


### PR DESCRIPTION
The action editor still works fine when reassigning the Escape key.