### PR TITLE
mainwindow: Add a crossfeed audio filter for headphones

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -183,6 +183,7 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionViewFullscreen) },
         { WRAP(ui->actionAudioFilterExtrastereo) },
         { WRAP(ui->actionAudioFilterAcompressor) },
+        { WRAP(ui->actionAudioFilterCrossfeed) },
         { WRAP(ui->actionPlaySubtitlesEnabled) },
         { WRAP(ui->actionPlayVolumeMute) },
         { "volume", volumeSlider_->value() },
@@ -217,11 +218,13 @@ void MainWindow::setState(const QVariantMap &map)
     UNWRAP(ui->actionViewFullscreen, false);
     UNWRAP(ui->actionAudioFilterExtrastereo, false);
     UNWRAP(ui->actionAudioFilterAcompressor, false);
+    UNWRAP(ui->actionAudioFilterCrossfeed, false);
     UNWRAP(ui->actionPlaySubtitlesEnabled, true);
     UNWRAP(ui->actionPlayVolumeMute, false);
 
     ui->actionAudioFilterExtrastereo->isChecked() ? on_actionAudioFilterExtrastereo_triggered(true) : qt_noop();
     ui->actionAudioFilterAcompressor->isChecked() ? on_actionAudioFilterAcompressor_triggered(true) : qt_noop();
+    ui->actionAudioFilterCrossfeed->isChecked() ? on_actionAudioFilterCrossfeed_triggered(true) : qt_noop();
     setSubtitlesEnabled(ui->actionPlaySubtitlesEnabled->isChecked(), true);
     on_actionPlayVolumeMute_toggled(ui->actionPlayVolumeMute->isChecked(), true);
     setVolume(map.value("volume", 100).toInt(), true);
@@ -2081,6 +2084,7 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
     ui->menuPlayAudio->addMenu(ui->menuPlayAudioFilters);
     ui->menuPlayAudioFilters->addAction(ui->actionAudioFilterExtrastereo);
     ui->menuPlayAudioFilters->addAction(ui->actionAudioFilterAcompressor);
+    ui->menuPlayAudioFilters->addAction(ui->actionAudioFilterCrossfeed);
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackPrevious);
     ui->menuPlayAudio->addAction(ui->actionPlayAudioTrackNext);
     audioTracksGroup->actions().constFirst()->setChecked(true);
@@ -2968,6 +2972,11 @@ void MainWindow::on_actionAudioFilterExtrastereo_triggered(bool checked)
 void MainWindow::on_actionAudioFilterAcompressor_triggered(bool checked)
 {
     emit audioFilter("acompressor", "", checked);
+}
+
+void MainWindow::on_actionAudioFilterCrossfeed_triggered(bool checked)
+{
+    emit audioFilter("bs2b", "profile=cmoy", checked);
 }
 
 void MainWindow::on_actionVideoFilterDeinterlace_triggered(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -386,6 +386,7 @@ private slots:
 
     void on_actionAudioFilterExtrastereo_triggered(bool checked);
     void on_actionAudioFilterAcompressor_triggered(bool checked);
+    void on_actionAudioFilterCrossfeed_triggered(bool checked);
 
     void on_actionVideoFilterDeinterlace_triggered(bool checked);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -892,6 +892,7 @@
       </property>
       <addaction name="actionAudioFilterExtrastereo"/>
       <addaction name="actionAudioFilterAcompressor"/>
+      <addaction name="actionAudioFilterCrossfeed"/>
      </widget>
      <addaction name="actionPlayAudioTrackPrevious"/>
      <addaction name="actionPlayAudioTrackNext"/>
@@ -2138,6 +2139,14 @@
   <action name="actionAudioFilterAcompressor">
    <property name="text">
     <string>&amp;Compressor</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </action>
+  <action name="actionAudioFilterCrossfeed">
+   <property name="text">
+    <string>&amp;Crossfeed (for headphones)</string>
    </property>
    <property name="checkable">
     <bool>true</bool>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1408,6 +1408,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">Captura de pantalla</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation>Screenshot</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1456,6 +1456,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">Captura de pantalla</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1420,6 +1420,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1444,6 +1444,10 @@
         <source>Screenshot</source>
         <translation>Capture d’écran</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (casque)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1492,6 +1492,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1452,6 +1452,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">Istantanee</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation>スクリーンショット</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1408,6 +1408,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1416,6 +1416,10 @@
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1500,6 +1500,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">Снимок экрана</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">திரைக்காட்சி</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1520,6 +1520,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">Ekran Görüntüsü</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1492,6 +1492,10 @@
         <source>Screenshot</source>
         <translation type="unfinished">屏幕截图</translation>
     </message>
+    <message>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Bauer stereo to binaural transformation, which improves headphone listening of stereo audio records by blending the left and right channels.
Uses the bs2b audio filter (Bauer stereophonic-to-binaural DSP) with the Chu Moy profile as it seems to be the most popular one.

Fixes #530.