### PR TITLE
settingswindow: Clear keysSearchField on window close

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1259,10 +1259,8 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
         sendSignals();
     }
     if (buttonRole == QDialogButtonBox::AcceptRole ||
-            buttonRole == QDialogButtonBox::RejectRole) {
-        ui->keysSearchField->clear();
+            buttonRole == QDialogButtonBox::RejectRole)
         close();
-    }
 }
 
 void SettingsWindow::closeEvent(QCloseEvent *event)
@@ -1271,6 +1269,7 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
     restoreColorControls();
     restoreAudioSettings();
     setCustomMpvOptions();
+    ui->keysSearchField->clear();
 }
 
 void SettingsWindow::keyPressEvent(QKeyEvent *event)


### PR DESCRIPTION
When clearing `keysSearchField` on dialog buttons click, it doesn't get cleared when closing the window with the window close button or the close window shortcut.