### PR TITLE
Implement gapless playback, read content of archives and playlists containing one file

### DIFF
--- a/ipc/http.h
+++ b/ipc/http.h
@@ -111,7 +111,7 @@ signals:
     void frameStepBack();
     void increaseRate();
     void decreaseRate();
-    void nextFile(bool forceFolderFallback);
+    void nextFile(bool forceFolderFallback, bool replaceMpvPlaylist = true);
     void previousFile(bool forceFolderFallback);
     void moveToRecycleBin();
     void quickAddFavorite();

--- a/ipc/mpris.h
+++ b/ipc/mpris.h
@@ -36,7 +36,7 @@ signals:
     void raiseWindow();
     void closeInstance();
     void volumeChange(double volume);
-    void playNextTrack(bool forceFolderFallback);
+    void playNextTrack(bool forceFolderFallback, bool replaceMpvPlaylist = true);
     void playPreviousTrack(bool forceFolderFallback);
     void pause();
     void playpause();

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -161,7 +161,7 @@ signals:
     void chapterPrevious();
     void chapterNext();
     void filePrevious(bool forceFolderFallback);
-    void fileNext(bool forceFolderFallback);
+    void fileNext(bool forceFolderFallback, bool replaceMpvPlaylist = true);
     void moveToRecycleBin();
     void showGoToWindow(double playTime, double playLength, double fps);
     void chapterSelected(int64_t id);

--- a/manager.cpp
+++ b/manager.cpp
@@ -326,12 +326,12 @@ void PlaybackManager::navigateToPrevChapter()
         playPrev(false);
 }
 
-bool PlaybackManager::playNext(bool forceFolderFallback)
+bool PlaybackManager::playNext(bool forceFolderFallback, bool replaceMpvPlaylist)
 {
     if ((folderFallback || forceFolderFallback) && playlistWindow_->isPlaylistSingularFile(nowPlayingList))
-        return playNextFile();
+        return playNextFile(replaceMpvPlaylist);
     else
-        return playNextTrack();
+        return playNextTrack(replaceMpvPlaylist);
 }
 
 void PlaybackManager::playPrev(bool forceFolderFallback)
@@ -378,7 +378,8 @@ void PlaybackManager::moveToRecycleBin()
 
 void PlaybackManager::repeatThisFile()
 {
-    startPlayWithUuid(nowPlaying_, nowPlayingList, nowPlayingItem, true);
+    startPlayWithUuid(nowPlaying_, nowPlayingList, nowPlayingItem,
+                      true, QUrl(), false);
 }
 
 void PlaybackManager::deltaExtraPlaytimes(int delta)
@@ -656,7 +657,8 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
 
 void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
                                         QUuid itemUuid, bool isRepeating,
-                                        QUrl with, bool clickedInPlaylist)
+                                        QUrl with, bool clickedInPlaylist,
+                                        bool replaceMpvPlaylist)
 {
     Logger::log("manager", "startPlayWithUuid");
     if (playbackState_ == WaitingState || what.isEmpty())
@@ -670,7 +672,8 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
 
     nowPlaying_ = what;
     mpvObject_->fileOpen(what.isLocalFile() ? what.toLocalFile()
-                                            : what.fromPercentEncoding(what.toEncoded()));
+                                            : what.fromPercentEncoding(what.toEncoded()),
+                         replaceMpvPlaylist);
     mpvObject_->setSubFile(with.toString());
     mpvObject_->setPaused(playbackStartPaused);
     playbackStartState = playbackStartPaused ? PausedState : PlayingState;
@@ -785,10 +788,10 @@ void PlaybackManager::checkAfterPlayback()
         emit systemShouldLock();
         break;
     case Helpers::PlayNextAfter:
-        playNext(true);
+        playNext(true, false);
         break;
     case Helpers::DoNothingAfter:
-        playNextTrack();
+        playNextTrack(false);
         break;
     case Helpers::RepeatAfter:
         break;
@@ -814,7 +817,7 @@ void PlaybackManager::updateChapters()
     emit chaptersAvailable(list);
 }
 
-bool PlaybackManager::playNextTrack()
+bool PlaybackManager::playNextTrack(bool replaceMpvPlaylist)
 {
     PlaylistItem next;
     next = playlistWindow_->getItemAfter(nowPlayingList, nowPlayingItem);
@@ -825,7 +828,8 @@ bool PlaybackManager::playNextTrack()
     }
     QUrl url = playlistWindow_->getUrlOf(next.list, next.item);
     if (!url.isEmpty()) {
-        startPlayWithUuid(url, next.list, next.item, false);
+        startPlayWithUuid(url, next.list, next.item,
+                          false, QUrl(), false, replaceMpvPlaylist);
         return true;
     }
     return false;
@@ -839,7 +843,7 @@ void PlaybackManager::playPrevTrack()
         startPlayWithUuid(url, nowPlayingList, itemUuid, false);
 }
 
-bool PlaybackManager::playNextFileUrl(QUrl url, int delta)
+bool PlaybackManager::playNextFileUrl(QUrl url, int delta, bool replaceMpvPlaylist)
 {
     Logger::log("manager", "playNextFileUrl");
     QFileInfo info;
@@ -869,19 +873,20 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta)
     emit playingNextFile();
     playlistWindow_->clearPlaylist(nowPlayingList);
     QUuid nowPlayingItemLocal = playlistWindow_->addToPlaylist(nowPlayingList, { url }).item;
-    startPlayWithUuid(url, nowPlayingList, nowPlayingItemLocal, false);
+    startPlayWithUuid(url, nowPlayingList, nowPlayingItemLocal,
+                      false, QUrl(), false, replaceMpvPlaylist);
     return true;
 }
 
-bool PlaybackManager::playNextFile(int delta)
+bool PlaybackManager::playNextFile(bool replaceMpvPlaylist, int delta)
 {
     QUrl url = playlistWindow_->getUrlOfFirst(nowPlayingList);
-    return playNextFileUrl(url, delta);
+    return playNextFileUrl(url, delta, replaceMpvPlaylist);
 }
 
 void PlaybackManager::playPrevFile()
 {
-    playNextFile(-1);
+    playNextFile(true, -1);
 }
 
 void PlaybackManager::mpvw_playTimeChanged(double time)

--- a/manager.h
+++ b/manager.h
@@ -125,7 +125,7 @@ public slots:
     void stepForward();
     void navigateToNextChapter();
     void navigateToPrevChapter();
-    bool playNext(bool forceFolderFallback);
+    bool playNext(bool forceFolderFallback, bool replaceMpvPlaylist = true);
     void playPrev(bool forceFolderFallback);
     void moveToRecycleBin();
     void repeatThisFile();
@@ -177,15 +177,16 @@ public slots:
 private:
     enum AspectNameChanged { OnOpen, OnFirstPlay, Manually };
     void startPlayWithUuid(QUrl what, QUuid playlistUuid, QUuid itemUuid,
-                           bool isRepeating, QUrl with = QUrl(), bool clickedInPlaylist = false);
+                           bool isRepeating, QUrl with = QUrl(),
+                           bool clickedInPlaylist = false, bool replaceMpvPlaylist = true);
     void selectDesiredTracks();
     void updateSubtitleTrack();
     void updateChapters();
     void checkAfterPlayback();
-    bool playNextTrack();
+    bool playNextTrack(bool replaceMpvPlaylist);
     void playPrevTrack();
-    bool playNextFileUrl(QUrl url, int delta = 1);
-    bool playNextFile(int delta = 1);
+    bool playNextFileUrl(QUrl url, int delta = 1, bool replaceMpvPlaylist = true);
+    bool playNextFile(bool replaceMpvPlaylist = true, int delta = 1);
     void playPrevFile();
     void playHalt();
 

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -331,11 +331,14 @@ void MpvObject::urlOpen(QUrl url)
                                : url.fromPercentEncoding(url.toEncoded()));
 }
 
-void MpvObject::fileOpen(QString filename)
+void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist)
 {
     setSubFile("\n");
     //setStartTime(0.0);
-    emit ctrlCommand(QStringList({"loadfile", filename}));
+    if (replaceMpvPlaylist)
+        emit ctrlCommand(QStringList({"loadfile", filename}));
+    else
+        emit ctrlCommand(QStringList({"loadfile", filename, "append-play"}));
     setMouseHideTime(hideTimer->interval());
 }
 

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -54,7 +54,7 @@ public:
     int selectedStatsPage();
 
     void urlOpen(QUrl url);
-    void fileOpen(QString filename);
+    void fileOpen(QString filename, bool replaceMpvPlaylist = true);
     void discFilesOpen(QString path);
     void stopPlayback();
     void stepBackward();


### PR DESCRIPTION
* Check content of mpv playlist instead of checking its size

> Allows us to get the content of archives and playlist files even when
> they only contain one file.
> 
> Also needed to be able to use the mpv playlist and its prefetch feature
> for gapless playback.
> 
> Archives and playlist files have a "playlist-path" property and each mpv
> playlist item has an unique id. So we can use them to check if we have
> to replace the current item from our playlist by items from mpv's
> playlist.
> 
> We can't use playlist-pos instead of iterating each time through the
> playlist items in PlaybackManager::mpvw_playlistChanged because its value
> is always 0 when called by the on_unload hook.

* Implement gapless playback

> Uses the mpv playlist which enables by default its prefetch feature.
> 
> Enabled when playing automatically the next track and when repeating the
> same track.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/531.