### PR TITLE
images: Rename "media-skip-*" and "go-*" buttons icons

### DIFF
--- a/images/theme/black/go-next.svg
+++ b/images/theme/black/go-next.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="7.5130095"
-     inkscape:cy="9.6595836"
+     inkscape:cx="10.638169"
+     inkscape:cy="10.606602"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1012"
+     inkscape:window-height="1005"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,25 +69,18 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-6"
-       width="2"
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.61803;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-14"
+       width="2.6657825"
        height="15.999988"
-       x="-16"
+       x="-4.708612"
        y="292.76666"
        transform="scale(-1,1)" />
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 14,300.76665 -7,8 v -16 z"
-       id="path4148-06"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 15,300.76665 -8.004413,8 v -16 z"
+       id="path4148-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 7,300.76665 -7,8 v -16 z"
-       id="path4148-9-1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       inkscape:transform-center-x="1.5625" />
   </g>
 </svg>

--- a/images/theme/black/go-previous.svg
+++ b/images/theme/black/go-previous.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="5.2717336"
-     inkscape:cy="10.290929"
+     inkscape:cx="10.638169"
+     inkscape:cy="10.606602"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1012"
+     inkscape:window-height="1005"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,24 +69,17 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146"
-       width="2"
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.66256;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-14-9"
+       width="2.717438"
        height="15.999988"
-       x="0"
+       x="11.239733"
        y="292.76666" />
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 2,300.76665 7,8 v -16 z"
-       id="path4148"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1,300.76665 7.9642365,8 v -16 z"
+       id="path4148-5-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 9,300.76665 7,8 v -16 z"
-       id="path4148-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       inkscape:transform-center-x="-1.5625" />
   </g>
 </svg>

--- a/images/theme/black/media-skip-backward.svg
+++ b/images/theme/black/media-skip-backward.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="10.638169"
-     inkscape:cy="10.606602"
+     inkscape:cx="5.2717336"
+     inkscape:cy="10.290929"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="1012"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,17 +69,24 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.66256;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-14-9"
-       width="2.717438"
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146"
+       width="2"
        height="15.999988"
-       x="11.239733"
+       x="0"
        y="292.76666" />
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 1,300.76665 7.9642365,8 v -16 z"
-       id="path4148-5-5"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2,300.76665 7,8 v -16 z"
+       id="path4148"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,300.76665 7,8 v -16 z"
+       id="path4148-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="-1.5625" />
   </g>
 </svg>

--- a/images/theme/black/media-skip-forward.svg
+++ b/images/theme/black/media-skip-forward.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="10.638169"
-     inkscape:cy="10.606602"
+     inkscape:cx="7.5130095"
+     inkscape:cy="9.6595836"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="1012"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,18 +69,25 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.61803;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-14"
-       width="2.6657825"
+       style="opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-6"
+       width="2"
        height="15.999988"
-       x="-4.708612"
+       x="-16"
        y="292.76666"
        transform="scale(-1,1)" />
     <path
-       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 15,300.76665 -8.004413,8 v -16 z"
-       id="path4148-5"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14,300.76665 -7,8 v -16 z"
+       id="path4148-06"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,300.76665 -7,8 v -16 z"
+       id="path4148-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="1.5625" />
   </g>
 </svg>

--- a/images/theme/white/go-next.svg
+++ b/images/theme/white/go-next.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="7.5130095"
-     inkscape:cy="9.6595836"
+     inkscape:cx="10.638169"
+     inkscape:cy="10.606602"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1012"
+     inkscape:window-height="1005"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,25 +69,18 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-6"
-       width="2"
+       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.61803;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-14"
+       width="2.6657825"
        height="15.999988"
-       x="-16"
+       x="-4.708612"
        y="292.76666"
        transform="scale(-1,1)" />
     <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 14,300.76665 -7,8 v -16 z"
-       id="path4148-06"
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 15,300.76665 -8.004413,8 v -16 z"
+       id="path4148-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 7,300.76665 -7,8 v -16 z"
-       id="path4148-9-1"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       inkscape:transform-center-x="1.5625" />
   </g>
 </svg>

--- a/images/theme/white/go-previous.svg
+++ b/images/theme/white/go-previous.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="5.3033008"
-     inkscape:cy="10.290929"
+     inkscape:cx="10.638169"
+     inkscape:cy="10.606602"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1012"
+     inkscape:window-height="1005"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,24 +69,17 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146"
-       width="2"
+       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.66256;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-14-9"
+       width="2.717438"
        height="15.999988"
-       x="0"
+       x="11.239733"
        y="292.76666" />
     <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 2,300.76665 7,8 v -16 z"
-       id="path4148"
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 1,300.76665 7.9642365,8 v -16 z"
+       id="path4148-5-5"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
-    <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 9,300.76665 7,8 v -16 z"
-       id="path4148-9"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc"
-       inkscape:transform-center-x="-1.5625" />
   </g>
 </svg>

--- a/images/theme/white/media-skip-backward.svg
+++ b/images/theme/white/media-skip-backward.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="10.638169"
-     inkscape:cy="10.606602"
+     inkscape:cx="5.3033008"
+     inkscape:cy="10.290929"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="1012"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,17 +69,24 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.66256;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-14-9"
-       width="2.717438"
+       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146"
+       width="2"
        height="15.999988"
-       x="11.239733"
+       x="0"
        y="292.76666" />
     <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06665px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 1,300.76665 7.9642365,8 v -16 z"
-       id="path4148-5-5"
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 2,300.76665 7,8 v -16 z"
+       id="path4148"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 9,300.76665 7,8 v -16 z"
+       id="path4148-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="-1.5625" />
   </g>
 </svg>

--- a/images/theme/white/media-skip-forward.svg
+++ b/images/theme/white/media-skip-forward.svg
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="10.638169"
-     inkscape:cy="10.606602"
+     inkscape:cx="7.5130095"
+     inkscape:cy="9.6595836"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,7 +35,7 @@
      inkscape:pagecheckerboard="true"
      inkscape:object-paths="true"
      inkscape:window-width="1920"
-     inkscape:window-height="1005"
+     inkscape:window-height="1012"
      inkscape:window-x="0"
      inkscape:window-y="0"
      inkscape:window-maximized="1"
@@ -69,18 +69,25 @@
      id="layer1"
      transform="translate(0,-292.76665)">
     <rect
-       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4.61803;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect4146-14"
-       width="2.6657825"
+       style="opacity:1;fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4146-6"
+       width="2"
        height="15.999988"
-       x="-4.708612"
+       x="-16"
        y="292.76666"
        transform="scale(-1,1)" />
     <path
-       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.06934px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       d="m 15,300.76665 -8.004413,8 v -16 z"
-       id="path4148-5"
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14,300.76665 -7,8 v -16 z"
+       id="path4148-06"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#fcfcfc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 7,300.76665 -7,8 v -16 z"
+       id="path4148-9-1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:transform-center-x="1.5625" />
   </g>
 </svg>


### PR DESCRIPTION
The `sodipodi:docname` are also updated to the new names, but even without that git didn't detect it as files getting renamed.

Follow-up to (and fixes regression introduced by) 2470ff21a80906e63ede3e93b8ddcc1a60784641.

Fixes #554.