### PR TITLE
Add "More Files" entry in Recent Files to show up to 50 recents in total

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1715,7 +1715,7 @@ void MainWindow::setFullscreenMouseMap(const MouseStateMap &map)
     mouseMapFullscreen = map;
 }
 
-void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
+void MainWindow::setRecentDocuments(const QList<TrackInfo> &tracks)
 {
     bool isEmpty = tracks.count() == 0;
     ui->menuFileRecent->clear();
@@ -1723,7 +1723,25 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
     if (isEmpty)
         return;
 
-    for (int i = 0; i < tracks.count() && i < 20; i++) {
+    addRecentDocumentsEntries(tracks, ui->menuFileRecent, 0, 20);
+
+    if (tracks.count() > 20) {
+        LogStream("mainwindow") << "tracks.count(): " << tracks.count();
+        Logger::log("mainwindow", "setRecentDocuments > 20");
+        QMenu *moreRecentsMenu = new QMenu(tr("More Files"));
+        addRecentDocumentsEntries(tracks, moreRecentsMenu, 20, 50);
+        ui->menuFileRecent->addSeparator();
+        ui->menuFileRecent->addMenu(moreRecentsMenu);
+        Logger::log("mainwindow", "setRecentDocuments > 20 done");
+    }
+
+    ui->menuFileRecent->addSeparator();
+    ui->menuFileRecent->addAction(ui->actionFileRecentClear);
+}
+
+void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end)
+{
+    for (int i = start; i < tracks.count() && i < end; i++) {
         TrackInfo track = tracks[i];
         QString displayString;
         if (track.url.isLocalFile())
@@ -1735,10 +1753,8 @@ void MainWindow::setRecentDocuments(QList<TrackInfo> tracks)
         connect(a, &QAction::triggered, this, [=]() {
             emit recentOpened(track, true);
         });
-        ui->menuFileRecent->addAction(a);
+        menu->addAction(a);
     }
-    ui->menuFileRecent->addSeparator();
-    ui->menuFileRecent->addAction(ui->actionFileRecentClear);
 }
 
 void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration,

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -237,7 +237,7 @@ public slots:
     void setTitleUseMediaTitle(bool enabled);
     void setWindowedMouseMap(const MouseStateMap &map);
     void setFullscreenMouseMap(const MouseStateMap &map);
-    void setRecentDocuments(QList<TrackInfo> tracks);
+    void setRecentDocuments(const QList<TrackInfo> &tracks);
     void setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration, bool setControlsInFullscreen);
     void setFavoriteTracks(QList<TrackInfo> files, QList<TrackInfo> streams);
     void setIconTheme(IconThemer::FolderMode folderMode, QString fallbackFolder, QString customFolder);
@@ -446,6 +446,7 @@ private slots:
     void playlistWindow_windowDocked();
     void playlistWindow_playlistAddItem(const QUuid &playlistUuid);
     void hideTimer_timeout();
+    void addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end);
 
     void on_actionFileLoadSubtitle_triggered();
 

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1420,6 +1420,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation>&amp;Reset Zoom</translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1468,6 +1468,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1432,6 +1432,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1460,6 +1460,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1508,6 +1508,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1468,6 +1468,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1420,6 +1420,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1428,6 +1428,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1516,6 +1516,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1536,6 +1536,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1508,6 +1508,10 @@
         <source>&amp;Reset Zoom</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>More Files</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
* mainwindow: Add "More Files" entry in Recent Files to show up to 50 recents in total

> We save up to 1000 recents when the "Remember file position" setting is enabled. So we can show more than 20 recent files. Adding recent entries for the last 50 ones takes less than a millisecond.
> Limiting the More Files submenu to 30 additional recent entries doesn't result in a scrolling list with an HD (1080) screen. A scrolling list can also end up hiding the top (21th) entry on some/all desktops.