### PR TITLE
Add a setting to choose whether to remember Quick Playlist content

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -162,7 +162,8 @@ Flow::~Flow()
             updateRecentPosition(false);
             settings = settingsWindow->settings();
             writeConfig();
-            storage.writeVList(filePlaylists, mainWindow->playlistWindow()->tabsToVList());
+            storage.writeVList(filePlaylists,
+                               mainWindow->playlistWindow()->tabsToVList(rememberQuickPlaylist));
             storage.writeVList(filePlaylistsBackup, PlaylistCollection::getBackup()->toVList());
         }
         delete mainWindow;
@@ -917,6 +918,8 @@ void Flow::setupFlowConnections()
             this, &Flow::settingswindow_rememberHistory);
     connect(settingsWindow, &SettingsWindow::rememberFilePosition,
             this, &Flow::settingswindow_rememberFilePosition);
+    connect(settingsWindow, &SettingsWindow::rememberQuickPlaylist,
+            this, &Flow::settingswindow_rememberQuickPlaylist);
     connect(settingsWindow, &SettingsWindow::rememberWindowGeometry,
             this, &Flow::settingswindow_rememberWindowGeometry);
     connect(settingsWindow, &SettingsWindow::rememberPanels,
@@ -1567,6 +1570,12 @@ void Flow::settingswindow_rememberFilePosition(bool yes)
 {
     // Remember our preference to restore the position when opening a file
     this->rememberFilePosition = yes;
+}
+
+void Flow::settingswindow_rememberQuickPlaylist(bool yes)
+{
+    // Remember our preference to restore the content of the Quick Playlist
+    this->rememberQuickPlaylist = yes;
 }
 
 void Flow::settingswindow_rememberWindowGeometry(bool yes)

--- a/main.h
+++ b/main.h
@@ -92,6 +92,7 @@ private slots:
     void settingswindow_inhibitScreensaver(bool yes);
     void settingswindow_rememberHistory(bool yes, bool onlyVideos);
     void settingswindow_rememberFilePosition(bool yes);
+    void settingswindow_rememberQuickPlaylist(bool yes);
     void settingswindow_rememberWindowGeometry(bool yes);
     void settingswindow_rememberPanels(bool yes);
     void settingswindow_keymapData(const QVariantMap &keyMap);
@@ -151,6 +152,7 @@ private:
     bool rememberHistory = true;
     bool rememberHistoryOnlyForVideos = true;
     bool rememberFilePosition = false;
+    bool rememberQuickPlaylist = true;
     bool rememberWindowGeometry = false;
     bool rememberPanels = false;
     bool nowPlayingDisplayingSubtitles = true;

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -247,11 +247,13 @@ void PlaylistWindow::deltaExtraPlayTimes(QUuid list, QUuid item, int delta)
 }
 
 // Save the tabs on stop
-QVariantList PlaylistWindow::tabsToVList() const
+QVariantList PlaylistWindow::tabsToVList(bool saveQuickPlaylist) const
 {
     QVariantList qvl;
     for (int i = 0; i < ui->tabWidget->count(); i++) {
         auto widget = reinterpret_cast<DrawnPlaylist *>(ui->tabWidget->widget(i));
+        if (!saveQuickPlaylist && widget->uuid().isNull())
+            widget->removeAll();
         qvl.append(widget->toVMap());
     }
     qvl.append(QVariantMap{{keyCurrentPlaylist, currentPlaylist}});

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -44,7 +44,7 @@ public:
     void deltaExtraPlayTimes(QUuid list, QUuid item, int delta);
     void reshufflePlaylist(const QUuid &playlistUuid);
 
-    QVariantList tabsToVList() const;
+    QVariantList tabsToVList(bool saveQuickPlaylist) const;
     void tabsFromVList(const QVariantList &qvl);
 
 protected:

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -719,6 +719,10 @@ void SettingsWindow::sendSignals()
     emit rememberHistory(WIDGET_LOOKUP(ui->playerKeepHistory).toBool(),
                          WIDGET_LOOKUP(ui->playerKeepHistoryOnlyForVideos).toBool());
     emit rememberFilePosition(WIDGET_LOOKUP(ui->playerRememberFilePosition).toBool());
+    if (!WIDGET_LOOKUP(ui->playerKeepHistory).toBool())
+        emit rememberQuickPlaylist(false);
+    else
+        emit rememberQuickPlaylist(WIDGET_LOOKUP(ui->playerRememberQuickPlaylist).toBool());
     emit rememberSelectedPlaylist(WIDGET_LOOKUP(ui->playerRememberLastPlaylist).toBool());
     emit rememberWindowGeometry(WIDGET_LOOKUP(ui->playerRememberWindowGeometry).toBool());
     emit rememberPanels(WIDGET_LOOKUP(ui->playerRememberPanels).toBool());
@@ -1114,6 +1118,7 @@ void SettingsWindow::setFreestanding(bool freestanding)
     ui->playerKeepHistory->setVisible(yes);
     ui->playerKeepHistoryOnlyForVideos->setVisible(yes);
     ui->playerRememberFilePosition->setVisible(yes);
+    ui->playerRememberQuickPlaylist->setVisible(yes);
     ui->playerRememberLastPlaylist->setVisible(yes);
     ui->playerRememberWindowGeometry->setVisible(yes);
     ui->playerRememberPanels->setVisible(yes);
@@ -1304,8 +1309,10 @@ void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state
 {
     bool playerKeepHistoryEnabled = state == Qt::Checked;
     ui->playerRememberFilePosition->setChecked(playerKeepHistoryEnabled);
+    ui->playerRememberQuickPlaylist->setChecked(playerKeepHistoryEnabled);
     ui->playerKeepHistoryOnlyForVideos->setEnabled(playerKeepHistoryEnabled);
     ui->playerRememberFilePosition->setEnabled(playerKeepHistoryEnabled);
+    ui->playerRememberQuickPlaylist->setEnabled(playerKeepHistoryEnabled);
 }
 
 void SettingsWindow::on_interfaceIconsTheme_currentIndexChanged(int index)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -92,6 +92,7 @@ signals:
     void titleUseMediaTitle(bool yes);
     void rememberHistory(bool yes, bool onlyVideos);
     void rememberFilePosition(bool yes);
+    void rememberQuickPlaylist(bool yes);
     void rememberSelectedPlaylist(bool yes);
     void rememberWindowGeometry(bool yes);
     void rememberPanels(bool yes);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -213,6 +213,16 @@
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="playerRememberQuickPlaylist">
+                <property name="text">
+                 <string>Remember Quick Playlist content</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="playerRememberLastPlaylist">
                 <property name="text">
                  <string>Remember last selected playlist</string>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4226,6 +4226,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4430,6 +4430,10 @@ arxiu multimèdia reproduït</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4406,6 +4406,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4442,6 +4442,10 @@ media file played</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation>Position ASS subs relative to the video frame</translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4298,6 +4298,10 @@ archivo multimedia reproducido</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4188,6 +4188,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4362,6 +4362,10 @@ fichier média lu</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4278,6 +4278,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4270,6 +4270,10 @@ ogni file multimediale riprodotto</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4430,6 +4430,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation>ビデオフレームを基準にしてASS字幕を配置する</translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4202,6 +4202,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4246,6 +4246,10 @@ arquivo de mídia reproduzido</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4402,6 +4402,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4430,6 +4430,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4422,6 +4422,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4304,6 +4304,10 @@ media file played</source>
         <source>Position ASS subs relative to the video frame</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Remember Quick Playlist content</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
Disabling "Keep history" also disables it.

Fixes #342 (Option to start with empty playlist).