### PR TITLE
settingswindow: Don't disable tooltip location setting when video preview is enabled

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1489,12 +1489,6 @@ void SettingsWindow::on_tweaksPreferWayland_toggled(bool checked)
         ui->playbackAutoZoom->setChecked(false);
 }
 
-void SettingsWindow::on_tweaksVideoPreview_toggled(bool checked)
-{
-    ui->tweaksTimeTooltip->setEnabled(!checked);
-    ui->tweaksTimeTooltipLocation->setEnabled(!checked);
-}
-
 void SettingsWindow::on_tweaksTimeTooltip_toggled(bool checked)
 {
     ui->tweaksTimeTooltipLocation->setEnabled(checked);

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -296,8 +296,6 @@ private slots:
 
     void on_tweaksPreferWayland_toggled(bool checked);
 
-    void on_tweaksVideoPreview_toggled(bool checked);
-
     void on_tweaksTimeTooltip_toggled(bool checked);
 
     void on_tweaksOsdFontChkBox_toggled(bool checked);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7737,9 +7737,6 @@ media file played</string>
                <property name="text">
                 <string>Show time tooltip:</string>
                </property>
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
                <property name="checked">
                 <bool>true</bool>
                </property>
@@ -7750,7 +7747,7 @@ media file played</string>
            <item row="10" column="1">
             <widget class="QComboBox" name="tweaksTimeTooltipLocation">
              <property name="enabled">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">


### PR DESCRIPTION
A tooltip is still shown on the seekbar for audio media, so this setting is still needed when video preview is enabled.

Follow-up to cf72cd92460c8e3fe05c51a6fedb011c931c84be.