### PR TITLE
settingswindow: Implement more subtitle options

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -484,8 +484,6 @@ void SettingsWindow::setupUnimplementedWidgets()
     ui->shadersPresetsBox->setVisible(false);
 
     ui->subtitlePlacementBox->setVisible(false);
-    ui->subtitlesFixTiming->setVisible(false);
-    ui->subtitlesClearOnSeek->setVisible(false);
     ui->subtitlesAssOverride->setVisible(false);
     ui->subtitlesAssOverrideLabel->setVisible(false);
 
@@ -985,6 +983,9 @@ void SettingsWindow::sendSignals()
     emit option("sub-italic", WIDGET_LOOKUP(ui->fontItalic).toBool());
     emit option("sub-font-size", WIDGET_LOOKUP(ui->fontSize).toInt());
     emit option("sub-border-size", WIDGET_LOOKUP(ui->borderSize).toInt());
+
+    emit option("sub-fix-timing", WIDGET_LOOKUP(ui->subtitlesFixTiming).toBool());
+    emit option("sub-clear-on-seek", WIDGET_LOOKUP(ui->subtitlesClearOnSeek).toBool());
     emit subtitlesDelayStep(WIDGET_LOOKUP(ui->subtitlesDelayStep).toInt());
     {
         struct AlignData { QRadioButton *btn; int x; int y; };
@@ -1021,6 +1022,7 @@ void SettingsWindow::sendSignals()
     emit option("sub-margin-x", WIDGET_LOOKUP(ui->subsMarginX).toInt());
     emit option("sub-margin-y", WIDGET_LOOKUP(ui->subsMarginY).toInt());
     emit option("sub-use-margins", !WIDGET_LOOKUP(ui->subsRelativeToVideoFrame).toBool());
+    emit option("sub-ass-force-margins", !WIDGET_LOOKUP(ui->subsAssRelativeToVideoFrame).toBool());
     emit option("sub-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsColorValue).toString()));
     emit option("sub-border-color", QString("#%1").arg(WIDGET_LOOKUP(ui->subsBorderColorValue).toString()));
     emit option("sub-shadow-offset", WIDGET_LOOKUP(ui->subsShadowOffset).toInt());

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6325,9 +6325,6 @@ media file played</string>
                 <property name="text">
                  <string>Fix timing</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
                </widget>
               </item>
               <item row="2" column="0" colspan="2">
@@ -6616,6 +6613,13 @@ media file played</string>
                      </property>
                      <property name="checked">
                       <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="subsAssRelativeToVideoFrame">
+                     <property name="text">
+                      <string>Position ASS subs relative to the video frame</string>
                      </property>
                     </widget>
                    </item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4222,6 +4222,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4426,6 +4426,10 @@ arxiu multimèdia reproduït</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4402,6 +4402,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4438,6 +4438,10 @@ media file played</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4294,6 +4294,10 @@ archivo multimedia reproducido</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4184,6 +4184,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4358,6 +4358,10 @@ fichier média lu</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4274,6 +4274,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4266,6 +4266,10 @@ ogni file multimediale riprodotto</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4426,6 +4426,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4198,6 +4198,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4242,6 +4242,10 @@ arquivo de mídia reproduzido</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4398,6 +4398,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4426,6 +4426,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4418,6 +4418,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4300,6 +4300,10 @@ media file played</source>
         <source>Preset applied</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Position ASS subs relative to the video frame</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
Implement sub-fix-timing, sub-clear-on-seek and sub-ass-force-margins. Note that "Fix timing" was enabled by default, so users will need to disable it if they don't want it.

sub-fix-timing removes minor gaps or overlaps between subtitles.

sub-clear-on-seek can be used to play broken mkv files with duplicate ReadOrder fields for ASS subtitles.

sub-ass-force-margins enables placing ASS toptitles and subtitles in black borders when they are available.

Fixes #515 (Add 'sub-ass-force-margins' into options).