### PR TITLE
Use a custom widget for the seekbar tooltip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(SOURCES
     widgets/logowidget.cpp widgets/logowidget.h
     widgets/paletteeditor.cpp widgets/paletteeditor.h
     widgets/screencombo.cpp widgets/screencombo.h
+    widgets/tooltip.cpp widgets/tooltip.h
     widgets/videopreview.cpp widgets/videopreview.h
 )
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -18,7 +18,6 @@
 #include <QTime>
 #include <QDesktopServices>
 #include <QMessageBox>
-#include <QToolTip>
 #include <QScreen>
 #include <QStyle>
 #include <QSvgRenderer>
@@ -556,6 +555,8 @@ void MainWindow::setFullscreenMode(bool fullscreenMode)
         WindowManager::restoreFullscreen(this, fullscreenMemory);
         if (videoPreview)
             videoPreview->hide();
+        if (tooltip)
+            tooltip->hide();
     }
 
     ui->actionViewFullscreenEscape->setEnabled(fullscreenMode);
@@ -1983,6 +1984,12 @@ void MainWindow::setVideoPreview(bool enable)
 
 void MainWindow::setTimeTooltip(bool shown, bool above)
 {
+    if (!tooltip && shown) {
+        tooltip = new Tooltip(this);
+    } else if (tooltip && !shown) {
+        delete tooltip;
+        tooltip = nullptr;
+    }
     timeTooltipShown = shown;
     timeTooltipAbove = above;
 }
@@ -3286,21 +3293,26 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
                                             timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
-    if (videoPreview && isVideo_) {
-        QToolTip::hideText();
-        QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), -1));
+    QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), timeTooltipAbove ? -1 : 65));
+    if (videoPreview && isVideo_)
         videoPreview->show(t, position, where, this->width());
-        mpvw->update();
-    } else {
-        QPoint where = positionSlider_->mapToGlobal(QPoint(std::round(mouseX), timeTooltipAbove ? -40 : 0));
-        QToolTip::showText(where, t, positionSlider_);
+    else if (tooltip) {
+        QString textTemplate = QString("%1%2%3").arg(Helpers::toDateFormatFixed(
+                                                        0,
+                                                        timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
+                                                    chapterInfo.isEmpty() ? "" : " - ",
+                                                    chapterInfo);
+        tooltip->show(t, where, this->width(), textTemplate);
     }
+    mpvw->update();
 }
 
 void MainWindow::position_hoverEnd()
 {
     if (videoPreview)
         videoPreview->hide();
+    if (tooltip)
+        tooltip->hide();
 
     setCursor(Qt::ArrowCursor);
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -9,6 +9,7 @@
 #include "helpers.h"
 #include "widgets/drawnslider.h"
 #include "widgets/drawnstatus.h"
+#include "widgets/tooltip.h"
 #include "widgets/videopreview.h"
 #include "manager.h"
 #include "playlistwindow.h"
@@ -465,6 +466,7 @@ private:
     MediaSlider *positionSlider_ = nullptr;
     VolumeSlider *volumeSlider_ = nullptr;
     VideoPreview *videoPreview = nullptr;
+    Tooltip *tooltip = nullptr;
     StatusTime *timePosition = nullptr;
     StatusTime *timeDuration = nullptr;
     PlaylistWindow *playlistWindow_ = nullptr;

--- a/widgets/tooltip.cpp
+++ b/widgets/tooltip.cpp
@@ -1,0 +1,61 @@
+#include <QToolTip>
+#include "tooltip.h"
+
+constexpr int windowSidesMargin = 20;
+constexpr int insidePadding = 10;
+
+Tooltip::Tooltip(QWidget *parent) : QWidget(parent)
+{
+    textLabel = new QLabel(parent);
+    textLabel->setAlignment(Qt::AlignCenter);
+
+    textLabel->setAutoFillBackground(true);
+    QPalette tooltipPalette = QToolTip::palette();
+    QPalette customPalette = this->palette();
+    customPalette.setColor(QPalette::Window, tooltipPalette.color(QPalette::ToolTipBase));
+    customPalette.setColor(QPalette::WindowText, tooltipPalette.color(QPalette::ToolTipText));
+    textLabel->setPalette(customPalette);
+    textLabel->setStyleSheet(R"(
+        QLabel {
+            background-color: palette(Window);
+            color: palette(WindowText);
+            border: 1px solid palette(Light);
+            border-radius: 4px;
+        }
+    )");
+
+    hide();
+    this->setVisible(false);
+}
+
+Tooltip::~Tooltip()
+{
+    delete textLabel;
+    textLabel = nullptr;
+}
+
+void Tooltip::show(const QString &text, QPoint &where, int mainWindowWidth, QString &textTemplate)
+{
+    textLabel->setText(text);
+    auto rect = QFontMetrics(font()).boundingRect(textTemplate);
+    textLabel->setFixedSize(rect.width() + insidePadding, rect.height() + insidePadding);
+    setPosition(where, mainWindowWidth);
+    textLabel->move(bottomLeft.x(),
+                    bottomLeft.y() - textLabel->height());
+    textLabel->setVisible(true);
+}
+
+void Tooltip::setPosition(QPoint &where, int mainWindowWidth)
+{
+    int tooltipWidth = textLabel->width();
+    int xPos = where.x() - std::round(tooltipWidth / 2);
+    if (xPos + tooltipWidth + windowSidesMargin > mainWindowWidth)
+        xPos = mainWindowWidth - tooltipWidth - windowSidesMargin;
+    else if (xPos < windowSidesMargin)
+        xPos = windowSidesMargin;
+    bottomLeft = QPoint(xPos, where.y());
+}
+
+void Tooltip::hide() {
+    textLabel->setVisible(false);
+}

--- a/widgets/tooltip.h
+++ b/widgets/tooltip.h
@@ -1,0 +1,21 @@
+#ifndef TOOLTIP_H
+#define TOOLTIP_H
+
+#include <qlabel.h>
+
+class Tooltip : public QWidget {
+    public:
+        explicit Tooltip(QWidget *parent = nullptr);
+        ~Tooltip();
+        void show(const QString &text, QPoint &where, int mainWindowWidth, QString &textTemplate);
+        void hide();
+
+    private:
+        void setPosition(QPoint &where, int mainWindowWidth);
+
+        QLabel *textLabel;
+        bool aspectRatioSet = false;
+        QPoint bottomLeft;
+    };
+
+#endif // TOOLTIP_H


### PR DESCRIPTION
Drawn on mainwindow like the video preview.

Avoids a recent (Qt?) bug where the mouse cursor doesn't always stay as a pointing hand and then preventing from clicking on the seek bar.

Also makes it possible to show the tooltip in fullscreen on Windows.

However, in the "below seekbar" mode, the tooltip isn't visible if there isn't enough vertical space available below the seekbar. For instance, in minimal or compact mode.