### PR TITLE
Display the current aspect ratio name in the aspect ratio submenu

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -845,6 +845,8 @@ void Flow::setupMpvObjectConnections()
             mainWindow, &MainWindow::videoTrackSet);
     connect(mpvObject, &MpvObject::chapterTitleChanged,
             mainWindow, &MainWindow::setChapterTitle);
+    connect(mpvObject, &MpvObject::aspectNameChanged,
+            mainWindow, &MainWindow::setAspectName);
 
     // settingswindow -> log
     auto logger = Logger::singleton();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -127,6 +127,8 @@ QList<QAction *> MainWindow::editableActions()
     actionList.move(actionList.indexOf(ui->actionPlaySeekBackwardsNormal),
         indexOfActionPlayFrameForward + 1);
 
+    actionList.remove(actionList.indexOf(ui->actionVideoAspectName));
+
     return actionList;
 }
 
@@ -1875,6 +1877,11 @@ void MainWindow::setChapterTitle(QString title)
     ui->chapter->setText(!title.isEmpty() ? title : "-");
 }
 
+void MainWindow::setAspectName(QString aspectName)
+{
+    ui->actionVideoAspectName->setText(!aspectName.isEmpty() ? aspectName : tr("Unknown"));
+}
+
 void MainWindow::setVideoSize(QSize size)
 {
     (void)size;
@@ -2131,6 +2138,8 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
     ui->menuPlayVideo->addMenu(ui->menuPlayVideoFilters);
     ui->menuPlayVideoFilters->addAction(ui->actionVideoFilterDeinterlace);
     ui->menuPlayVideo->addMenu(ui->menuPlayVideoAspect);
+    ui->menuPlayVideoAspect->addAction(ui->actionVideoAspectName);
+    ui->menuPlayVideoAspect->addSeparator();
     ui->menuPlayVideoAspect->addAction(ui->actionDecreaseVideoAspect);
     ui->menuPlayVideoAspect->addAction(ui->actionIncreaseVideoAspect);
     ui->menuPlayVideoAspect->addAction(ui->actionResetVideoAspect);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -246,6 +246,7 @@ public slots:
     void setTime(double time, double length);
     void setMediaTitleWithFilename(QString title, QString filename);
     void setChapterTitle(QString title);
+    void setAspectName(QString aspectName);
     void setVideoSize(QSize size);
     void setVolumeStep(int stepSize);
     void setSizeFactor(double factor);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -923,6 +923,7 @@
       <property name="title">
        <string>&amp;Aspect ratio</string>
       </property>
+      <addaction name="actionVideoAspectName"/>
       <addaction name="actionDecreaseVideoAspect"/>
       <addaction name="actionIncreaseVideoAspect"/>
       <addaction name="actionResetVideoAspect"/>
@@ -2226,6 +2227,14 @@
    </property>
    <property name="checkable">
     <bool>true</bool>
+   </property>
+  </action>
+  <action name="actionVideoAspectName">
+   <property name="text">
+    <string>Unknown</string>
+   </property>
+   <property name="enabled">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionDecreaseVideoAspect">


### PR DESCRIPTION
Since it's not an actual action we have to remove it from the editableActions to prevent it from showing up in the Keys action editor.