### PR TITLE
playlistwindow: Make the "Quick Playlist" name fully translatable

### DIFF
--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -278,6 +278,8 @@ void PlaylistWindow::tabsFromVList(const QVariantList &qvl)
         connect(qdp, &DrawnPlaylist::contextMenuRequested,
                 this, &PlaylistWindow::playlist_contextMenuRequested);
         auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
+        if (pl->uuid().isNull())
+            pl->setTitle(tr("Quick Playlist"));
         ui->tabWidget->addTab(qdp, pl->title());
         widgets.insert(pl->uuid(), qdp);
     }


### PR DESCRIPTION
While the "Quick Playlist" name was translated on first start, that name was then saved with the playlist and reused during following starts. By translating it on restore, we make sure the currently selected language is used.