### PR TITLE
settingswindow: Enable hr-seek-framedrop by default for faster seeking

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7651,6 +7651,9 @@ media file played</string>
              <property name="text">
               <string>Drop frames before the seek target in the decoder</string>
              </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
             </widget>
            </item>
            <item row="2" column="0" colspan="2">


### PR DESCRIPTION
Allows faster seeking especially without hardware acceleration.
This is enabled by default in mpv.

I didn't notice any problem with deinterlacing enabled.