### PR TITLE
mainwindow: Limit the width of the recent files menu

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1744,6 +1744,7 @@ void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu
             displayString = track.url.fileName();
         else
             displayString = track.title;
+        displayString.truncate(100);
         QAction *a = new QAction(QString("%1").arg(displayString),
                                  this);
         connect(a, &QAction::triggered, this, [=]() {


### PR DESCRIPTION
Truncate the names of the recents entries to 100 characters to limit the menu width in case of a very long URL or filename.