### PR TITLE
Add option to append opened files to Quick Playlist

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -744,6 +744,8 @@ void Flow::setupSettingsConnections()
             settingsWindow, &SettingsWindow::setHidePanels);
 
     // settings -> manager
+    connect(settingsWindow, &SettingsWindow::appendToQuickPlaylist,
+            playbackManager, &PlaybackManager::setAppendToQuickPlaylist);
     connect(settingsWindow, &SettingsWindow::speedStep,
             playbackManager, &PlaybackManager::setSpeedStep);
     connect(settingsWindow, &SettingsWindow::speedStepAdditive,

--- a/manager.h
+++ b/manager.h
@@ -139,6 +139,7 @@ public slots:
 
     // output functions
     void setPlaybackSpeed(double speed);
+    void setAppendToQuickPlaylist(bool isAppend);
     void setSpeedStep(double step);
     void setSpeedStepAdditive(bool isAdditive);
     void setStepTimeNormal(int normalMsec);
@@ -264,6 +265,7 @@ private:
     bool playbackForever = false;
     bool fastSeek = true;
     bool folderFallback = false;
+    bool appendToQuickPlaylist = false;
 
     bool timeShortMode = false;
 

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -78,11 +78,13 @@ PlaylistItem PlaylistWindow::addToCurrentPlaylist(QList<QUrl> what)
     return addToPlaylist(currentPlaylist, what);
 }
 
-PlaylistItem PlaylistWindow::urlToQuickPlaylist(QUrl what)
+PlaylistItem PlaylistWindow::urlToQuickPlaylist(QUrl what, bool appendToPlaylist)
 {
     auto pl = PlaylistCollection::getSingleton()->getPlaylist(QUuid());
-    pl->clear();
-    widgets[QUuid()]->clear();
+    if (!appendToPlaylist) {
+        pl->clear();
+        widgets[QUuid()]->clear();
+    }
     ui->tabWidget->setCurrentWidget(widgets[QUuid()]);
     return addToCurrentPlaylist(QList<QUrl>() << what);
 }

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -27,7 +27,7 @@ public:
     void clearPlaylist(QUuid what);
     PlaylistItem addToPlaylist(const QUuid &playlist, const QList<QUrl> &what);
     PlaylistItem addToCurrentPlaylist(QList<QUrl> what);
-    PlaylistItem urlToQuickPlaylist(QUrl what);
+    PlaylistItem urlToQuickPlaylist(QUrl what, bool appendToPlaylist);
     bool isCurrentPlaylistEmpty();
     bool isPlaylistSingularFile(QUuid list);
     bool isPlaylistRepeat(QUuid list);

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -708,6 +708,7 @@ void SettingsWindow::sendSignals()
                         WIDGET_LOOKUP(ui->logHistoryLines).toInt() : 0);
     }
 
+    emit appendToQuickPlaylist(WIDGET_LOOKUP(ui->playerAppendToQuickPlaylist).toBool());
     emit trayIcon(WIDGET_LOOKUP(ui->playerTrayIcon).toBool());
     emit showOsd(WIDGET_LOOKUP(ui->playerOSD).toBool());
     emit limitProportions(WIDGET_LOOKUP(ui->playerLimitProportions).toBool());
@@ -1114,6 +1115,7 @@ void SettingsWindow::setFreestanding(bool freestanding)
     ui->ipcMpris->setVisible(yes);
     ui->playerOpenSame->setVisible(yes);
     ui->playerOpenNew->setVisible(yes);
+    ui->playerAppendToQuickPlaylist->setVisible(yes);
     ui->playerOpenBox->setEnabled(yes);
     ui->playerKeepHistory->setVisible(yes);
     ui->playerKeepHistoryOnlyForVideos->setVisible(yes);
@@ -1287,6 +1289,23 @@ void SettingsWindow::keyPressEvent(QKeyEvent *event)
         this->close();
     else
         QWidget::keyPressEvent(event);
+}
+
+void SettingsWindow::on_playerOpenSame_clicked()
+{
+    ui->playerAppendToQuickPlaylist->setEnabled(true);
+}
+
+void SettingsWindow::on_playerOpenNew_clicked()
+{
+    ui->playerAppendToQuickPlaylist->setEnabled(false);
+    ui->playerAppendToQuickPlaylist->setChecked(false);
+}
+
+void SettingsWindow::on_playerAppendToQuickPlaylist_checkStateChanged(Qt::CheckState state)
+{
+    if (state == Qt::Checked)
+        ui->playerRememberQuickPlaylist->setChecked(false);
 }
 
 void SettingsWindow::on_playerTitleDisplayFullPath_clicked()

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -83,6 +83,7 @@ signals:
     void mouseWindowedMap(const MouseStateMap &map);
     void mouseFullscreenMap(const MouseStateMap &map);
 
+    void appendToQuickPlaylist(bool yes);
     void trayIcon(bool yes);
     void showOsd(bool yes);
     void limitProportions(bool yes);
@@ -235,6 +236,12 @@ private slots:
     void closeEvent(QCloseEvent *event) override;
     void keyPressEvent(QKeyEvent *event) override;
     bool eventFilter(QObject *obj, QEvent *event) override;
+
+    void on_playerOpenSame_clicked();
+
+    void on_playerOpenNew_clicked();
+
+    void on_playerAppendToQuickPlaylist_checkStateChanged(Qt::CheckState state);
 
     void on_playerTitleDisplayFullPath_clicked();
 

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -383,6 +383,13 @@ media file played</string>
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="playerAppendToQuickPlaylist">
+                <property name="text">
+                 <string>Append opened files to Quick Playlist</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="playerOpenSpacer">
                 <property name="orientation">
                  <enum>Qt::Orientation::Vertical</enum>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4230,6 +4230,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4434,6 +4434,10 @@ arxiu multimèdia reproduït</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4410,6 +4410,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4446,6 +4446,10 @@ media file played</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4302,6 +4302,10 @@ archivo multimedia reproducido</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4192,6 +4192,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4366,6 +4366,10 @@ fichier média lu</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4282,6 +4282,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4274,6 +4274,10 @@ ogni file multimediale riprodotto</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4434,6 +4434,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4206,6 +4206,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4250,6 +4250,10 @@ arquivo de mídia reproduzido</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4406,6 +4406,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4434,6 +4434,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4426,6 +4426,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4308,6 +4308,10 @@ media file played</source>
         <source>Remember Quick Playlist content</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Append opened files to Quick Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
If a file is already playing, the new files are appended and played on their turn. If no file is currently playing, the new files are appended and played immediately. If the player is paused, the new files are just appended.

Enabling this option disables the "Remember Quick Playlist" option by default to prevent the Quick Playlist from getting bigger and bigger without the user noticing. It's still possible to manually re-enable that setting.

Fixes #393 (Append opened files to playlist, instead of replacing current).