### PR TITLE
Improve video presets workflow and remove debanding from "Highest" preset

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -578,7 +578,6 @@ void SettingsWindow::generateVideoPresets()
     setWidget(ui->scaleScaler, 13); // scale=ewa_lanczossharp
     setWidget(ui->dscaleScaler, 15);  // dscale=ewa_lanczossoft
     setWidget(ui->cscaleScaler, 13); // cscale=ewa_lanczossharp
-    setWidget(ui->debandEnabled, true); //deband=yes
     videoPresets.append(videoWidgets);
 
     // placebo

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -345,6 +345,8 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
     ui->audioTabs->setCurrentIndex(0);
     ui->hwdecTabs->setCurrentIndex(0);
 
+    ui->videoPresetApplied->clear();
+
     ui->screenshotDirectoryValue->setPlaceholderText(
                 QStandardPaths::writableLocation(
                     QStandardPaths::PicturesLocation) + "/mpc_shots");
@@ -518,7 +520,8 @@ SettingMap SettingsWindow::generateSettingMap(QWidget *root)
             && !item->objectName().isEmpty()
             && item->objectName() != "qt_spinbox_lineedit"
             && item->objectName() != "qt_keysequenceedit_lineedit"
-            && item->objectName() != "keysSearchField") {
+            && item->objectName() != "keysSearchField"
+            && item->objectName() != "videoPreset") {
             QString name = item->objectName();
             QString className = item->metaObject()->className();
             QVariant value = Setting::classFetcher[className](item);
@@ -1268,6 +1271,7 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
     restoreAudioSettings();
     setCustomMpvOptions();
     ui->keysSearchField->clear();
+    ui->videoPreset->setCurrentIndex(0);
 }
 
 void SettingsWindow::keyPressEvent(QKeyEvent *event)
@@ -1365,10 +1369,16 @@ void SettingsWindow::on_logoInternal_currentIndexChanged(int index)
     updateLogoWidget();
 }
 
-void SettingsWindow::on_videoPresetLoad_clicked()
+void SettingsWindow::on_videoPreset_currentIndexChanged(int index)
 {
-    for (Setting &s : videoPresets[ui->videoPreset->currentIndex()])
-        s.sendToControl();
+    if (index > 0) {
+        for (Setting &s : videoPresets[index-1])
+            s.sendToControl();
+        ui->videoPresetApplied->setText(tr("Preset applied"));
+        QTimer::singleShot(3000, this, [this]() {
+            ui->videoPresetApplied->clear();
+        });
+    }
 }
 
 void SettingsWindow::on_screenshotFormat_currentIndexChanged(int index)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -259,7 +259,7 @@ private slots:
 
     void on_logoInternal_currentIndexChanged(int index);
 
-    void on_videoPresetLoad_clicked();
+    void on_videoPreset_currentIndexChanged(int index);
 
     void on_screenshotFormat_currentIndexChanged(int index);
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -172,7 +172,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>20</number>
+          <number>7</number>
          </property>
          <widget class="QWidget" name="playerPage">
           <layout class="QGridLayout" name="playerPageLayout">
@@ -264,11 +264,11 @@
            </item>
            <item row="1" column="0">
             <widget class="QGroupBox" name="playerLanguageBox">
-             <property name="title">
-              <string>Language Override</string>
-             </property>
              <property name="toolTip">
               <string>Requires restarting the application to apply changes</string>
+             </property>
+             <property name="title">
+              <string>Language Override</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_17">
               <item>
@@ -741,8 +741,8 @@ media file played</string>
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>68</width>
-                   <height>16</height>
+                   <width>96</width>
+                   <height>26</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_6"/>
@@ -1715,7 +1715,7 @@ media file played</string>
                    </widget>
                   </item>
                   <item row="3" column="1">
-                   <layout class="QHBoxLayout" name="videoPresetLayout" stretch="1,1,2">
+                   <layout class="QHBoxLayout" name="videoPresetLayout" stretch="1,0,2">
                     <item>
                      <widget class="QComboBox" name="videoPreset">
                       <property name="sizePolicy">
@@ -6711,11 +6711,11 @@ media file played</string>
                    </item>
                    <item row="2" column="0">
                     <widget class="QLabel" name="subsShadowColorLabel">
-                     <property name="text">
-                      <string>Shadow color</string>
-                     </property>
                      <property name="enabled">
                       <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Shadow color</string>
                      </property>
                     </widget>
                    </item>
@@ -6723,27 +6723,27 @@ media file played</string>
                     <layout class="QHBoxLayout" name="subsShadowColorLayout">
                      <item>
                       <widget class="QLineEdit" name="subsShadowColorValue">
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
                        <property name="inputMask">
                         <string>HHHHHH</string>
                        </property>
                        <property name="text">
                         <string notr="true">000000</string>
                        </property>
-                       <property name="enabled">
-                        <bool>false</bool>
-                       </property>
                       </widget>
                      </item>
                      <item>
                       <widget class="QPushButton" name="subsShadowColorPick">
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
                        <property name="styleSheet">
                         <string notr="true">background: #000000;</string>
                        </property>
                        <property name="text">
                         <string/>
-                       </property>
-                       <property name="enabled">
-                        <bool>false</bool>
                        </property>
                       </widget>
                      </item>
@@ -6751,24 +6751,24 @@ media file played</string>
                    </item>
                    <item row="3" column="0">
                     <widget class="QLabel" name="subsShadowOffsetLabel">
-                     <property name="text">
-                      <string>Shadow offset</string>
-                     </property>
                      <property name="enabled">
                       <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Shadow offset</string>
                      </property>
                     </widget>
                    </item>
                    <item row="3" column="1">
                     <widget class="QSpinBox" name="subsShadowOffset">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
                      <property name="maximum">
                       <number>10</number>
                      </property>
                      <property name="value">
                       <number>1</number>
-                     </property>
-                     <property name="enabled">
-                      <bool>false</bool>
                      </property>
                     </widget>
                    </item>
@@ -7612,11 +7612,11 @@ media file played</string>
           <layout class="QFormLayout" name="tweaksPageLayout">
            <item row="0" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksFastSeek">
-             <property name="text">
-              <string>Prioritize seeking speed over accuracy</string>
-             </property>
              <property name="toolTip">
               <string>Seek to keyframe when hardware decoding is unavailable</string>
+             </property>
+             <property name="text">
+              <string>Prioritize seeking speed over accuracy</string>
              </property>
              <property name="checked">
               <bool>true</bool>
@@ -7816,7 +7816,7 @@ media file played</string>
             </layout>
            </item>
            <item row="13" column="1">
-            <layout class="QHBoxLayout" name="tweaksMpvOptionsTextLayout" stretch="1,0">
+            <layout class="QHBoxLayout" name="tweaksMpvOptionsTextLayout" stretch="1">
              <item>
               <widget class="QLineEdit" name="tweaksMpvOptionsText">
                <property name="enabled">

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1718,6 +1718,17 @@ media file played</string>
                    <layout class="QHBoxLayout" name="videoPresetLayout" stretch="1,1,2">
                     <item>
                      <widget class="QComboBox" name="videoPreset">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <item>
+                       <property name="text">
+                        <string>Select</string>
+                       </property>
+                      </item>
                       <item>
                        <property name="text">
                         <string>Plain</string>
@@ -1751,9 +1762,9 @@ media file played</string>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QPushButton" name="videoPresetLoad">
+                     <widget class="QLabel" name="videoPresetApplied">
                       <property name="text">
-                       <string>Load</string>
+                       <string>Preset applied</string>
                       </property>
                      </widget>
                     </item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4214,6 +4214,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4418,6 +4418,14 @@ arxiu multimèdia reproduït</translation>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4394,6 +4394,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4430,6 +4430,14 @@ media file played</translation>
         <source>Enable shadow</source>
         <translation>Enable shadow</translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4286,6 +4286,14 @@ archivo multimedia reproducido</translation>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4176,6 +4176,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4350,6 +4350,14 @@ fichier média lu</translation>
         <source>Enable shadow</source>
         <translation>Activer l&apos;ombre</translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4266,6 +4266,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4258,6 +4258,14 @@ ogni file multimediale riprodotto</translation>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4418,6 +4418,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation>影を有効にする</translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4190,6 +4190,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4234,6 +4234,14 @@ arquivo de mídia reproduzido</translation>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4390,6 +4390,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4418,6 +4418,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4410,6 +4410,14 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4292,6 +4292,14 @@ media file played</source>
         <source>Enable shadow</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Select</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Preset applied</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
* settingswindow: Remove video debanding from "Highest" preset

> mpv removed it in its high-quality profile as it worsens the quality for
> content that don't require debanding.
> See https://github.com/mpv-player/mpv/pull/13172

* settingswindow: Apply video preset immediately when selected in menu

> Includes a temporary message to let the user know that the preset has
> been applied.

* settingswindow: Reformat .ui file with Qt Designer

> After making changes by hand, this is needed so that the actual changes
> are not drowned out by Qt Designer’s auto-reformatting.
> The way to avoid this step is of course to load and save the .ui file in
> Qt Designer after making changes by hand.

Changes suggested in #597.