### PR TITLE
Show more information in the Properties window

### DIFF
--- a/helpers.cpp
+++ b/helpers.cpp
@@ -257,6 +257,8 @@ QString Helpers::toDateFormatWithZero(double time)
 
 QString Helpers::toDateFormatFixed(double time, Helpers::TimeFormat format)
 {
+    if (format == ShortFormat || format == ShortHourFormat)
+        time = std::round(time);
     int t = int(time*1000 + 0.5);
     if (t < 0)
         t = 0;

--- a/main.cpp
+++ b/main.cpp
@@ -823,8 +823,8 @@ void Flow::setupMpvObjectConnections()
             propertiesWindow, &PropertiesWindow::setMediaLength);
     connect(mpvObject, &MpvObject::videoSizeChanged,
             propertiesWindow, &PropertiesWindow::setVideoSize);
-    connect(mpvObject, &MpvObject::fileCreationTimeChanged,
-            propertiesWindow, &PropertiesWindow::setFileCreationTime);
+    connect(playbackManager, &PlaybackManager::startingPlayingFile,
+            propertiesWindow, &PropertiesWindow::setFileModifiedTime);
     connect(mpvObject, &MpvObject::tracksChanged,
             propertiesWindow, &PropertiesWindow::setTracks);
     connect(mpvObject, &MpvObject::mediaTitleChanged,

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -62,7 +62,6 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("audio-device-list", self_audioDeviceList, toList, QVariantList()),
     HANDLE_PROP("filename", fileNameChanged, toString, QString()),
     HANDLE_PROP("file-format", fileFormatChanged, toString, QString()),
-    HANDLE_PROP("file-date-created", fileCreationTimeChanged, toLongLong, 0ll),
     HANDLE_PROP("file-size", fileSizeChanged, toLongLong, 0ll),
     HANDLE_PROP("path", filePathChanged, toString, QString()),
     HANDLE_PROP("sub-text", subTextChanged, toString, QString())
@@ -171,7 +170,6 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "filename", 0, MPV_FORMAT_STRING },
         { "file-format", 0, MPV_FORMAT_STRING },
         { "file-size", 0, MPV_FORMAT_STRING },
-        { "file-date-created", 0, MPV_FORMAT_NODE },
         { "path", 0, MPV_FORMAT_STRING },
         { "seekable", 0, MPV_FORMAT_FLAG },
         { "sub-text", 0, MPV_FORMAT_STRING }

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -143,7 +143,6 @@ signals:
     void fileNameChanged(QString filename);
     void fileFormatChanged(QString format);
     void fileSizeChanged(int64_t size);
-    void fileCreationTimeChanged(int64_t secsSinceEpoch);
     void filePathChanged(QString path);
     void subTextChanged(QString subText);
     void playlistChanged(QVariantList playlist);

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -60,7 +60,7 @@ void PropertiesWindow::setFileSize(const int64_t &bytes)
 void PropertiesWindow::setMediaLength(double time)
 {
     ui->detailsLength->setText(time < 0 ? QString("-")
-                                        : Helpers::toDateFormat(time));
+                                        : Helpers::toDateFormatFixed(time, Helpers::ShortFormat));
 }
 
 void PropertiesWindow::setVideoSize(const QSize &sz)

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -65,8 +65,8 @@ void PropertiesWindow::setMediaLength(double time)
 
 void PropertiesWindow::setVideoSize(const QSize &sz)
 {
-    ui->detailsLength->setText(sz.isValid() ? QString("-")
-                                            : QString("%1 x %2").arg(sz.width(), sz.height()));
+    ui->detailsVideoSize->setText(!sz.isValid() ? QString("-")
+                                            : QString("%1 x %2").arg(sz.width()).arg(sz.height()));
 }
 
 void PropertiesWindow::setFileCreationTime(const int64_t &secsSinceEpoch)

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -153,11 +153,8 @@ void PropertiesWindow::setTracks(const QVariantList &tracks)
         trackText += sectionText(typeText + " #" + QString::number(trackId), track);
     }
 
-    QTextCursor cursor = ui->detailsTracks->textCursor();
-    cursor.select(QTextCursor::Document);
-    cursor.removeSelectedText();
-    cursor.insertText(lines.join('\n'));
-    ui->detailsTracks->setTextCursor(cursor);
+    ui->detailsTracks->clear();
+    ui->detailsTracks->insertPlainText(lines.join('\n'));
 
     updateLastTab();
 }
@@ -174,11 +171,8 @@ void PropertiesWindow::setMetaData(QVariantMap data)
                                : QString("-"));
     ui->clipRating->setText(data.contains("rating") ? data["rating"].toString() : QString("-"));
 
-    QTextCursor cursor = ui->clipDescription->textCursor();
-    cursor.select(QTextCursor::Document);
-    cursor.removeSelectedText();
-    cursor.insertText(data.contains("description") ? data["description"].toString() : QString());
-    ui->clipDescription->setTextCursor(cursor);
+    ui->clipDescription->clear();
+    ui->clipDescription->insertPlainText(data.contains("description") ? data["description"].toString() : QString());
 
     metadataText = sectionText(tr("General"), data);
     if (data.contains("artist") && data.contains("title"))
@@ -218,12 +212,8 @@ void PropertiesWindow::updateSaveVisibility()
 
 void PropertiesWindow::updateLastTab()
 {
-    QTextCursor cursor = ui->mediaInfoText->textCursor();
-    cursor.select(QTextCursor::Document);
-    cursor.removeSelectedText();
-    cursor.insertText(metadataText + trackText + chapterText);
-    cursor.setPosition(0);
-    ui->mediaInfoText->setTextCursor(cursor);
+    ui->mediaInfoText->clear();
+    ui->mediaInfoText->insertPlainText(generalDataText() + trackText + chapterText);
 }
 
 QString PropertiesWindow::sectionText(const QString &header, const QVariantMap &fields)

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -69,10 +69,12 @@ void PropertiesWindow::setVideoSize(const QSize &sz)
                                             : QString("%1 x %2").arg(sz.width()).arg(sz.height()));
 }
 
-void PropertiesWindow::setFileCreationTime(const int64_t &secsSinceEpoch)
+void PropertiesWindow::setFileModifiedTime(const QUrl &file)
 {
-    QDateTime date(QDateTime::fromMSecsSinceEpoch(secsSinceEpoch * 1000));
-    ui->detailsCreated->setText(date.isNull() ? QString("-") : date.toString());
+    QLocale locale;
+    auto lastModified = QFileInfo(file.toLocalFile()).lastModified();
+    ui->detailsModified->setText(!file.isLocalFile() ? QString("-") :
+                                                       locale.toString(lastModified, QLocale::ShortFormat));
 }
 
 void PropertiesWindow::setMediaTitle(const QString &title)

--- a/propertieswindow.cpp
+++ b/propertieswindow.cpp
@@ -104,12 +104,23 @@ void PropertiesWindow::setTracks(const QVariantList &tracks)
         QString type = track.contains("type") ? track["type"].toString() : QString();
         QString typeText = typeToText.value(type, "Unknown:");
         line << typeText << ":";
+        if (track.contains("lang")) {
+#if QT_VERSION < QT_VERSION_CHECK(6,3,0)
+            QString langName = QLocale::languageToString(QLocale(track["lang"].toString()).language());
+#else
+            QString langName = QLocale::languageToString(QLocale::codeToLanguage(
+                                                            track["lang"].toString(),
+                                                            QLocale::AnyLanguageCode));
+#endif
+            line << QString("%1").arg(langName);
+            line << QString("[%1]").arg(track["lang"].toString().remove('\n'));
+        }
         if (track.contains("decoder-desc"))
             line << track["decoder-desc"].toString().remove('\n');
         else if (track.contains("codec"))
             line << track["codec"].toString().remove('\n');
-        if (track.contains("lang"))
-            line << track["lang"].toString().remove('\n');
+        if (track.contains("codec-profile"))
+            line << track["codec-profile"].toString();
         if (track.contains("demux-w") && track.contains("demux-h"))
             line << QString("%1x%2").arg(QString::number(track["demux-w"].toInt()),
                                          QString::number(track["demux-h"].toInt()));
@@ -117,8 +128,22 @@ void PropertiesWindow::setTracks(const QVariantList &tracks)
             line << QString("%1fps").arg(QString::number(track["demux-fps"].toDouble(), 'g', 6));
         if (track.contains("demux-samplerate"))
             line << QString("%1kHz").arg(std::round(track["demux-samplerate"].toInt() / 100) / 10.0);
-        if (track.contains("audio-channels"))
-            line << QString("%1ch").arg(track["audio-channels"].toInt());
+        if (track.contains("demux-channels")) {
+            QString channels = track["demux-channels"].toString();
+            line << QString("%1").arg(channels.contains("unknown") ?
+                                                  channels.remove("unknown") + "ch" : channels);
+        }
+        int bitrate = 0;
+        if (track.contains("demux-bitrate"))
+            bitrate = track["demux-bitrate"].toInt();
+        else if (track.contains("metadata")) {
+            QVariantMap metadata = track["metadata"].toMap();
+            if (metadata.contains("BPS"))
+                bitrate = metadata["BPS"].toInt();
+        }
+        if (bitrate != 0 && (!track.contains("type") || track["type"].toString() != "sub"))
+            line << QString("%1 kb/s").arg(std::round(bitrate / 1000.0));
+
         lines << line.join(' ');
 
         int trackId = 0;

--- a/propertieswindow.h
+++ b/propertieswindow.h
@@ -27,7 +27,7 @@ public slots:
     void setFileSize(const int64_t &bytes);
     void setMediaLength(double time);
     void setVideoSize(const QSize &sz);
-    void setFileCreationTime(const int64_t &secsSinceEpoch);
+    void setFileModifiedTime(const QUrl &file);
     void setTracks(const QVariantList &tracks);
     void setMediaTitle(const QString &title);
     void setFilePath(const QString &path);

--- a/propertieswindow.h
+++ b/propertieswindow.h
@@ -40,12 +40,13 @@ private slots:
 
 private:
     void updateLastTab();
+    QString generalDataText();
     QString sectionText(const QString &header, const QVariantMap &fields);
 
     Ui::PropertiesWindow *ui;
 
     QString filename;
-    QString metadataText;
+    QVariantMap generalData;
     QString trackText;
     QString chapterText;
 };

--- a/propertieswindow.ui
+++ b/propertieswindow.ui
@@ -55,12 +55,6 @@
          </item>
          <item>
           <widget class="QLabel" name="detailsFilename">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
            <property name="text">
             <string notr="true">-</string>
            </property>
@@ -222,12 +216,6 @@
          </item>
          <item>
           <widget class="QLabel" name="clipFilename">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
            <property name="text">
             <string notr="true">-</string>
            </property>

--- a/propertieswindow.ui
+++ b/propertieswindow.ui
@@ -150,14 +150,14 @@
         </widget>
        </item>
        <item row="6" column="0">
-        <widget class="QLabel" name="detailsCreatedLabel">
+        <widget class="QLabel" name="detailsModifiedLabel">
          <property name="text">
-          <string>Created:</string>
+          <string>Modified:</string>
          </property>
         </widget>
        </item>
        <item row="6" column="1">
-        <widget class="QLabel" name="detailsCreated">
+        <widget class="QLabel" name="detailsModified">
          <property name="text">
           <string notr="true">-</string>
          </property>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1957,10 +1957,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Created:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Clip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2024,6 +2020,10 @@
     </message>
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2122,7 +2122,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Creat:</translation>
+        <translation type="vanished">Creat:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2191,6 +2191,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Documents de text (*.txt);;Tots els fitxers (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2114,7 +2114,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Erstellt:</translation>
+        <translation type="vanished">Erstellt:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2181,6 +2181,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Textdokumente (*.txt);;Alle Dateien (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2134,7 +2134,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Created:</translation>
+        <translation type="vanished">Created:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2203,6 +2203,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Text documents (*.txt);;All files (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2022,7 +2022,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Creado:</translation>
+        <translation type="vanished">Creado:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2091,6 +2091,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Documentos de texto (*.txt);;Todos los archivos (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1986,7 +1986,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Luotu:</translation>
+        <translation type="vanished">Luotu:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2055,6 +2055,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Tekstiasiakirjat (*.txt);;Kaikki tiedostot (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2054,7 +2054,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Créé :</translation>
+        <translation type="vanished">Créé :</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2123,6 +2123,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Documents texte (*.txt);;Tous les fichiers (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2057,10 +2057,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Created:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Clip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2124,6 +2120,10 @@
     </message>
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2018,7 +2018,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Creato:</translation>
+        <translation type="vanished">Creato:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2086,6 +2086,10 @@
     </message>
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2122,7 +2122,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>作成日時 :</translation>
+        <translation type="vanished">作成日時 :</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2191,6 +2191,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>テキスト ドキュメント (*.txt);;すべてのファイル (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1953,10 +1953,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Created:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Clip</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2020,6 +2016,10 @@
     </message>
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Modified:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1966,7 +1966,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Criação:</translation>
+        <translation type="vanished">Criação:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2035,6 +2035,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Documento de Texto (*.txt);;Todos os Arquivos (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2102,7 +2102,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Создан:</translation>
+        <translation type="vanished">Создан:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2171,6 +2171,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Текстовые документы (*.txt);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2122,7 +2122,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>உருவாக்கப்பட்டது:</translation>
+        <translation type="vanished">உருவாக்கப்பட்டது:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2191,6 +2191,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>உரை ஆவணங்கள் (*.txt) ;; அனைத்து கோப்புகளும் (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2122,7 +2122,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>Oluşturulma:</translation>
+        <translation type="vanished">Oluşturulma:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2191,6 +2191,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>Metin belgeleri (*.txt);;Tüm dosyalar (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2078,7 +2078,7 @@
     </message>
     <message>
         <source>Created:</source>
-        <translation>创建于:</translation>
+        <translation type="vanished">创建于:</translation>
     </message>
     <message>
         <source>Clip</source>
@@ -2147,6 +2147,10 @@
     <message>
         <source>Text documents (*.txt);;All files (*.*)</source>
         <translation>文本文档 (*.txt);;所有文件 (*.*)</translation>
+    </message>
+    <message>
+        <source>Modified:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
* propertieswindow: Show video size and media length

> Two bugs prevented both from being shown: the media length was overriden
> by a reversed test on the video size, so both were shown as empty.

* propertieswindow: Use short format for media length

* helpers: Round seconds for short formats in toDateFormatFixed

> So that for instance 01:32:05.923 is shown as 01:32:06 instead of 01:32:05.

* propertieswindow: Show the file modified date

> The mpv "file-date-created" doesn't seem to exist, and MPC-HC shows the
> file modified date, so let's do the same.

* propertieswindow: Don't let the filename take too much vertical space

> These sizePolicy probably shouldn't do it, but removing them fixes that
> problem in the Details and Clip tabs.

* propertieswindow: Add more track information

> Move language to the start and format it like "English [en]".
> Add codec profile, like "High" or "lc".
> Use "demux-channels" as it's more detailed ("5.1(side)" instead of "6ch").
> Add bitrate.

* propertieswindow: Simplify refreshing QPlainTextEdit content

* propertieswindow: Add more information in General section of Mediainfo tab

> Add filename, file format, size, time and overall_bitrate.

Fixes #577.