### PR TITLE
manager: Show stream titles in the playlist

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -1082,6 +1082,9 @@ void PlaybackManager::mpvw_aspectNameChanged(QString newAspectName)
 
 void PlaybackManager::mpvw_metadataChanged(QVariantMap metadata)
 {
+    // yt-dlp metadata doesn't include the title, so let's add it
+    if (!nowPlaying_.isLocalFile() && !nowPlayingTitle.isEmpty() && !metadata.contains("title"))
+        metadata.insert("title", nowPlayingTitle);
     playlistWindow_->setMetadata(nowPlayingList, nowPlayingItem, metadata);
 }
 


### PR DESCRIPTION
When using yt-dlp, mpv doesn't seem to include the title in the metadata.
And since the playlist relies on it to display the title, streams don't get their title shown in it. So we have to add the title to the metadata ourselves.