### PR TITLE
main: Add Qt core strings translations on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,16 @@ qt_add_translations(mpc-qt
     LUPDATE_OPTIONS -locations none -no-ui-lines
 )
 
+if(WIN32) # Add the Qt interface translations on Windows
+    file(GLOB QT_QM_FILES "${PROJECT_SOURCE_DIR}/translations/qt/qtbase_*.qm")
+
+    qt_add_resources(mpc-qt "qt_translations"
+        PREFIX "/i18n/"
+        BASE "${PROJECT_SOURCE_DIR}/translations/qt"
+        FILES ${QT_QM_FILES}
+    )
+endif()
+
 target_link_libraries(mpc-qt PRIVATE
     Qt::Gui
     Qt::Network

--- a/main.cpp
+++ b/main.cpp
@@ -444,7 +444,7 @@ void Flow::setTranslation(QApplication *app, QTranslator *qtTranslator, QTransla
     if (localeSetting != 0)
         locale = QLocale("en");
 
-    if (qtTranslator->load(locale, "qt", "_", ":/i18n"))
+    if (qtTranslator->load(locale, "qtbase", "_", ":/i18n"))
         app->installTranslator(qtTranslator);
 
     if (appTranslator->load(locale, "mpc-qt", "_", ":/i18n"))

--- a/make-release-msys2.sh
+++ b/make-release-msys2.sh
@@ -20,6 +20,9 @@ BINDIR="/mingw64/bin"
 SUFFIX="win-x64"
 DEST="mpc-qt-$SUFFIX"
 
+mkdir -p translations/qt
+cp /mingw64/share/qt6/translations/qtbase_*.qm translations/qt
+
 cmake -DMPCQT_VERSION=$VERSION -DENABLE_LOCAL_MPV=ON -G Ninja -B build
 ninja -C build
 

--- a/make-release-win.sh
+++ b/make-release-win.sh
@@ -7,6 +7,9 @@ BUILDDIR=bin
 SUFFIX="win-x64-$VERSION"
 DEST="mpc-qt-$SUFFIX"
 
+mkdir -p translations/qt
+cp /mingw64/share/qt6/translations/qtbase_*.qm translations/qt
+
 cmake --build build --target clean
 rm -r build/*
 cmake -DMPCQT_VERSION=$DOTTEDVERSION -DENABLE_LOCAL_MPV=ON -G Ninja -B build


### PR DESCRIPTION
Since Windows users most likely don't have Qt installed, we need to add the Qt core strings translation files so that Qt interface strings like "OK" or "Cancel" get translated.
The core Qt dialogs and widgets strings are in the qtbase files.

Fixes #573.