### PR TITLE
settingswindow: Add "Minimum" yt-dlp preset, remove presets, rename setting

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -161,8 +161,8 @@ QHash<QString, QStringList> SettingMap::indexedValueToText = {
     {"ccHdrMapper", {"clip", "mobius", "reinhard", "hable", "gamma", \
                      "linear"}},
     {"ccHdrCompute", {"auto", "yes", "no"}},
-    {"ytdlpMaxHeight", {"240", "360", "480", "720", "1080", "1440",
-                             "2160", "2880", "4320"}},
+    {"ytdlpQuality", {"minimum", "480", "720", "1080",
+                      "1440", "2160", "2880", "4320"}},
     {"audioChannels", {"auto-safe", "auto", "stereo"}},
     {"audioRenderer", {"pulse", "alsa", "oss", "null"}},
     {"audioAutoloadMatch", { "exact", "fuzzy", "all" }},
@@ -768,7 +768,10 @@ void SettingsWindow::sendSignals()
 
     emit afterPlaybackDefault(Helpers::AfterPlayback(WIDGET_LOOKUP(ui->afterPlaybackDefault).toInt()));
 
-    emit option("ytdl-format", QString("bestvideo[height<=%1]+bestaudio/best").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
+    if (WIDGET_TO_TEXT(ui->ytdlpQuality) != "minimum")
+        emit option("ytdl-format", QString("bestvideo[height<=%1]+bestaudio/best").arg(WIDGET_TO_TEXT(ui->ytdlpQuality)));
+    else
+        emit option("ytdl-format", "worstvideo+worstaudio");
 
     emit zoomCenter(WIDGET_LOOKUP(ui->playbackAutoCenterWindow).toBool());
     double factor = WIDGET_LOOKUP(ui->playbackAutoFitFactor).toInt() / 100.0;

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1498,23 +1498,18 @@ media file played</string>
               <item>
                <widget class="QLabel" name="ytdlpLabel">
                 <property name="text">
-                 <string>Max video height:</string>
+                 <string>Quality:</string>
                 </property>
                </widget>
               </item>
               <item>
-               <widget class="QComboBox" name="ytdlpMaxHeight">
+               <widget class="QComboBox" name="ytdlpQuality">
                 <property name="currentIndex">
-                 <number>4</number>
+                 <number>3</number>
                 </property>
                 <item>
                  <property name="text">
-                  <string notr="true">240</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string notr="true">360</string>
+                  <string notr="true">Minimum</string>
                  </property>
                 </item>
                 <item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4191,10 +4191,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,6 +4208,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4395,10 +4395,6 @@ arxiu multimèdia reproduït</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4416,6 +4412,10 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4367,10 +4367,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4388,6 +4384,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4408,7 +4408,7 @@ media file played</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Max video height:</translation>
+        <translation type="vanished">Max video height:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4429,6 +4429,10 @@ media file played</translation>
     <message>
         <source>Enable shadow</source>
         <translation>Enable shadow</translation>
+    </message>
+    <message>
+        <source>Quality:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4263,10 +4263,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4284,6 +4280,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4153,10 +4153,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4174,6 +4170,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4328,7 +4328,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Hauteur maximale des vidéos&#xa0;:</translation>
+        <translation type="vanished">Hauteur maximale des vidéos&#xa0;:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4349,6 +4349,10 @@ fichier média lu</translation>
     <message>
         <source>Enable shadow</source>
         <translation>Activer l&apos;ombre</translation>
+    </message>
+    <message>
+        <source>Quality:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4243,10 +4243,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4264,6 +4260,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4235,10 +4235,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4256,6 +4252,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4396,7 +4396,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>ビデオの最大高さ :</translation>
+        <translation type="vanished">ビデオの最大高さ :</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4417,6 +4417,10 @@ media file played</source>
     <message>
         <source>Enable shadow</source>
         <translation>影を有効にする</translation>
+    </message>
+    <message>
+        <source>Quality:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4167,10 +4167,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4188,6 +4184,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4211,10 +4211,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4232,6 +4228,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4368,7 +4368,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Максимальная высота видео:</translation>
+        <translation type="vanished">Максимальная высота видео:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4388,6 +4388,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4396,7 +4396,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>அதிகபட்ச வீடியோ உயரம்:</translation>
+        <translation type="vanished">அதிகபட்ச வீடியோ உயரம்:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4416,6 +4416,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4388,7 +4388,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>En çok video yüksekliği:</translation>
+        <translation type="vanished">En çok video yüksekliği:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4408,6 +4408,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4269,10 +4269,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4290,6 +4286,10 @@ media file played</source>
     </message>
     <message>
         <source>Enable shadow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quality:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Users with low bandwith or metered Internet connections need to use the "worstvideo" and "worstaudio" yt-dlp format to get the smallest file possible.
So the new "Minimum" yt-dlp preset does that.
The 240 and 360 presets don't make much sense as users who don't want at least 480 quality probably want the smallest file.
Renaming that setting to "Quality" as that seems more used elsewhere and makes more sense with the "Minimum" preset.

Fixes #466.