### PR TITLE
translations: Fix French string for Crossfeed

### DIFF
--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1445,8 +1445,8 @@
         <translation>Capture d’écran</translation>
     </message>
     <message>
-        <source>&amp;Crossfeed (casque)</source>
-        <translation type="unfinished"></translation>
+        <source>&amp;Crossfeed (for headphones)</source>
+        <translation>&amp;Crossfeed (casque)</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The `<source>` string was used by error for the translation.