### PR TITLE
helpers: Add module file formats

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -114,8 +114,28 @@ QSet<QString> Helpers::audioVideoFileExtensions {
     "m3u", "m3u8",
     "pls",
     "cue",
-    // Modfiles
-    "mod"
+    // Module file formats
+    "mod",
+    "s3m",
+    "xm",
+    "it",
+    "669",
+    "amf",
+    "ams",
+    "dbm",
+    "dmf",
+    "dsm",
+    "far",
+    "mdl",
+    "med",
+    "mtm",
+    "okt",
+    "ptm",
+    "stm",
+    "ult",
+    "umx",
+    "mt2",
+    "psm"
 };
 
 QSet<QString> Helpers::imagesFileExtensions {


### PR DESCRIPTION
These are the formats supported by libmodplug.

They play, but mpv seems to stop playing halfway through.
But since mpv kinda supports them, we can allow users to open them without creating default associations.

Fixes #578.