### PR TITLE
Remember streams position and show them in Recent files

### DIFF
--- a/favoriteswindow.cpp
+++ b/favoriteswindow.cpp
@@ -143,17 +143,17 @@ QWidget *FavoritesDelegate::createEditor(QWidget *parent, const QStyleOptionView
 void FavoritesDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const
 {
     FavoritesItem *item = static_cast<FavoritesItem*>(owner->item(index.row()));
-    static_cast<QLineEdit*>(editor)->setText(item->track().text);
+    static_cast<QLineEdit*>(editor)->setText(item->track().title);
 }
 
 void FavoritesDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const
 {
     Q_UNUSED(model)
     FavoritesItem *item = static_cast<FavoritesItem*>(owner->item(index.row()));
-    QString text = static_cast<QLineEdit*>(editor)->text();
-    if (text.isEmpty())
-        text = item->track().url.toString();
-    item->track().text = text;
+    QString title = static_cast<QLineEdit*>(editor)->text();
+    if (title.isEmpty())
+        title = item->track().url.toString();
+    item->track().title = title;
 }
 
 QSize FavoritesDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
@@ -171,13 +171,13 @@ void FavoritesDelegate::paint(QPainter *painter, const QStyleOptionViewItem &opt
 
     QApplication::style()->drawControl(QStyle::CE_ItemViewItem, &option, painter);
 
-    QString text = listItem->track().text;
+    QString title = listItem->track().title;
     QString time = Helpers::toDateFormat(listItem->track().position) + " / "
                    + Helpers::toDateFormat(listItem->track().length);
     QRect rc = option.rect.adjusted(3, 0, -3, 0);
     painter->drawText(rc, Qt::AlignRight|Qt::AlignCenter, time);
     rc.adjust(0, 0, -(3 + option.fontMetrics.horizontalAdvance(time)), 0);
-    painter->drawText(rc, Qt::AlignLeft|Qt::AlignVCenter, text);
+    painter->drawText(rc, Qt::AlignLeft|Qt::AlignVCenter, title);
 }
 
 void FavoritesDelegate::updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -945,13 +945,13 @@ QString DisplayParser::parseMetadata(QVariantMap metaData,
 
 
 
-TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length,
+TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString title, double length,
                      double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack)
 {
     this->url = url;
     this->list = list;
     this->item = item;
-    this->text = text.isEmpty() ? url.toString() : text;
+    this->title = title.isEmpty() ? url.toString() : title;
     this->length = length;
     this->position = position;
     this->videoTrack = videoTrack;
@@ -962,7 +962,7 @@ TrackInfo::TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QStr
 QVariantMap TrackInfo::toVMap() const
 {
     return QVariantMap({{"url", url}, {"list", list}, {"item", item},
-                        {"text", text}, {"length", length},
+                        {"text", title}, {"length", length},
                         {"position", position}, {"videoTrack", (long long) videoTrack},
                         {"audioTrack", (long long) audioTrack},
                         {"subtitleTrack", (long long) subtitleTrack}});
@@ -973,9 +973,9 @@ void TrackInfo::fromVMap(const QVariantMap &map)
     url = map.value("url").toUrl();
     list = map.value("list").toUuid();
     item = map.value("item").toUuid();
-    text = map.value("text").toString();
-    if (text.isEmpty())
-        text = url.toString();
+    title = map.value("text").toString();
+    if (title.isEmpty())
+        title = url.toString();
     length = map.value("length").toDouble();
     position = map.value("position").toDouble();
     videoTrack = map.value("videoTrack").toLongLong();

--- a/helpers.h
+++ b/helpers.h
@@ -114,12 +114,12 @@ private:
 class TrackInfo {
 public:
     TrackInfo() {}
-    TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString text, double length,
+    TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString title, double length,
               double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack);
     QUrl url;
     QUuid list;
     QUuid item;
-    QString text;
+    QString title;
     double length;
     double position;
     int64_t videoTrack;

--- a/main.cpp
+++ b/main.cpp
@@ -1335,7 +1335,7 @@ void Flow::mainwindow_recentOpened(const TrackInfo &track, bool isFromRecents)
 
     // Navigate to a particular position if this is from the favorites menu
     // or if this is from the recents menu and not disabled
-    if (track.url.isLocalFile() && (!isFromRecents || rememberFilePosition)) {
+    if (!isFromRecents || rememberFilePosition) {
         if (track.position > 0)
             playbackManager->navigateToTime(track.position);
         playbackManager->setVideoTrack(track.videoTrack, true);
@@ -1674,7 +1674,7 @@ void Flow::updateRecentPosition(bool resetPosition)
         resetPosition = true;
     playbackManager->getCurrentTrackInfo(url, listUuid, itemUuid, title, length, position,
                                          videoTrack, audioTrack, subtitleTrack, hasVideo);
-    if (!itemUuid.isNull() && url.isLocalFile() && (hasVideo || !rememberHistoryOnlyForVideos))
+    if (!itemUuid.isNull() && !url.isEmpty() && (hasVideo || !rememberHistoryOnlyForVideos))
         updateRecents(url, listUuid, itemUuid, title, length, resetPosition ? 0 : position,
                       videoTrack, audioTrack, subtitleTrack);
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1721,7 +1721,11 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
 
     for (int i = 0; i < tracks.count() && i < 20; i++) {
         TrackInfo track = tracks[i];
-        QString displayString = track.url.fileName();
+        QString displayString;
+        if (track.url.isLocalFile())
+            displayString = track.url.fileName();
+        else
+            displayString = track.text;
         QAction *a = new QAction(QString("%1").arg(displayString),
                                  this);
         connect(a, &QAction::triggered, this, [=]() {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1725,7 +1725,7 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
         if (track.url.isLocalFile())
             displayString = track.url.fileName();
         else
-            displayString = track.text;
+            displayString = track.title;
         QAction *a = new QAction(QString("%1").arg(displayString),
                                  this);
         connect(a, &QAction::triggered, this, [=]() {
@@ -1776,7 +1776,7 @@ void MainWindow::setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> stre
     auto addTracks = [&](const QList<TrackInfo> &tracks) {
         for (const auto &t : tracks) {
             auto a = new QAction(this);
-            a->setText(t.text);
+            a->setText(t.title);
             connect(a, &QAction::triggered,
                     a, [t, this]() {
                 emit this->recentOpened(t);

--- a/manager.cpp
+++ b/manager.cpp
@@ -638,7 +638,7 @@ void PlaybackManager::sendCurrentTrackInfo()
                            videoTrackSelected, audioTrackSelected, subtitleTrackSelected});
 }
 
-void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString title,
+void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& itemUuid, QString& title,
                                           double& length, double& position, int64_t& videoTrack,
                                           int64_t& audioTrack, int64_t& subtitleTrack, bool& hasVideo)
 {

--- a/manager.h
+++ b/manager.h
@@ -170,7 +170,7 @@ public slots:
 
     // misc functions
     void sendCurrentTrackInfo();
-    void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString title,
+    void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString &title,
                              double &length, double &position, int64_t &videoTrack,
                              int64_t &audioTrack, int64_t &subtitleTrack, bool &hasVideo);
 


### PR DESCRIPTION
* Remember streams position and show them in Recent files

> For streams, the title is shown in Recent files instead of the file name.
> Like for local files, loading a Favorite still overrides the position from recents. This may not be what the user wants.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/f8c7aab2d405d6e15538aff96d582a783a02fefa which checked for local file url in updateRecentPosition when it should have checked for empty url.

* manager: Send title by reference in getCurrentTrackInfo

> Regression introduced by https://github.com/mpc-qt/mpc-qt/commit/6f68dc2a70bf1bbfb439458a4497a114e74d4156.
> Because of it, the recents file stored the same value for the url and the title (called "text" in the recent.json file).
> This had no visible effect since we didn't use the title until https://github.com/mpc-qt/mpc-qt/commit/3f4ec88ad2d7d6b26e6e29ceefed374a25d8ef70.

* Use more verbose "title" name for media title property of TrackInfo 

> While keeping "text" as the property name in the recent.json file for backward compatibility.