### PR TITLE
videopreview: Request minimum file size for yt-dlp

### DIFF
--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -26,7 +26,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
-    emit mpv->ctrlSetOptionVariant("ytdl-format", "worst");
+    emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "format-sort=[+size,+br,+res,+fps]");
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 
     connect(mpv, &MpvObject::aspectChanged,


### PR DESCRIPTION
This is recommended in the yt-dlp documentation to get the absolute minimum video file size.
The "worst" preset isn't specific enough and doesn't work for all video sources. "worstvideo" is better but still isn't specific enough as we're interested about the filesize.
This preset notably works better for bilibili (see #466, though that issue isn't about the video preview).