### PR TITLE
Don't percent-encode filename for screenshot name and use stream title for streams

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1230,8 +1230,11 @@ QString Flow::pictureTemplate(Helpers::DisabledTrack tracks, Helpers::Subtitles 
 {
     double playTime = mainWindow->mpvObject()->playTime();
     QUrl nowPlaying = playbackManager->nowPlaying();
-    QString basename = QFileInfo(nowPlaying.toDisplayString().split('/').last())
-                       .completeBaseName();
+    QString basename;
+    if (nowPlaying.isLocalFile())
+        basename = QFileInfo(nowPlaying.fileName()).completeBaseName();
+    else
+        basename = Platform::sanitizedFilename(playbackManager->nowPlayingTitle());
 
     // FIXME: Use parseFormatEx?
     QString fileName = Helpers::parseFormat(screenshotTemplate, basename, tracks, subs, playTime, 0, 0);

--- a/manager.cpp
+++ b/manager.cpp
@@ -642,7 +642,7 @@ void PlaybackManager::sendCurrentTrackInfo()
 {
     QUrl url(playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem));
     emit currentTrackInfo({url, nowPlayingList, nowPlayingItem,
-                           nowPlayingTitle, mpvLength, mpvTime,
+                           nowPlayingTitle_, mpvLength, mpvTime,
                            videoTrackSelected, audioTrackSelected, subtitleTrackSelected});
 }
 
@@ -653,13 +653,17 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
     url = playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem);
     listUuid = nowPlayingList;
     itemUuid = nowPlayingItem;
-    title = nowPlayingTitle;
+    title = nowPlayingTitle_;
     length = mpvLength;
     position = mpvTime;
     videoTrack = videoTrackSelected;
     audioTrack = audioTrackSelected;
     subtitleTrack = subtitleTrackSelected;
     hasVideo = !videoList.isEmpty() && !videoListData[1].isImage;
+}
+
+QString PlaybackManager::nowPlayingTitle() {
+    return nowPlayingTitle_;
 }
 
 void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
@@ -986,7 +990,7 @@ void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
 
 void PlaybackManager::mpvw_mediaTitleChanged(QString title)
 {
-    nowPlayingTitle = title;
+    nowPlayingTitle_ = title;
     emit titleChanged(title);
     emit titleChangedWithFilename(title,
                                   nowPlaying().isLocalFile() ? nowPlaying().fileName() : QString());
@@ -1103,8 +1107,8 @@ void PlaybackManager::mpvw_hwdecCurrentChanged(QString newHwdecCurrent)
 void PlaybackManager::mpvw_metadataChanged(QVariantMap metadata)
 {
     // yt-dlp metadata doesn't include the title, so let's add it
-    if (!nowPlaying_.isLocalFile() && !nowPlayingTitle.isEmpty() && !metadata.contains("title"))
-        metadata.insert("title", nowPlayingTitle);
+    if (!nowPlaying_.isLocalFile() && !nowPlayingTitle_.isEmpty() && !metadata.contains("title"))
+        metadata.insert("title", nowPlayingTitle_);
     playlistWindow_->setMetadata(nowPlayingList, nowPlayingItem, metadata);
 }
 

--- a/manager.h
+++ b/manager.h
@@ -174,6 +174,7 @@ public slots:
     void getCurrentTrackInfo(QUrl &url, QUuid &listUuid, QUuid &itemUuid, QString &title,
                              double &length, double &position, int64_t &videoTrack,
                              int64_t &audioTrack, int64_t &subtitleTrack, bool &hasVideo);
+    QString nowPlayingTitle();
 
 private:
     enum AspectNameChanged { OnOpen, OnFirstPlay, Manually };
@@ -222,7 +223,7 @@ private:
     QUrl  nowPlaying_;
     QUuid nowPlayingList;
     QUuid nowPlayingItem;
-    QString nowPlayingTitle;
+    QString nowPlayingTitle_;
     int64_t currentMpvPlaylistItemId = 0;
 
     double mpvStartTime = -1.0;

--- a/platform/unify.cpp
+++ b/platform/unify.cpp
@@ -89,6 +89,8 @@ QString Platform::sanitizedFilename(QString fileName)
     if (isWindows)
         for (auto f : {':', '<', '>', '"', '/', '\\', '|', '?', '*'})
             fileName.replace(f, '.');
+    else
+        fileName.replace('/', '.');
     return fileName;
 }
 


### PR DESCRIPTION
`QUrl::toDisplayString()` returns a percent-encoded string ("%5B" and "%5D" instead of "[" and "]"), even when using the `QUrl::FullyDecoded` format.
`QUrl::fileName()` doesn't have that problem and already uses that format by default. It also returns the filename so we don't have to manually remove the directory path.

Like for recent files, streams usually don't have a useful filename, so their title is used instead.
If the title includes a slash, we have to replace it for *nix systems.

Fixes #600 (Keep the original file name when saving screenshot (don't convert characters to percent-encoding character)).