### PR TITLE
Only load playlists backup when needed to avoid slowing down app startup

### DIFF
--- a/.github/actions/linux/tests/start/action.yml
+++ b/.github/actions/linux/tests/start/action.yml
@@ -33,10 +33,11 @@ runs:
     uses: ./.github/actions/commands/check_if_file_exists
     with:
       filename: "playlists.json"
-  - name: Check that mpc-qt wrote playlists_backup.json
-    uses: ./.github/actions/commands/check_if_file_exists
-    with:
-      filename: "playlists_backup.json"
+  # The playlists backup doesn't get written anymore when not needed.
+  # - name: Check that mpc-qt wrote playlists_backup.json
+  #   uses: ./.github/actions/commands/check_if_file_exists
+  #   with:
+  #     filename: "playlists_backup.json"
   - name: Check that mpc-qt wrote recent.json
     uses: ./.github/actions/commands/check_if_file_exists
     with:

--- a/.github/actions/windows/tests/start/action.yml
+++ b/.github/actions/windows/tests/start/action.yml
@@ -37,10 +37,11 @@ runs:
     uses: ./.github/actions/commands/check_if_file_exists
     with:
       filename: "playlists.json"
-  - name: Check that mpc-qt wrote playlists_backup.json
-    uses: ./.github/actions/commands/check_if_file_exists
-    with:
-      filename: "playlists_backup.json"
+  # The playlists backup doesn't get written anymore when not needed.
+  # - name: Check that mpc-qt wrote playlists_backup.json
+  #   uses: ./.github/actions/commands/check_if_file_exists
+  #   with:
+  #     filename: "playlists_backup.json"
   - name: Check that mpc-qt wrote recent.json
     uses: ./.github/actions/commands/check_if_file_exists
     with:

--- a/main.h
+++ b/main.h
@@ -69,6 +69,7 @@ private:
 
 private slots:
     void self_windowsRestored();
+    void loadPlaylistsBackup();
     void mainwindow_instanceShouldQuit();
     void mainwindow_fullscreenHideControls(bool hide);
     void mainwindow_repeatAfter();
@@ -147,6 +148,7 @@ private:
 
     static bool settingsDisableWindowManagement;
     bool firstFile = true;
+    bool playlistsBackupLoaded = false;
     bool inhibitScreensaver = false;
     bool manipulateScreensaver = false;
     bool rememberHistory = true;

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -1037,6 +1037,7 @@ void PlaylistWindow::on_tabWidget_tabCloseRequested(int index)
         return;
 
     auto collection = PlaylistCollection::getSingleton();
+    emit playlistsBackupRequested();
     auto backup = PlaylistCollection::getBackup();
     auto copy = collection->clonePlaylist(qdp->uuid());
     copy->setCreated(qdp->playlist()->created());

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -78,6 +78,7 @@ signals:
     void playlistRepeatChanged(QUuid playlistUuid, bool repeat);
     void playlistShuffleChanged(QUuid playlistUuid, bool shuffle);
     void hideFullscreenChanged(bool checked);
+    void playlistsBackupRequested();
     void playlistMovedToBackup(QUuid backupUuid);
 
 public slots:


### PR DESCRIPTION
Loading the playlists backup on startup is slow, so only load the playlists backup when the user opens the Library or closes a playlist tab (which then gets backed up).

To avoid overwriting the playlists backup file with an empty one, we then need to skip the entire write to disk part if the backup hasn't been loaded.

Fixes #612 (Playlists backup slows down app startup).