### PR TITLE
Use Escape key for both "Escape Fullscreen" and "Finish Searching"

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -3339,8 +3339,26 @@ void MainWindow::on_actionPlaylistSearch_triggered()
     if (playlistWindow_->isHidden())
         playlistWindow_->show();
     playlistWindow_->revealSearch();
+    if (ui->actionPlaylistFinishSearching->shortcut().isEmpty()) {
+        for (auto action : this->findChildren<QAction*>()) {
+            if (action->shortcut() == Qt::Key::Key_Escape) {
+                escShortcutActionBackup = action;
+                action->setShortcut(QKeySequence());
+                break;
+            }
+        }
+        ui->actionPlaylistFinishSearching->setShortcut(Qt::Key::Key_Escape);
+    }
 }
 
+void MainWindow::on_actionPlaylistFinishSearching_triggered()
+{
+    ui->actionPlaylistFinishSearching->setShortcut(QKeySequence());
+    if (escShortcutActionBackup) {
+        escShortcutActionBackup->setShortcut(Qt::Key::Key_Escape);
+        escShortcutActionBackup = nullptr;
+    }
+}
 
 void MainWindow::on_actionFavoritesAdd_triggered()
 {

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -435,6 +435,7 @@ private slots:
     void on_actionHelpAbout_triggered();
 
     void on_actionPlaylistSearch_triggered();
+    void on_actionPlaylistFinishSearching_triggered();
 
     void mpvw_customContextMenuRequested(const QPoint &pos);
     void position_sliderMoved(int position);
@@ -473,6 +474,7 @@ private:
     QActionGroup* audioTracksGroup = nullptr;
     QActionGroup* videoTracksGroup = nullptr;
     QActionGroup* subtitleTracksGroup = nullptr;
+    QAction * escShortcutActionBackup = nullptr;
 
     bool freestanding_ = false;
     Helpers::TitlePrefix titlebarFormat_ = Helpers::PrefixFileName;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1854,9 +1854,6 @@
    <property name="text">
     <string>&amp;Finish Searching</string>
    </property>
-   <property name="shortcut">
-    <string>Esc</string>
-   </property>
   </action>
   <action name="actionPlaylistNewTab">
    <property name="text">
@@ -2134,7 +2131,7 @@
     <string>&amp;Escape Fullscreen</string>
    </property>
    <property name="shortcut">
-    <string notr="true">`</string>
+    <string notr="true">Esc</string>
    </property>
   </action>
   <action name="actionAudioFilterExtrastereo">

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -837,10 +837,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Esc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;New Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -909,10 +909,6 @@
         <translation>&amp;Finalizar la búsqueda</translation>
     </message>
     <message>
-        <source>Esc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;New Tab</source>
         <translation>&amp;Nueva pestaña</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -849,10 +849,6 @@
         <translation>&amp;Lopeta haku</translation>
     </message>
     <message>
-        <source>Esc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;New Tab</source>
         <translation>&amp;Uusi Välilehti</translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -886,7 +886,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Échap</translation>
+        <translation type="vanished">Échap</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -910,7 +910,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -910,7 +910,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -837,10 +837,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Esc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;New Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -845,10 +845,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Esc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;New Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>தப்பி</translation>
+        <translation type="vanished">தப்பி</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Vazgeç</translation>
+        <translation type="vanished">Vazgeç</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -918,7 +918,7 @@
     </message>
     <message>
         <source>Esc</source>
-        <translation>Esc</translation>
+        <translation type="vanished">Esc</translation>
     </message>
     <message>
         <source>&amp;New Tab</source>


### PR DESCRIPTION
* mainwindow: Use Escape key shortcut for "Finish Searching" only while searchbar opened

> The Escape key shortcut is used by default for closing the playlist searchbar.
> But this shortcut only makes sense while the searchbar is opened.
> So it's switched to "Finish Searching" while the searchbar is opened and
> returned to the default or user set action once the searchbar is closed.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/0204f25bef98d65f194d224fecf1c9e29425d429.

* mainwindow: Use Escape key shortcut for "Escape Fullscreen"

> With https://github.com/mpc-qt/mpc-qt/commit/bba29850297024f1420dd9a249b4ae68c20bd576 freeing up the Escape key, we can use it to exit fullscreen by default.