### PR TITLE
settingswindow: Only enable the Apply button when something can be applied

### DIFF
--- a/settingswindow.h
+++ b/settingswindow.h
@@ -222,12 +222,15 @@ private slots:
     void colorPick_changed(QLineEdit *colorValue, QPushButton *colorPick);
     QList<MpvOption> parseMpvOptions(const QString& optionsInline);
 
+    bool settingsOrKeyMapChanged();
+
     void on_pageTree_itemSelectionChanged();
 
     void on_buttonBox_clicked(QAbstractButton *button);
 
     void closeEvent(QCloseEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
     void on_playerTitleDisplayFullPath_clicked();
 


### PR DESCRIPTION
We need to ignore keysSearchText when saving settings so that the Apply button doesn't get enabled when filtering keys.

Installing the event filter in the constructor instead of installing /uninstalling it on show / close only triggers it two more times, so it's not worth it to add more code.

Fixes #381.