### PR TITLE
Allow importing .txt plaintext playlists, rename the Import/Export Playlist File windows

### DIFF
--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -527,7 +527,7 @@ void PlaylistWindow::importTab()
     options = QFileDialog::DontUseNativeDialog;
 #endif
     QString file;
-    file = QFileDialog::getOpenFileName(this, tr("Import File"), QString(),
+    file = QFileDialog::getOpenFileName(this, tr("Import Playlist File"), QString(),
                                         tr("Playlist files (*.m3u *.m3u8 *.txt)"), nullptr, options);
     if (!file.isEmpty())
         emit importPlaylist(file);
@@ -729,7 +729,7 @@ void PlaylistWindow::savePlaylist(const QUuid &playlistUuid)
     options = QFileDialog::DontUseNativeDialog;
 #endif
     QString file;
-    file = QFileDialog::getSaveFileName(this, tr("Export File"), QString(),
+    file = QFileDialog::getSaveFileName(this, tr("Export Playlist File"), QString(),
                                         tr("Playlist files (*.m3u *.m3u8)"), nullptr, options);
     auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
     if (!file.isEmpty() && pl)

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1726,15 +1726,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1831,6 +1823,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1847,7 +1847,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Importar fitxer</translation>
+        <translation type="vanished">Importar fitxer</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1855,7 +1855,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Exportar fitxer</translation>
+        <translation type="vanished">Exportar fitxer</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1951,6 +1951,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1846,15 +1846,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1951,6 +1943,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1847,7 +1847,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Import File</translation>
+        <translation type="vanished">Import File</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1855,7 +1855,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Export File</translation>
+        <translation type="vanished">Export File</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1951,6 +1951,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1783,7 +1783,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Importar un archivo</translation>
+        <translation type="vanished">Importar un archivo</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1791,7 +1791,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Exportar a un archivo</translation>
+        <translation type="vanished">Exportar a un archivo</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1887,6 +1887,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1747,7 +1747,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Tuo Tiedosto</translation>
+        <translation type="vanished">Tuo Tiedosto</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1755,7 +1755,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Vie Tiedosto</translation>
+        <translation type="vanished">Vie Tiedosto</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1851,6 +1851,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1771,7 +1771,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Importer un fichier</translation>
+        <translation type="vanished">Importer un fichier</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1779,7 +1779,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Exporter le fichier</translation>
+        <translation type="vanished">Exporter le fichier</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1871,6 +1871,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1810,15 +1810,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1911,6 +1903,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1779,7 +1779,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Importa file</translation>
+        <translation type="vanished">Importa file</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1787,7 +1787,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Esporta file</translation>
+        <translation type="vanished">Esporta file</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1879,6 +1879,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1847,7 +1847,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>ファイルのインポート</translation>
+        <translation type="vanished">ファイルのインポート</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1855,7 +1855,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>ファイルのエクスポート</translation>
+        <translation type="vanished">ファイルのエクスポート</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1951,6 +1951,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1726,15 +1726,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1827,6 +1819,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1734,15 +1734,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Import File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Export File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1839,6 +1831,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1827,7 +1827,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Импортировать файл</translation>
+        <translation type="vanished">Импортировать файл</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1835,7 +1835,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Экспортировать файл</translation>
+        <translation type="vanished">Экспортировать файл</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1931,6 +1931,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1847,7 +1847,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>கோப்பு இறக்குமதி</translation>
+        <translation type="vanished">கோப்பு இறக்குமதி</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1855,7 +1855,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>ஏற்றுமதி கோப்பு</translation>
+        <translation type="vanished">ஏற்றுமதி கோப்பு</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1951,6 +1951,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1847,7 +1847,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>Dosya İçe Aktar</translation>
+        <translation type="vanished">Dosya İçe Aktar</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1855,7 +1855,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>Dosyayı Dışa Aktar</translation>
+        <translation type="vanished">Dosyayı Dışa Aktar</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1951,6 +1951,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1819,7 +1819,7 @@
     </message>
     <message>
         <source>Import File</source>
-        <translation>导入文件</translation>
+        <translation type="vanished">导入文件</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
@@ -1827,7 +1827,7 @@
     </message>
     <message>
         <source>Export File</source>
-        <translation>导出文件</translation>
+        <translation type="vanished">导出文件</translation>
     </message>
     <message>
         <source>Open</source>
@@ -1923,6 +1923,14 @@
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8 *.txt)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export Playlist File</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
* playlistwindow: Allow importing .txt plaintext playlists

> mpv supports importing plaintext playlists.
> We do too, but we currently filter them out in the Import Playlist
> dialog.
> For the record, the format is the same as for M3U playlists but without
> the leading #EXTM3U and the blank line after it.
> So for instance:
> /path/to/file1
> /path/to/file2

* playlistwindow: Rename the Import/Export Playlist File windows