### PR TITLE
settingswindow: Regroup and fix subtitles shadow settings

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -451,8 +451,7 @@ void SettingsWindow::setupColorPickers()
         { ui->windowInfoForegroundValue, ui->windowInfoForegroundPick },
         { ui->subsColorValue, ui->subsColorPick },
         { ui->subsBorderColorValue, ui->subsBorderColorPick },
-        { ui->subsShadowColorValue, ui->subsShadowColorPick },
-        { ui->subsBackcolorValue, ui->subsBackcolorpick }
+        { ui->subsShadowColorValue, ui->subsShadowColorPick }
     };
     for (const ValuePick c : colors) {
         connect(c.pick, &QPushButton::clicked,
@@ -986,7 +985,6 @@ void SettingsWindow::sendSignals()
     emit option("sub-italic", WIDGET_LOOKUP(ui->fontItalic).toBool());
     emit option("sub-font-size", WIDGET_LOOKUP(ui->fontSize).toInt());
     emit option("sub-border-size", WIDGET_LOOKUP(ui->borderSize).toInt());
-    emit option("sub-shadow-offset", WIDGET_LOOKUP(ui->borderShadowOffset).toInt());
     emit subtitlesDelayStep(WIDGET_LOOKUP(ui->subtitlesDelayStep).toInt());
     {
         struct AlignData { QRadioButton *btn; int x; int y; };
@@ -1025,9 +1023,9 @@ void SettingsWindow::sendSignals()
     emit option("sub-use-margins", !WIDGET_LOOKUP(ui->subsRelativeToVideoFrame).toBool());
     emit option("sub-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsColorValue).toString()));
     emit option("sub-border-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsBorderColorValue).toString()));
-    emit option("sub-shadow-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsShadowColorValue).toString()));
-    if (WIDGET_LOOKUP(ui->subsBackcolorEnabled).toBool())
-        emit option("sub-back-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsBackcolorValue).toString()));
+    emit option("sub-shadow-offset", WIDGET_LOOKUP(ui->subsShadowOffset).toInt());
+    if (WIDGET_LOOKUP(ui->subsShadowEnabled).toBool())
+        emit option("sub-back-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsShadowColorValue).toString()));
     else
         emit option("sub-back-color", "#00000000");
 
@@ -1501,6 +1499,15 @@ void SettingsWindow::on_ccICCBrowse_clicked()
         return;
 
     ui->ccICCLocation->setText(file);
+}
+
+void SettingsWindow::on_subsShadowEnabled_toggled(bool checked)
+{
+    ui->subsShadowColorLabel->setEnabled(checked);
+    ui->subsShadowColorValue->setEnabled(checked);
+    ui->subsShadowColorPick->setEnabled(checked);
+    ui->subsShadowOffsetLabel->setEnabled(checked);
+    ui->subsShadowOffset->setEnabled(checked);
 }
 
 // REMOVEME: Disable auto zoom in Wayland mode as window centering isn't possible yet

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -299,6 +299,8 @@ private slots:
 
     void on_ccICCBrowse_clicked();
 
+    void on_subsShadowEnabled_toggled(bool checked);
+
     void on_tweaksPreferWayland_toggled(bool checked);
 
     void on_tweaksTimeTooltip_toggled(bool checked);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6521,20 +6521,6 @@ media file played</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="1" column="0">
-                    <widget class="QLabel" name="borderShadowOffsetLabel">
-                     <property name="text">
-                      <string>Shadow offset</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="1" column="1">
-                    <widget class="QSpinBox" name="borderShadowOffset">
-                     <property name="maximum">
-                      <number>10</number>
-                     </property>
-                    </widget>
-                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -6744,10 +6730,32 @@ media file played</string>
                      </item>
                     </layout>
                    </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="subsShadowBox">
+                  <property name="title">
+                   <string>Shadow</string>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout_2">
+                   <item row="0" column="0" colspan="2">
+                    <widget class="QCheckBox" name="subsShadowEnabled">
+                     <property name="text">
+                      <string>Enable shadow</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="2" column="0">
                     <widget class="QLabel" name="subsShadowColorLabel">
                      <property name="text">
                       <string>Shadow color</string>
+                     </property>
+                     <property name="enabled">
+                      <bool>false</bool>
                      </property>
                     </widget>
                    </item>
@@ -6761,6 +6769,9 @@ media file played</string>
                        <property name="text">
                         <string notr="true">000000</string>
                        </property>
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
                       </widget>
                      </item>
                      <item>
@@ -6771,60 +6782,33 @@ media file played</string>
                        <property name="text">
                         <string/>
                        </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="subsBackcolorBox">
-                  <property name="title">
-                   <string>Back color</string>
-                  </property>
-                  <layout class="QGridLayout" name="gridLayout_2">
-                   <item row="0" column="0" colspan="2">
-                    <widget class="QCheckBox" name="subsBackcolorEnabled">
-                     <property name="text">
-                      <string>Enable back color</string>
-                     </property>
-                     <property name="checked">
-                      <bool>false</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="3" column="1">
-                    <layout class="QHBoxLayout" name="subsBackcolorLayout">
-                     <item>
-                      <widget class="QLineEdit" name="subsBackcolorValue">
-                       <property name="inputMask">
-                        <string>HHHHHH</string>
-                       </property>
-                       <property name="text">
-                        <string notr="true">000000</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <widget class="QPushButton" name="subsBackcolorpick">
-                       <property name="styleSheet">
-                        <string notr="true">background: #000000;</string>
-                       </property>
-                       <property name="text">
-                        <string/>
+                       <property name="enabled">
+                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
                     </layout>
                    </item>
                    <item row="3" column="0">
-                    <widget class="QLabel" name="subsBackcolorLabel">
+                    <widget class="QLabel" name="subsShadowOffsetLabel">
                      <property name="text">
-                      <string>Back color</string>
+                      <string>Shadow offset</string>
                      </property>
-                     <property name="alignment">
-                      <set>Qt::AlignmentFlag::AlignCenter</set>
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="1">
+                    <widget class="QSpinBox" name="subsShadowOffset">
+                     <property name="maximum">
+                      <number>10</number>
+                     </property>
+                     <property name="value">
+                      <number>1</number>
+                     </property>
+                     <property name="enabled">
+                      <bool>false</bool>
                      </property>
                     </widget>
                    </item>
@@ -7803,7 +7787,7 @@ media file played</string>
              </item>
             </widget>
            </item>
-           <item row="11" colspan="2">
+           <item row="11" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
              <property name="text">
               <string>Show OSD timer on seek</string>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -3919,14 +3919,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4224,6 +4216,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4104,11 +4104,11 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Back color</source>
-        <translation>Color de fons</translation>
+        <translation type="vanished">Color de fons</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>Habilitar color de fons</translation>
+        <translation type="vanished">Habilitar color de fons</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4408,6 +4408,14 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Ombra</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4087,14 +4087,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4392,6 +4384,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4116,11 +4116,11 @@ media file played</translation>
     </message>
     <message>
         <source>Back color</source>
-        <translation>Back color</translation>
+        <translation type="vanished">Back color</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>Enable back color</translation>
+        <translation type="vanished">Enable back color</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4420,6 +4420,14 @@ media file played</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Shadow</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3983,14 +3983,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4284,6 +4276,14 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Sombra</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3885,14 +3885,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4186,6 +4178,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Varjo</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4036,11 +4036,11 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Back color</source>
-        <translation>Couleur de fond</translation>
+        <translation type="vanished">Couleur de fond</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>Activer la couleur de fond</translation>
+        <translation type="vanished">Activer la couleur de fond</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4340,6 +4340,14 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Ombre</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3971,14 +3971,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4276,6 +4268,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3955,14 +3955,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4256,6 +4248,14 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4104,11 +4104,11 @@ media file played</source>
     </message>
     <message>
         <source>Back color</source>
-        <translation>背景色</translation>
+        <translation type="vanished">背景色</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>背景色を有効にする</translation>
+        <translation type="vanished">背景色を有効にする</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4408,6 +4408,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">シャドウ</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3891,14 +3891,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4200,6 +4192,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -3931,14 +3931,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4240,6 +4232,14 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Sombra</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4076,7 +4076,7 @@ media file played</source>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>Включить фон</translation>
+        <translation type="vanished">Включить фон</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4140,7 +4140,7 @@ media file played</source>
     </message>
     <message>
         <source>Back color</source>
-        <translation>Цвет фона</translation>
+        <translation type="vanished">Цвет фона</translation>
     </message>
     <message>
         <source>BT.470M</source>
@@ -4380,6 +4380,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Тень</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4104,11 +4104,11 @@ media file played</source>
     </message>
     <message>
         <source>Back color</source>
-        <translation>பின் நிறம்</translation>
+        <translation type="vanished">பின் நிறம்</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>பின் வண்ணத்தை இயக்கவும்</translation>
+        <translation type="vanished">பின் வண்ணத்தை இயக்கவும்</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4408,6 +4408,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">நிழல்</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4092,11 +4092,11 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Back color</source>
-        <translation>Arka plan rengi</translation>
+        <translation type="vanished">Arka plan rengi</translation>
     </message>
     <message>
         <source>Enable back color</source>
-        <translation>Arka plan rengini etkinleştir</translation>
+        <translation type="vanished">Arka plan rengini etkinleştir</translation>
     </message>
     <message>
         <source>Stylesheet</source>
@@ -4400,6 +4400,14 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">Gölge</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3993,14 +3993,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Enable back color</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Stylesheet</source>
         <translation>样式</translation>
     </message>
@@ -4290,6 +4282,14 @@ media file played</source>
     </message>
     <message>
         <source>Prioritize seeking speed over accuracy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shadow</source>
+        <translation type="unfinished">阴影</translation>
+    </message>
+    <message>
+        <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Regroup subtitles shadow color and shadow offset and use a checkbox to enable them like backcolor did.

The shadow offset is set to 1 by default so that the shadow is directly visible when enabled.

"sub-shadow-color" is an alias for "sub-back-color".
So the backcolor setting was overriding the shadow color setting and hiding the shadow if not enabled.

"Subtitles shadow" is more user-friendly and is what MPC-HC uses.

Fixes #582 (Bug: Subtitle shadows missing after program restart).