### PR TITLE
Use fast seek (by default) when hardware decoding is unavailable

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -759,6 +759,8 @@ void Flow::setupSettingsConnections()
             playbackManager, &PlaybackManager::setPlaybackForever);
     connect(settingsWindow, &SettingsWindow::playbackPlayTimes,
             playbackManager, &PlaybackManager::setPlaybackPlayTimes);
+    connect(settingsWindow, &SettingsWindow::fastSeek,
+            playbackManager, &PlaybackManager::setFastSeek);
     connect(settingsWindow, &SettingsWindow::fallbackToFolder,
             playbackManager, &PlaybackManager::setFolderFallback);
     connect(settingsWindow, &SettingsWindow::subsPreferDefaultForced,

--- a/manager.h
+++ b/manager.h
@@ -166,6 +166,7 @@ public slots:
     // playback options
     void setPlaybackPlayTimes(int times);
     void setPlaybackForever(bool yes);
+    void setFastSeek(bool yes);
     void setFolderFallback(bool yes);
 
     // misc functions
@@ -213,6 +214,7 @@ private slots:
     void mpvw_audioBitrateChanged(double bitrate);
     void mpvw_videoBitrateChanged(double bitrate);
     void mpvw_aspectNameChanged(QString newAspectName);
+    void mpvw_hwdecCurrentChanged(QString newHwdecCurrent);
 
 private:
     MpvObject *mpvObject_ = nullptr;
@@ -230,6 +232,7 @@ private:
     double speedStep = 1.25;
     bool speedStepAdditive = true;
     bool eofReached_ = false;
+    bool fastHardwareDecoding = false;
     double stepTimeNormal = 5.0;
     double stepTimeLarge = 20.0;
     PlaybackState playbackState_ = StoppedState;
@@ -258,6 +261,7 @@ private:
     int playbackPlayTimes = 1;
     bool playbackStartPaused = false;
     bool playbackForever = false;
+    bool fastSeek = true;
     bool folderFallback = false;
 
     bool timeShortMode = false;

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -64,7 +64,8 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("file-format", fileFormatChanged, toString, QString()),
     HANDLE_PROP("file-size", fileSizeChanged, toLongLong, 0ll),
     HANDLE_PROP("path", filePathChanged, toString, QString()),
-    HANDLE_PROP("sub-text", subTextChanged, toString, QString())
+    HANDLE_PROP("sub-text", subTextChanged, toString, QString()),
+    HANDLE_PROP("hwdec-current", hwdecCurrentChanged, toString, QString())
 };
 
 MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
@@ -172,7 +173,8 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "file-size", 0, MPV_FORMAT_STRING },
         { "path", 0, MPV_FORMAT_STRING },
         { "seekable", 0, MPV_FORMAT_FLAG },
-        { "sub-text", 0, MPV_FORMAT_STRING }
+        { "sub-text", 0, MPV_FORMAT_STRING },
+        { "hwdec-current", 0, MPV_FORMAT_STRING }
     };
     QSet<QString> throttled = {
         "time-pos", "avsync", "estimated-vf-fps", "frame-drop-count",

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -145,6 +145,7 @@ signals:
     void fileSizeChanged(int64_t size);
     void filePathChanged(QString path);
     void subTextChanged(QString subText);
+    void hwdecCurrentChanged(QString hwdecCurrent);
     void playlistChanged(QVariantList playlist);
 
     void audioTrackSet(int64_t id);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1055,7 +1055,7 @@ void SettingsWindow::sendSignals()
     emit option("screenshot-png-filter", WIDGET_LOOKUP(ui->pngFilter).toInt());
     emit option("screenshot-tag-colorspace", WIDGET_LOOKUP(ui->pngColorspace).toBool());
 
-    emit option("hr-seek", WIDGET_LOOKUP(ui->tweaksFastSeek).toBool() ? "absolute" : "yes");
+    emit fastSeek(WIDGET_LOOKUP(ui->tweaksFastSeek).toBool());
     emit option("hr-seek-framedrop", WIDGET_LOOKUP(ui->tweaksSeekFramedrop).toBool());
     emit fallbackToFolder(WIDGET_LOOKUP(ui->tweaksOpenNextFile).toBool());
     emit mpvMouseEvents(WIDGET_LOOKUP(ui->tweaksMpvMouseEvents).toBool());

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -174,6 +174,7 @@ signals:
     void encodeAudioBitrate(int kilobits);
 
     void chapterMarks(bool yes);
+    void fastSeek(bool yes);
     void fallbackToFolder(bool yes);
     void volumeMax(int maximum);
     void timeShorten(bool yes);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7639,7 +7639,10 @@ media file played</string>
            <item row="0" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksFastSeek">
              <property name="text">
-              <string>Fast seek (when skipping)</string>
+              <string>Prioritize seeking speed over accuracy</string>
+             </property>
+             <property name="toolTip">
+              <string>Seek to keyframe when hardware decoding is unavailable</string>
              </property>
              <property name="checked">
               <bool>true</bool>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -3659,10 +3659,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4220,6 +4216,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -3840,7 +3840,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Recerca ràpida (quan es salta)</translation>
+        <translation type="vanished">Recerca ràpida (quan es salta)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4400,6 +4400,14 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -3827,10 +3827,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4388,6 +4384,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3852,7 +3852,7 @@ media file played</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Fast seek (when skipping)</translation>
+        <translation type="vanished">Fast seek (when skipping)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4413,6 +4413,14 @@ media file played</translation>
     <message>
         <source>Custom mpv options:</source>
         <translation>Custom mpv options:</translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3736,7 +3736,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Búsqueda rápida (al omitir)</translation>
+        <translation type="vanished">Búsqueda rápida (al omitir)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4276,6 +4276,14 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3645,10 +3645,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4182,6 +4178,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -3772,7 +3772,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Recherche rapide (lors du saut)</translation>
+        <translation type="vanished">Recherche rapide (lors du saut)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4333,6 +4333,14 @@ fichier média lu</translation>
     <message>
         <source>Custom mpv options:</source>
         <translation>Options avancées pour mpv&#xa0;:</translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3727,10 +3727,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4272,6 +4268,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3708,7 +3708,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Ricerca veloce (durante salto)</translation>
+        <translation type="vanished">Ricerca veloce (durante salto)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4248,6 +4248,14 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -3840,7 +3840,7 @@ media file played</source>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>高速シーク (スキップ時)</translation>
+        <translation type="vanished">高速シーク (スキップ時)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4401,6 +4401,14 @@ media file played</source>
     <message>
         <source>Custom mpv options:</source>
         <translation>カスタム mpv オプション :</translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3643,10 +3643,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4196,6 +4192,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -3671,10 +3671,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Fast seek (when skipping)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Drop frames before the seek target in the decoder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4236,6 +4232,14 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3816,7 +3816,7 @@ media file played</source>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Быстрый поиск (с пропуском)</translation>
+        <translation type="vanished">Быстрый поиск (с пропуском)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4372,6 +4372,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -3840,7 +3840,7 @@ media file played</source>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>வேகமாக தேடுங்கள் (தவிர்க்கும்போது)</translation>
+        <translation type="vanished">வேகமாக தேடுங்கள் (தவிர்க்கும்போது)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4400,6 +4400,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -3828,7 +3828,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>Hızlı ara (atlama yaparken)</translation>
+        <translation type="vanished">Hızlı ara (atlama yaparken)</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4392,6 +4392,14 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3750,7 +3750,7 @@ media file played</source>
     </message>
     <message>
         <source>Fast seek (when skipping)</source>
-        <translation>快速定位</translation>
+        <translation type="vanished">快速定位</translation>
     </message>
     <message>
         <source>Drop frames before the seek target in the decoder</source>
@@ -4282,6 +4282,14 @@ media file played</source>
     </message>
     <message>
         <source>Custom mpv options:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Seek to keyframe when hardware decoding is unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prioritize seeking speed over accuracy</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Exact seeking, introduced by 1e0e9633c15e0a67e68ce2141006922d8875ae0d, can be rather slow when a fast (non-copy) hardware decoding isn't used.

While ede05e65460417f8e8bc4c1193b878b6a15f1b17 introduced fast seeking, it didn't affect small (now called normal) step seeking.

By detecting if fast hardware decoding is available for the current file, we can make the "fast seek" (now "Prioritize seeking speed over accuracy") Tweaks setting enable fast seek (aka keyframe seek) only when an exact seek would be slower.

The default "hr-seek" mpv setting, unlike the "absolute" one, enables accurate seek for audio files and fast seek - unless overridden by the "exact" parameter - for video files.

Both MPC-HC and mpv use fast seek by default.