### PR TITLE
Fix most important things suggested by SonarQube linter

### DIFF
--- a/favoriteswindow.h
+++ b/favoriteswindow.h
@@ -75,14 +75,14 @@ class FavoritesDelegate : public QAbstractItemDelegate
 public:
     explicit FavoritesDelegate(QWidget *parent = nullptr);
     ~FavoritesDelegate();
-    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-    virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    virtual void paint(QPainter *painter,
-                       const QStyleOptionViewItem &option,
-                       const QModelIndex &index) const;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void paint(QPainter *painter,
+               const QStyleOptionViewItem &option,
+               const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
     FavoritesList *owner;

--- a/gotowindow.cpp
+++ b/gotowindow.cpp
@@ -25,12 +25,12 @@ void GoToWindow::init(double currentTime, double maxTime, double fps)
 
     ui->goToTime->setText(Helpers::toDateFormatWithZero(currentTime));
     QRegularExpression regexTime(R"(^([0-9]?[0-9]):([0-9]?[0-9]):([0-9]?[0-9])\.[0-9]{3}$)");
-    QRegularExpressionValidator* validatorTime = new QRegularExpressionValidator(regexTime, this);
+    auto const* validatorTime = new QRegularExpressionValidator(regexTime, this);
     ui->goToTime->setValidator(validatorTime);
     ui->goToTime->installEventFilter(this);
 
     QRegularExpression regexFrame(R"(^([0-9]{1,})$)");
-    QRegularExpressionValidator* validatorFrame = new QRegularExpressionValidator(regexFrame, this);
+    auto const* validatorFrame = new QRegularExpressionValidator(regexFrame, this);
     ui->goToFrame->setValidator(validatorFrame);
     ui->goToFrame->setText(QString::number(currentTime * fps, 'f', 0));
 
@@ -77,7 +77,7 @@ void GoToWindow::on_goToFrameButton_clicked()
 bool GoToWindow::eventFilter(QObject *obj, QEvent *event)
 {
     if (obj == ui->goToTime && event->type() == QEvent::KeyPress) {
-        auto keyEvent = reinterpret_cast<QKeyEvent*>(event);
+        auto keyEvent = static_cast<QKeyEvent*>(event);
         int cursorPos = ui->goToTime->cursorPosition();
         int key = keyEvent->key();
         if (key == Qt::Key_Backspace) {

--- a/gotowindow.h
+++ b/gotowindow.h
@@ -22,7 +22,7 @@ public slots:
     void init(double currentTime, double maxTime, double fps);
 
 protected:
-    bool eventFilter(QObject *obj, QEvent *event);
+    bool eventFilter(QObject *obj, QEvent *event) override;
 
 private slots:
     void on_goToTime_textChanged(const QString &text);

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -13,7 +13,7 @@ const char autoIcons[] = "auto";
 const char blackIconsPath[] = ":/images/theme/black/";
 const char whiteIconsPath[] = ":/images/theme/white/";
 
-QSet<QString> Helpers::audioVideoFileExtensions {
+const QSet<QString> Helpers::audioVideoFileExtensions {
     // DVD/Blu-ray audio formats
     "ac3", "a52",
     "eac3",
@@ -138,7 +138,7 @@ QSet<QString> Helpers::audioVideoFileExtensions {
     "psm"
 };
 
-QSet<QString> Helpers::imagesFileExtensions {
+const QSet<QString> Helpers::imagesFileExtensions {
     // Image formats
     "bmp",
     "dds",
@@ -166,7 +166,7 @@ QSet<QString> Helpers::imagesFileExtensions {
     "xpm"
 };
 
-QSet<QString> Helpers::archivesFileExtensions {
+const QSet<QString> Helpers::archivesFileExtensions {
     // Archives
     "rar",
     "zip",
@@ -174,18 +174,18 @@ QSet<QString> Helpers::archivesFileExtensions {
     "cbr",
     "iso"
 };
-QSet<QString> Helpers::othersFileExtensions {
+const QSet<QString> Helpers::othersFileExtensions {
     // Other formats
     "at9",
     "mpc"
 };
 
-QSet<QString> Helpers::allMediaExtensions = Helpers::audioVideoFileExtensions |
+const QSet<QString> Helpers::allMediaExtensions = Helpers::audioVideoFileExtensions |
                                             Helpers::imagesFileExtensions |
                                             Helpers::archivesFileExtensions |
                                             Helpers::othersFileExtensions;
 
-QSet<QString> Helpers::subsExtensions {
+const QSet<QString> Helpers::subsExtensions {
     "aqtitle", "aqt",
     "ass", "ssa",
     "dvbsub", "sub",
@@ -263,10 +263,10 @@ QString Helpers::toDateFormat(double time)
     int mn = t/60000 % 60;
     int se = t%60000 / 1000;
     int fr = t % 1000;
-    return QString("%1:%2:%3.%4").arg(QString().number(hr))
-            .arg(QString().number(mn),2,'0')
-            .arg(QString().number(se),2,'0')
-            .arg(QString().number(fr),3,'0');
+    return QString("%1:%2:%3.%4").arg(QString::number(hr))
+            .arg(QString::number(mn),2,'0')
+            .arg(QString::number(se),2,'0')
+            .arg(QString::number(fr),3,'0');
 }
 
 QString Helpers::toDateFormatWithZero(double time)
@@ -288,23 +288,23 @@ QString Helpers::toDateFormatFixed(double time, Helpers::TimeFormat format)
     int fr = t % 1000;
     switch (format) {
     case LongFormat:
-        return QString("%1:%2:%3.%4").arg(QString().number(hr))
-                .arg(QString().number(mn),2,'0')
-                .arg(QString().number(se),2,'0')
-                .arg(QString().number(fr),3,'0');
+        return QString("%1:%2:%3.%4").arg(QString::number(hr))
+                .arg(QString::number(mn),2,'0')
+                .arg(QString::number(se),2,'0')
+                .arg(QString::number(fr),3,'0');
     case ShortFormat:
-        return QString("%1:%2:%3").arg(QString().number(hr),2,'0')
-                .arg(QString().number(mn),2,'0')
-                .arg(QString().number(se),2,'0');
+        return QString("%1:%2:%3").arg(QString::number(hr),2,'0')
+                .arg(QString::number(mn),2,'0')
+                .arg(QString::number(se),2,'0');
     case LongHourFormat:
         return QString("%1:%2.%3")
-                .arg(QString().number(mn),2,'0')
-                .arg(QString().number(se),2,'0')
-                .arg(QString().number(fr),3,'0');
+                .arg(QString::number(mn),2,'0')
+                .arg(QString::number(se),2,'0')
+                .arg(QString::number(fr),3,'0');
     case ShortHourFormat:
         return QString("%1:%2")
-                .arg(QString().number(mn),2,'0')
-                .arg(QString().number(se),2,'0');
+                .arg(QString::number(mn),2,'0')
+                .arg(QString::number(se),2,'0');
     }
     return QString();
 }
@@ -336,7 +336,7 @@ double Helpers::fromDateFormat(QString date)
     return times[0].toDouble()*3600 + times[1].toDouble()*60 + times[2].toDouble();
 }
 
-static QString grabBrackets(QString source, int &position, int &length) {
+static QString grabBrackets(QString source, int &position, int const &length) {
     QString match;
     QChar c;
     enum MatchMode { Bracket, Inside, Finish };
@@ -370,7 +370,7 @@ QString Helpers::parseFormat(QString fmt, QString fileName,
 {
     // convenient format parsing
     struct TimeParse {
-        TimeParse(double time) {
+        explicit TimeParse(double time) {
             this->time = time;
             int t = int(time*1000 + 0.5);
             hr = t/3600000;
@@ -635,13 +635,13 @@ QRect Helpers::availableGeometryFromPoint(const QPoint &point)
 
 QScreen *Helpers::findScreenByName(QString s)
 {
-    for (auto screen : qApp->screens())
+    for (auto screen : QApplication::screens())
         if (screenToVisualName(screen) == s)
             return screen;
     return nullptr;
 }
 
-QString Helpers::screenToVisualName(QScreen *s)
+QString Helpers::screenToVisualName(const QScreen *s)
 {
     // If someone has a way to convert QScreen to unique device ids on Windows,
     // please enlighten me.  It would be nice to select a monitor and not lose
@@ -738,7 +738,7 @@ void IconThemer::updateButton(const IconData &data)
 class DisplayNode {
 public:
     enum NodeType { NullNode, PlainText, Trie, Property, DisplayName };
-    DisplayNode() { }
+    DisplayNode() = default;
     ~DisplayNode() {
         empty();
         if (next)
@@ -834,10 +834,7 @@ private:
 
 
 
-DisplayParser::DisplayParser()
-{
-
-}
+DisplayParser::DisplayParser() = default;
 
 DisplayParser::~DisplayParser()
 {
@@ -1038,24 +1035,14 @@ QList<TrackInfo> TrackInfo::tracksFromVList(const QVariantList &list)
 
 MouseState::MouseState() : button(0), mod(0), press(MouseUp) {}
 
-MouseState::MouseState(const MouseState &m) {
-    button = m.button;
-    mod = m.mod;
-    press = m.press;
-}
+MouseState::MouseState(const MouseState &m) = default;
 
 MouseState::MouseState(int button, int mod, MousePress press)
     : button(button), mod(mod), press(press)
 {
 }
 
-MouseState MouseState::operator =(const MouseState &other)
-{
-    button = other.button;
-    mod = other.mod;
-    press = other.press;
-    return *this;
-}
+MouseState& MouseState::operator =(const MouseState &other) = default;
 
 Qt::MouseButtons MouseState::mouseButtons() const
 {
@@ -1245,7 +1232,7 @@ int MouseState::pressToTextCount()
 
 
 
-Command::Command() {}
+Command::Command() = default;
 
 Command::Command(QAction *a, MouseState mf, MouseState mw) : action(a),
     mouseFullscreen(mf), mouseWindowed(mw) {}
@@ -1274,10 +1261,7 @@ void Command::fromAction(QAction *a)
 
 
 
-AudioDevice::AudioDevice()
-{
-
-}
+AudioDevice::AudioDevice() = default;
 
 AudioDevice::AudioDevice(const QVariantMap &m)
 {

--- a/helpers.h
+++ b/helpers.h
@@ -40,12 +40,12 @@ namespace Helpers {
     enum TimeFormat { LongFormat, ShortFormat,
                       LongHourFormat, ShortHourFormat };
 
-    extern QSet<QString> audioVideoFileExtensions;
-    extern QSet<QString> imagesFileExtensions;
-    extern QSet<QString> archivesFileExtensions;
-    extern QSet<QString> othersFileExtensions;
-    extern QSet<QString> allMediaExtensions;
-    extern QSet<QString> subsExtensions;
+    extern const QSet<QString> audioVideoFileExtensions;
+    extern const QSet<QString> imagesFileExtensions;
+    extern const QSet<QString> archivesFileExtensions;
+    extern const QSet<QString> othersFileExtensions;
+    extern const QSet<QString> allMediaExtensions;
+    extern const QSet<QString> subsExtensions;
 
     QString fileSizeToString(int64_t bytes);
     QString fileSizeToStringShort(int64_t bytes);
@@ -72,7 +72,7 @@ namespace Helpers {
     bool pointFromString(QPoint &point, const QString &text);
     QRect availableGeometryFromPoint(const QPoint &point);
     QScreen *findScreenByName(QString s);
-    QString screenToVisualName(QScreen *s);
+    QString screenToVisualName(const QScreen *s);
 }
 
 class IconThemer : public QObject {
@@ -113,7 +113,7 @@ private:
 
 class TrackInfo {
 public:
-    TrackInfo() {}
+    TrackInfo() = default;
     TrackInfo(const QUrl &url, const QUuid &list, const QUuid &item, QString title, double length,
               double position, int64_t videoTrack, int64_t audioTrack, int64_t subtitleTrack);
     QUrl url;
@@ -147,7 +147,7 @@ public:
     MouseState();
     MouseState(const MouseState &m);
     MouseState(int button, int mod, MousePress press);
-    MouseState operator =(const MouseState &other);
+    MouseState& operator =(const MouseState &other);
 
     // Components
     int button;
@@ -191,7 +191,7 @@ inline uint qHash(const MouseState &m, uint seed) {
     return m.mouseHash();
 }
 
-typedef QHash<MouseState, QAction*> MouseStateMap;
+using MouseStateMap = QHash<MouseState, QAction *>;
 
 class Command {
 public:
@@ -218,7 +218,7 @@ public:
 class AudioDevice {
 public:
     AudioDevice();
-    AudioDevice(const QVariantMap &m);
+    explicit AudioDevice(const QVariantMap &m);
     void setFromVMap(const QVariantMap &m);
 
     bool operator ==(const AudioDevice &other) const;

--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -15,7 +15,7 @@ constexpr char mimeFormUrlEncoded[] = "application/x-www-form-urlencoded";
 constexpr char mimeHtml[] = "text/html";
 constexpr char dateZero[] = "1970.01.01 00:00";
 
-static QMap<HttpResponse::HttpStatus,QString> statusToText = {
+static const QMap<HttpResponse::HttpStatus, QString> statusToText = {
     { HttpResponse::Http200Ok, "200 OK" },
     { HttpResponse::Http204NoContent, "204 No Content" },
     { HttpResponse::Http301MovedPermanently, "301 Moved Permanently" },
@@ -29,7 +29,7 @@ static QMap<HttpResponse::HttpStatus,QString> statusToText = {
     { HttpResponse::Http501NotImplemented, "501 Not Implemented" }
 };
 
-static QMap<QString,QString> extensionToText {
+static const QMap<QString, QString> extensionToText {
     { "aac", "audio/aac" },
     { "avi", "video/x-msvideo" },
     { "bin", "application/octet-stream" },
@@ -131,7 +131,7 @@ QString HttpServer::extensionToContentType(QString extension)
 
 QString HttpServer::urlDecode(QString urlText, bool plusToSpace)
 {
-    typedef unsigned char byte;
+    using byte = unsigned char;
     static QByteArray chToHex = [](){
         QByteArray map;
         map.resize(256);
@@ -192,7 +192,7 @@ QString HttpServer::urlDecode(QString urlText, bool plusToSpace)
 
 QString HttpServer::urlEncode(QString plainText)
 {
-    typedef unsigned char byte;
+    using byte = unsigned char;
     static const QByteArray isEncoded = [] {
         QByteArray map;
         map.resize(256);

--- a/ipc/mpris.cpp
+++ b/ipc/mpris.cpp
@@ -143,7 +143,7 @@ MprisServer::MprisServer(QObject *parent)
 
 MprisInstance *MprisServer::instance()
 {
-    return reinterpret_cast<MprisInstance*>(parent());
+    return static_cast<MprisInstance*>(parent());
 }
 
 bool MprisServer::fullscreen()
@@ -210,7 +210,7 @@ MprisPlayerServer::MprisPlayerServer(QObject *parent)
 
 MprisInstance *MprisPlayerServer::instance()
 {
-    return reinterpret_cast<MprisInstance*>(parent());
+    return static_cast<MprisInstance*>(parent());
 }
 
 QString MprisPlayerServer::playbackStatus()

--- a/ipc/mpris.h
+++ b/ipc/mpris.h
@@ -166,7 +166,7 @@ public slots:
     void Stop();
     void Play();
     void Seek(qlonglong Offset);
-    void SetPosition(const QDBusObjectPath& TrackId, qlonglong Position);
+    void SetPosition(const QDBusObjectPath &TrackId, qlonglong Position);
     void OpenUri(QString uri);
 
 private slots:

--- a/librarywindow.cpp
+++ b/librarywindow.cpp
@@ -42,7 +42,7 @@ void LibraryWindow::on_restorePlaylist_clicked()
     int currentRow = collectionWidget->currentRow();
     if (currentRow == -1)
         return;
-    auto collectionItem = reinterpret_cast<CollectionItem*>(collectionWidget->currentItem());
+    auto collectionItem = static_cast<CollectionItem*>(collectionWidget->currentItem());
     auto playlistCollection = PlaylistCollection::getSingleton();
     auto backupCollection = PlaylistCollection::getBackup();
 
@@ -59,7 +59,7 @@ void LibraryWindow::on_removePlaylist_clicked()
     if (currentRow == -1)
         return;
     auto backupCollection = PlaylistCollection::getBackup();
-    auto collectionItem = reinterpret_cast<CollectionItem*>(collectionWidget->currentItem());
+    auto collectionItem = static_cast<CollectionItem*>(collectionWidget->currentItem());
     backupCollection->removePlaylist(collectionItem->uuid());
     delete collectionWidget->takeItem(currentRow);
 }

--- a/logger.cpp
+++ b/logger.cpp
@@ -5,7 +5,7 @@
 
 class StdFileCopy {
 public:
-    StdFileCopy(FILE *fp) {
+    explicit StdFileCopy(FILE *fp) {
         int handle = dup(fileno(fp));
         if (handle == -1) {
             ptr = fp;

--- a/logger.h
+++ b/logger.h
@@ -66,7 +66,7 @@ private:
 // Unlike QDebug, this does not insert spaces between << invocations.
 class LogStream {
 public:
-    LogStream(QString prefix = QString(), QString level = QString());
+    explicit LogStream(QString prefix = QString(), QString level = QString());
     ~LogStream();
     LogStream &always();
     LogStream &operator<<(const char *a);

--- a/logwindow.cpp
+++ b/logwindow.cpp
@@ -50,7 +50,7 @@ void LogWindow::closeEvent(QCloseEvent *event)
 void LogWindow::on_copy_clicked()
 {
     QTextDocument *doc = ui->messages->document();
-    qApp->clipboard()->setText(doc->toPlainText());
+    QApplication::clipboard()->setText(doc->toPlainText());
 }
 
 void LogWindow::on_save_clicked()

--- a/logwindow.h
+++ b/logwindow.h
@@ -27,7 +27,7 @@ public slots:
     void setLogLimit(int lines);
 
 protected:
-    void closeEvent(QCloseEvent *event);
+    void closeEvent(QCloseEvent *event) override;
 
 private slots:
     void on_copy_clicked();

--- a/main.cpp
+++ b/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     }
     Logger::setConsoleLogging(foundLoggingOpt);
     Logger::singleton();
-    a.setWindowIcon(QIcon(":/images/icon/mpc-qt.svg"));
+    QApplication::setWindowIcon(QIcon(":/images/icon/mpc-qt.svg"));
 
     // Qt sets the locale in the QApplication constructor, but libmpv requires
     // the LC_NUMERIC category to be set to "C", so change it back.
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     QTranslator qtTranslator;
     QTranslator appTranslator;
 
-    Flow::setTranslation(&a, &qtTranslator, &appTranslator);
+    Flow::setTranslation(&qtTranslator, &appTranslator);
 
 #ifndef MPCQT_VERSION_STR
 #define MPCQT_VERSION_STR MainWindow::tr("Development Build")
@@ -404,7 +404,7 @@ int Flow::run()
 
     // Wait here until quit
     Logger::log("main", "telling the program to run");
-    return qApp->exec();
+    return QApplication::exec();
 }
 
 bool Flow::earlyQuit()
@@ -434,7 +434,7 @@ void Flow::earlyPlatformOverride()
 }
 
 // Register the translations
-void Flow::setTranslation(QApplication *app, QTranslator *qtTranslator, QTranslator *appTranslator)
+void Flow::setTranslation(QTranslator *qtTranslator, QTranslator *appTranslator)
 {
     QLocale locale;
     Storage s;
@@ -444,10 +444,10 @@ void Flow::setTranslation(QApplication *app, QTranslator *qtTranslator, QTransla
         locale = QLocale("en");
 
     if (qtTranslator->load(locale, "qtbase", "_", ":/i18n"))
-        app->installTranslator(qtTranslator);
+        QApplication::installTranslator(qtTranslator);
 
     if (appTranslator->load(locale, "mpc-qt", "_", ":/i18n"))
-        app->installTranslator(appTranslator);
+        QApplication::installTranslator(appTranslator);
 }
 
 void Flow::readConfig()
@@ -783,7 +783,7 @@ void Flow::setupSettingsConnections()
 
     // settings -> application
     connect(settingsWindow, &SettingsWindow::applicationPalette,
-            qApp, [](const QPalette &pal) { qApp->setPalette(pal); });
+            qApp, [](const QPalette &pal) { QApplication::setPalette(pal); });
 }
 
 void Flow::setupMpvObjectConnections()
@@ -1170,7 +1170,7 @@ void Flow::setupMpcHc()
             mpcHcServer, &MpcHcServer::setVolumeMuted);
 
     // mpvObject -> mpcHcServer
-    MpvObject *mpvObject = mainWindow->mpvObject();
+    const MpvObject *mpvObject = mainWindow->mpvObject();
     connect(mpvObject, &MpvObject::fileSizeChanged,
             mpcHcServer, &MpcHcServer::setFileSize);
 
@@ -1203,7 +1203,7 @@ bool Flow::isNvidiaGPU()
     for (const QString &line : result.split('\n'))
         LogStream("main") << line;
 
-    if (result.contains("nvidia", Qt::CaseSensitivity::CaseInsensitive) > 0) {
+    if (result.contains("nvidia", Qt::CaseSensitivity::CaseInsensitive)) {
         foundNvidia = true;
     }
     return foundNvidia;
@@ -1383,7 +1383,7 @@ void Flow::mainwindow_recentClear()
 
 void Flow::mainwindow_takeImage(Helpers::ScreenshotRender render)
 {
-    static QFileDialog::Options options = QFileDialog::Options();
+    static auto options = QFileDialog::Options();
 #ifdef Q_OS_MAC
     options = QFileDialog::DontUseNativeDialog;
 #endif
@@ -1634,14 +1634,14 @@ void Flow::settingswindow_stylesheetIsFusion(bool yes)
 {
     static QString originalApplicationStyle;
     if (originalApplicationStyle.isNull()) {
-        originalApplicationStyle = qApp->style()->name();
+        originalApplicationStyle = QApplication::style()->name();
     }
 
-    bool wasFusion = qApp->style()->name() == "Fusion";
+    bool wasFusion = QApplication::style()->name() == "Fusion";
     if (!yes && wasFusion)
-        qApp->setStyle(originalApplicationStyle);
+        QApplication::setStyle(originalApplicationStyle);
     if (yes && !wasFusion)
-        qApp->setStyle(QStyleFactory::create("Fusion"));
+        QApplication::setStyle(QStyleFactory::create("Fusion"));
 }
 
 void Flow::settingswindow_stylesheetText(QString text)

--- a/main.h
+++ b/main.h
@@ -39,7 +39,7 @@ public:
     int run();
     bool earlyQuit();
     static void earlyPlatformOverride();
-    static void setTranslation(QApplication *app, QTranslator *qtTranslator, QTranslator *appTranslator);
+    static void setTranslation(QTranslator *qtTranslator, QTranslator *appTranslator);
     static bool isNvidiaGPU();
 
 signals:

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -67,7 +67,7 @@ MainWindow::MainWindow(QWidget *parent) :
     if (Platform::isUnix) {
         setAttribute(Qt::WA_DontShowOnScreen, true);
         show();
-        qApp->processEvents(QEventLoop::AllEvents |
+        QApplication::processEvents(QEventLoop::AllEvents |
                             QEventLoop::WaitForMoreEvents,
                             50);
         hide();
@@ -150,7 +150,7 @@ QVariantMap MainWindow::mouseMapDefaults()
     return commandMap;
 }
 
-QMap<int, QAction *> MainWindow::wmCommandMap()
+QMap<int, QAction *> MainWindow::wmCommandMap() const
 {
     QMap<int, QAction *> wmCommands = {
 
@@ -306,7 +306,7 @@ QSize MainWindow::desirableSize(bool first_run)
     return wanted + fudgeFactor;
 }
 
-QPoint MainWindow::desirablePosition(QSize &size, bool first_run)
+QPoint MainWindow::desirablePosition(QSize &size, bool first_run) const
 {
     QRect available = first_run ? Helpers::availableGeometryFromPoint(QCursor::pos())
                                 : screen()->availableGeometry();
@@ -424,7 +424,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
         checkBottomArea(event->globalPosition());
 }
 
-static bool insideWidget(QPoint p, QWidget *widget) {
+static bool insideWidget(QPoint p, QWidget const *widget) {
     if (widget == nullptr)
         return false;
     QRect rc(widget->mapToGlobal(QPoint()), widget->size());
@@ -525,22 +525,22 @@ VolumeSlider *MainWindow::volumeSlider()
     return volumeSlider_;
 }
 
-MainWindow::DecorationState MainWindow::decorationState()
+MainWindow::DecorationState MainWindow::decorationState() const
 {
     return decorationState_;
 }
 
-bool MainWindow::fullscreenMode()
+bool MainWindow::fullscreenMode() const
 {
     return fullscreenMode_;
 }
 
-QSize MainWindow::noVideoSize()
+QSize MainWindow::noVideoSize() const
 {
     return noVideoSize_;
 }
 
-double MainWindow::sizeFactor()
+double MainWindow::sizeFactor() const
 {
     return sizeFactor_;
 }
@@ -858,7 +858,7 @@ void MainWindow::setupHideTimer()
             this, &MainWindow::hideTimer_timeout);
 }
 
-void MainWindow::connectActionsToSignals()
+void MainWindow::connectActionsToSignals() const
 {
     connect(ui->actionFileSaveThumbnails, &QAction::triggered,
             this, &MainWindow::takeThumbnails);
@@ -866,7 +866,7 @@ void MainWindow::connectActionsToSignals()
             this, &MainWindow::showFileProperties);
 }
 
-void MainWindow::connectActionsToSlots()
+void MainWindow::connectActionsToSlots() const
 {
     connect(ui->actionHelpAboutQt, &QAction::triggered,
             qApp, &QApplication::aboutQt);
@@ -904,7 +904,7 @@ void MainWindow::connectButtonsToActions()
             ui->actionPlayVolumeMute, &QAction::toggled);
 }
 
-void MainWindow::connectPlaylistWindowToActions()
+void MainWindow::connectPlaylistWindowToActions() const
 {
     connect(ui->actionPlaylistCopy, &QAction::triggered,
             playlistWindow_, &PlaylistWindow::copy);
@@ -1261,7 +1261,7 @@ void MainWindow::updateMouseHideTime()
 void MainWindow::updateDiscList()
 {
     bool addedSomething = false;
-    auto func = [&](DeviceInfo *device) -> void {
+    auto func = [this, &addedSomething](DeviceInfo *device) {
         if (device->deviceType != DeviceInfo::OpticalDrive &&
             device->deviceType != DeviceInfo::RemovableDrive)
             return;
@@ -1313,7 +1313,8 @@ QList<QUrl> MainWindow::doQuickOpenFileDialog()
     return urls;
 }
 
-QIcon MainWindow::createIconFromSvg(const QString& svgPath, int maxSize) {
+QIcon MainWindow::createIconFromSvg(const QString &svgPath, int maxSize) const
+{
     QIcon icon;
     QSvgRenderer svgRenderer(svgPath);
 
@@ -1328,7 +1329,8 @@ QIcon MainWindow::createIconFromSvg(const QString& svgPath, int maxSize) {
     return icon;
 }
 
-QPixmap MainWindow::renderPixmapFromSvg(const QString &path) {
+QPixmap MainWindow::renderPixmapFromSvg(const QString &path) const
+{
     QSvgRenderer renderer(path);
     qreal devicePixelRatio = this->devicePixelRatioF();
     int iconSize = 16;
@@ -1715,7 +1717,7 @@ void MainWindow::setFullscreenMouseMap(const MouseStateMap &map)
 
 void MainWindow::setRecentDocuments(const QList<TrackInfo> &tracks)
 {
-    bool isEmpty = tracks.count() == 0;
+    bool isEmpty = tracks.isEmpty();
     ui->menuFileRecent->clear();
     ui->menuFileRecent->setDisabled(isEmpty);
     if (isEmpty)
@@ -1749,7 +1751,7 @@ void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu
         displayString.truncate(100);
         QAction *a = new QAction(QString("%1").arg(displayString),
                                  this);
-        connect(a, &QAction::triggered, this, [=]() {
+        connect(a, &QAction::triggered, this, [this, track]() {
             emit recentOpened(track, true);
         });
         menu->addAction(a);
@@ -2437,7 +2439,7 @@ void MainWindow::on_actionFileOpenNetworkStream_triggered()
     if (mimeData->hasText() && QUrl::fromUserInput(mimeData->text()).isValid())
         qid->setTextValue(QUrl::fromUserInput(mimeData->text()).toString());
     qid->resize(500, qid->height());
-    connect(qid, &QInputDialog::accepted, this, [=] () {
+    connect(qid, &QInputDialog::accepted, this, [this, qid] () {
         emit streamOpened(QUrl::fromUserInput(qid->textValue()));
     });
     qid->show();
@@ -2493,7 +2495,7 @@ void MainWindow::on_actionFileLoadSubtitle_triggered()
     emit subtitlesLoaded(url);
 }
 
-void MainWindow::on_actionFileSubtitleDatabaseSearch_triggered()
+void MainWindow::on_actionFileSubtitleDatabaseSearch_triggered() const
 {
     QString fileNameNoExt = QFileInfo(currentFile.fileName()).completeBaseName();
     QDesktopServices::openUrl(QUrl("https://www.opensubtitles.org/search2/moviename-" +
@@ -3065,7 +3067,7 @@ void MainWindow::on_actionPlaySubtitlesPrevious_triggered()
 
 void MainWindow::on_actionPlaySubtitlesCopy_triggered()
 {
-    QClipboard *clippy = qApp->clipboard();
+    QClipboard *clippy = QApplication::clipboard();
     clippy->setText(subtitleText);
 }
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -40,12 +40,12 @@ public:
     PlaylistWindow *playlistWindow();
     QList<QAction *> editableActions();
     QVariantMap mouseMapDefaults();
-    QMap<int, QAction *> wmCommandMap();
+    QMap<int, QAction *> wmCommandMap() const;
     QVariantMap state();
     void setState(const QVariantMap &map);
     void setScreensaverAbilities(QSet<ScreenSaver::Ability> ab);
     QSize desirableSize(bool first_run = false);
-    QPoint desirablePosition(QSize &size, bool first_run = false);
+    QPoint desirablePosition(QSize &size, bool first_run = false) const;
     void unfreezeWindow();
     void fixMpvwSize();
     void setActionPlayLoopUse();
@@ -68,10 +68,10 @@ private:
     MediaSlider *positionSlider();
     VolumeSlider *volumeSlider();
 
-    DecorationState decorationState();
-    bool fullscreenMode();
-    QSize noVideoSize();
-    double sizeFactor();
+    DecorationState decorationState() const;
+    bool fullscreenMode() const;
+    QSize noVideoSize() const;
+    double sizeFactor() const;
 
     void setDiscState(bool playingADisc);
 
@@ -90,10 +90,10 @@ private:
     void setupBottomArea();
     void setupIconThemer();
     void setupHideTimer();
-    void connectActionsToSignals();
-    void connectActionsToSlots();
+    void connectActionsToSignals() const;
+    void connectActionsToSlots() const;
     void connectButtonsToActions();
-    void connectPlaylistWindowToActions();
+    void connectPlaylistWindowToActions() const;
     void globalizeAllActions();
     void setUiDecorationState(DecorationState state);
     void setOSDPage(int page);
@@ -116,8 +116,8 @@ private:
     void resizePlaylistToFit();
     QList<QUrl> doQuickOpenFileDialog();
 
-    QIcon createIconFromSvg(const QString& svgPath, int maxSize);
-    QPixmap renderPixmapFromSvg(const QString &path);
+    QIcon createIconFromSvg(const QString &svgPath, int maxSize) const;
+    QPixmap renderPixmapFromSvg(const QString &path) const;
 
 signals:
     void instanceShouldQuit();
@@ -452,7 +452,7 @@ private slots:
 
     void on_actionFileLoadSubtitle_triggered();
 
-    void on_actionFileSubtitleDatabaseSearch_triggered();
+    void on_actionFileSubtitleDatabaseSearch_triggered() const;
 
     void on_actionFavoritesAdd_triggered();
 

--- a/manager.cpp
+++ b/manager.cpp
@@ -250,7 +250,7 @@ void PlaybackManager::playDevice(QUrl device)
 void PlaybackManager::loadSubtitle(QUrl with)
 {
     QString f = with.isLocalFile() ? with.toLocalFile()
-                                   : with.fromPercentEncoding(with.toEncoded());
+                                   : QUrl::fromPercentEncoding(with.toEncoded());
     mpvObject_->addSubFile(f);
 }
 
@@ -670,7 +670,8 @@ void PlaybackManager::getCurrentTrackInfo(QUrl& url, QUuid& listUuid, QUuid& ite
     hasVideo = !videoList.isEmpty() && !videoListData[1].isImage;
 }
 
-QString PlaybackManager::nowPlayingTitle() {
+QString PlaybackManager::nowPlayingTitle()
+{
     return nowPlayingTitle_;
 }
 
@@ -691,7 +692,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
 
     nowPlaying_ = what;
     mpvObject_->fileOpen(what.isLocalFile() ? what.toLocalFile()
-                                            : what.fromPercentEncoding(what.toEncoded()),
+                                            : QUrl::fromPercentEncoding(what.toEncoded()),
                          replaceMpvPlaylist);
     mpvObject_->setSubFile(with.toString());
     mpvObject_->setPaused(playbackStartPaused);
@@ -822,7 +823,7 @@ void PlaybackManager::updateChapters()
     QList<Chapter> list;
 
     if (!chapters.isEmpty()) {
-        for (QVariant &v : chapters) {
+        for (QVariant const &v : chapters) {
             QMap<QString, QVariant> node = v.toMap();
             QString text = QString("[%1] - %2").arg(
                     toDateFormatFixed(node["time"].toDouble(),
@@ -1021,7 +1022,7 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
     subtitleListData.clear();
     Track track;
 
-    for (QVariant &trackItem : tracks) {
+    for (QVariant const &trackItem : tracks) {
         TrackData td = TrackData::fromMap(trackItem.toMap());
         track.id = td.trackId;
         track.title = td.formatted();
@@ -1126,7 +1127,7 @@ void PlaybackManager::mpvw_playlistChanged(const QVariantList &playlist)
     // replace current item with the content we got from the archive or playlist file, and trigger its playback
     QList<QUrl> urls;
     bool currentItemFound = false;
-    for (auto i : playlist) {
+    for (auto const& i : playlist) {
         if (i.toMap()["current"].toBool()) {
             currentItemFound = true;
             if (i.toMap()["id"].toInt() != currentMpvPlaylistItemId)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -31,8 +31,8 @@ class MpvObject : public QObject
 {
     Q_OBJECT
 
-    typedef std::function<void(MpvObject*,bool,const QVariant&)> PropertyDispatchFunction;
-    typedef QMap<QString, PropertyDispatchFunction> PropertyDispatchMap;
+    using PropertyDispatchFunction = std::function<void (MpvObject *, bool, const QVariant &)>;
+    using PropertyDispatchMap = QMap<QString, PropertyDispatchFunction>;
 public:
     explicit MpvObject(QObject *owner, const QString &clientName = "mpv");
     ~MpvObject();
@@ -102,9 +102,9 @@ public:
 
     void setCachedMpvOption(const QString &option, const QVariant &value);
     void setUncachedMpvOption(const QString &option, const QVariant &value);
-    QVariant blockingMpvCommand(QVariant params);
-    QVariant blockingSetMpvPropertyVariant(QString name, QVariant value);
-    QVariant blockingSetMpvOptionVariant(QString name, QVariant value);
+    QVariant blockingMpvCommand(const QVariant &params);
+    QVariant blockingSetMpvPropertyVariant(QString name, const QVariant &value);
+    QVariant blockingSetMpvOptionVariant(QString name, const QVariant &value);
     QVariant getMpvPropertyVariant(QString name);
 
 signals:
@@ -160,19 +160,19 @@ signals:
     void keyRelease(int key);
 
 private:
-    void setMpvPropertyVariant(QString name, QVariant value);
-    void setMpvOptionVariant(QString name, QVariant value);
+    void setMpvPropertyVariant(QString name, const QVariant &value);
+    void setMpvOptionVariant(QString name, const QVariant &value);
     void showCursor();
     void hideCursor();
 
 private slots:
-    void ctrl_mpvPropertyChanged(QString name, QVariant v);
+    void ctrl_mpvPropertyChanged(QString name, const QVariant &v);
     void ctrl_hookEvent(QString name, uint64_t selfId, uint64_t mpvId);
     void ctrl_unhandledMpvEvent(int eventLevel);
     void ctrl_videoSizeChanged(QSize size);
     void self_playTimeChanged(double playTime);
     void self_playLengthChanged(double playLength);
-    void self_chapterChanged(double chapter);
+    void self_chapterChanged(int64_t chapter);
     void self_metadata(QVariantMap metadata);
     void self_audioDeviceList(const QVariantList &list);
     void hideTimer_timeout();
@@ -199,7 +199,7 @@ private:
     QSize videoSize_;
     double playTime_ = 0.0;
     double playLength_ = 0.0;
-    double chapter_ = 0.0;
+    int64_t chapter_ = 0;
     double aspect = 0.0;
 
     int shownStatsPage = 0;
@@ -239,11 +239,11 @@ public:
     explicit MpvGlWidget(MpvObject *object, QWidget *parent = nullptr);
     ~MpvGlWidget();
 
-    QWidget *self();
-    void initMpv();
-    void setLogoUrl(const QString &filename);
-    void setLogoBackground(const QColor &color);
-    void setDrawLogo(bool yes);
+    QWidget *self() override;
+    void initMpv() override;
+    void setLogoUrl(const QString &filename) override;
+    void setLogoBackground(const QColor &color) override;
+    void setDrawLogo(bool yes) override;
     static void *get_proc_address(void *ctx, const char *name);
 
 signals:
@@ -251,14 +251,14 @@ signals:
     void mousePress(int x, int y);
 
 protected:
-    void initializeGL();
-    void paintGL();
-    void resizeGL(int w, int h);
-    void mouseMoveEvent(QMouseEvent *event);
-    void mousePressEvent(QMouseEvent *event);
-    void mouseReleaseEvent(QMouseEvent *event);
-    void keyPressEvent(QKeyEvent *event);
-    void keyReleaseEvent(QKeyEvent *event);
+    void initializeGL() override;
+    void paintGL() override;
+    void resizeGL(int w, int h) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void keyReleaseEvent(QKeyEvent *event) override;
 
 private:
     static void render_update(void *ctx);
@@ -273,7 +273,8 @@ private:
     mpv_render_context *render = nullptr;
     LogoDrawer *logo = nullptr;
     bool drawLogo = true;
-    int glWidth = 0, glHeight = 0;
+    int glWidth = 0;
+    int glHeight = 0;
     bool windowDragging = false;
     int resizeEdge = 0;
     QPointF mousePressPosition;
@@ -281,10 +282,10 @@ private:
 
 
 // FIXME: implement MpvVulkanCbWidget
-typedef MpvGlWidget MpvVulkanCbWidget;
+using MpvVulkanCbWidget = MpvGlWidget;
 
 // FIXME: implement MpvEmbedWidget
-typedef MpvGlWidget MpvEmbedWidget;
+using MpvEmbedWidget = MpvGlWidget;
 
 
 
@@ -293,9 +294,9 @@ typedef MpvGlWidget MpvEmbedWidget;
 
 class MpvErrorCode {
 public:
-    MpvErrorCode() {}
-    MpvErrorCode(int value) : value(value) {}
-    MpvErrorCode(const MpvErrorCode &mec) : value(mec.value) {}
+    MpvErrorCode() = default;
+    explicit MpvErrorCode(int value) : value(value) {}
+    MpvErrorCode(const MpvErrorCode &mec) = default;
     ~MpvErrorCode() {}
     int errorcode() { return value; }
 private:
@@ -314,10 +315,10 @@ Q_DECLARE_METATYPE(MpvErrorCode)
 class MpvCallback : public QObject {
     Q_OBJECT
 public:
-    typedef std::function<void(QVariant)> Callback;
+    using Callback = std::function<void (QVariant)>;
     explicit MpvCallback(const Callback &callback, QObject *owner = nullptr);
 public slots:
-    void reply(QVariant value);
+    void reply(const QVariant &value);
 private:
     Callback callback;
 };
@@ -336,14 +337,14 @@ public:
         MpvProperty(const QString &name, uint64_t userData, mpv_format format)
             : name(name), userData(userData), format(format) {}
     };
-    typedef QVector<MpvProperty> PropertyList;
+    using PropertyList = QVector<MpvProperty>;
     struct MpvOption {
         QString name;
         QVariant value;
     };
-    typedef QVector<MpvOption> OptionList;
+    using OptionList = QVector<MpvOption>;
 
-    MpvController(QObject *parent = nullptr);
+    explicit MpvController(QObject *parent = nullptr);
     ~MpvController();
 
 signals:
@@ -404,7 +405,7 @@ private:
 
     QTimer *throttler = nullptr;
     QSet<QString> throttledProperties;
-    typedef QMap<QString,QPair<QVariant,uint64_t>> ThrottledValueMap;
+    using ThrottledValueMap = QMap<QString, QPair<QVariant, uint64_t>>;
     ThrottledValueMap throttledValues;
 
     int shownStatsPage = 0;

--- a/platform/devicemanager_unix.cpp
+++ b/platform/devicemanager_unix.cpp
@@ -1,10 +1,10 @@
 #include "logger.h"
 #include "devicemanager_unix.h"
 
-typedef QList<unsigned char> dbus_ay;
-typedef QMap<QString,QVariantMap> QVariantMapMap;
-typedef QMap<QDBusObjectPath, QVariantMapMap> DBusManagedObjects;
-typedef QList<QByteArray> ByteArrayList;
+using dbus_ay = QList<unsigned char>;
+using QVariantMapMap = QMap<QString, QVariantMap>;
+using DBusManagedObjects = QMap<QDBusObjectPath, QVariantMapMap>;
+using ByteArrayList = QList<QByteArray>;
 Q_DECLARE_METATYPE(dbus_ay)
 Q_DECLARE_METATYPE(QVariantMapMap)
 Q_DECLARE_METATYPE(DBusManagedObjects)

--- a/platform/devicemanager_unix.h
+++ b/platform/devicemanager_unix.h
@@ -16,7 +16,7 @@ class DeviceManagerUnix : public DeviceManager
 public:
     explicit DeviceManagerUnix(QObject *parent = nullptr);
     ~DeviceManagerUnix();
-    bool deviceAccessPossible();
+    bool deviceAccessPossible() override;
 
     QStringList blockDevices();
     UDisks2Block *blockDevice(const QString &node);
@@ -37,7 +37,7 @@ signals:
     void filesystemChanged(const QString &node);
 
 protected:
-    void populate();
+    void populate() override;
 
 private:
     void addDrive(const QString &node);
@@ -61,11 +61,10 @@ private:
 class UDisks2Block : public DeviceInfo {
     Q_OBJECT
 public:
-    explicit UDisks2Block(const QString &node, QObject *parent = NULL);
-    QString toDisplayString();
-    void mount();
+    explicit UDisks2Block(const QString &node, QObject *parent = nullptr);
+    QString toDisplayString() override;
+    void mount() override;
 
-public:
     //QString name;       // deviceName
     QString dev;
     QString id;
@@ -100,7 +99,7 @@ private:
 class UDisks2Filesystem : public QObject {
     Q_OBJECT
 public:
-    UDisks2Filesystem(const QString &node, QObject *parent = nullptr);
+    explicit UDisks2Filesystem(const QString &node, QObject *parent = nullptr);
     const QStringList &mountPoints() const;
     void mount();
     void unmount();
@@ -118,7 +117,7 @@ private:
 class UDisks2Drive : public QObject {
     Q_OBJECT
 public:
-    explicit UDisks2Drive(const QString &node, QObject *parent = NULL);
+    explicit UDisks2Drive(const QString &node, QObject *parent = nullptr);
 
     QString name;
     qulonglong size;

--- a/platform/devicemanager_win.cpp
+++ b/platform/devicemanager_win.cpp
@@ -123,7 +123,7 @@ bool DeviceListener::nativeEvent(const QByteArray &eventType, void *message, lon
 {
     Q_UNUSED(eventType);
     Q_UNUSED(result);
-    MSG *m = reinterpret_cast<MSG*>(message);
+    MSG *m = static_cast<MSG*>(message);
     if (m->message == WM_DEVICECHANGE) {
         Logger::log("devman", "got device change notification");
         rescanTimer.start();

--- a/playlist.cpp
+++ b/playlist.cpp
@@ -4,17 +4,17 @@
 
 
 
-static char keyContents[] = "contents";
-static char keyCreated[] = "created";
-static char keyItems[] = "items";
-static char keyMetadata[] = "metadata";
-static char keyNowPlaying[] = "nowplaying";
-static char keyRepeat[] = "repeat";
-static char keyShuffle[] = "shuffle";
-static char keyTitle[] = "title";
-static char keyUrl[] = "url";
-static char keyUuid[] = "uuid";
-static char keyOriginalPosition[] = "originalposition";
+constexpr char keyContents[] = "contents";
+constexpr char keyCreated[] = "created";
+constexpr char keyItems[] = "items";
+constexpr char keyMetadata[] = "metadata";
+constexpr char keyNowPlaying[] = "nowplaying";
+constexpr char keyRepeat[] = "repeat";
+constexpr char keyShuffle[] = "shuffle";
+constexpr char keyTitle[] = "title";
+constexpr char keyUrl[] = "url";
+constexpr char keyUuid[] = "uuid";
+constexpr char keyOriginalPosition[] = "originalposition";
 
 
 
@@ -342,7 +342,7 @@ bool Playlist::contains(const QUuid &itemUuid)
 void Playlist::iterateItems(const std::function<void(QSharedPointer<Item>)> &callback)
 {
     QReadLocker locker(&listLock);
-    for (auto &item : items)
+    for (auto const &item : items)
         callback(item);
 }
 
@@ -766,10 +766,7 @@ QSharedPointer<PlaylistCollection> PlaylistCollection::collection;
 QSharedPointer<PlaylistCollection> PlaylistCollection::backup;
 QSharedPointer<QueuePlaylist> PlaylistCollection::queue;
 
-PlaylistCollection::PlaylistCollection()
-{
-
-}
+PlaylistCollection::PlaylistCollection() = default;
 
 PlaylistCollection::~PlaylistCollection()
 {
@@ -958,7 +955,7 @@ void PlaylistSearcher::filterPlaylist(QSharedPointer<Playlist> list, QString tex
     emit playlistFiltered(list->uuid());
 }
 
-void PlaylistSearcher::clearPlaylistFilter(QSharedPointer<Playlist> &list)
+void PlaylistSearcher::clearPlaylistFilter(QSharedPointer<Playlist> const &list)
 {
     if (list.isNull())
         return;

--- a/playlist.h
+++ b/playlist.h
@@ -23,7 +23,7 @@ struct PlaylistItem {
 
 class Item {
 public:
-    Item(QUrl url = QUrl());
+    explicit Item(QUrl url = QUrl());
 
     QUuid uuid() const;
     void setUuid(const QUuid &itemUuid);
@@ -93,7 +93,7 @@ private:
 class Playlist : public QObject {
     Q_OBJECT
 public:
-    Playlist(const QString &title = QString());
+    explicit Playlist(const QString &title = QString());
     ~Playlist();
     QSharedPointer<Item> addItem(const QUrl &url = QUrl());
     QSharedPointer<Item> addItem(const QUuid &itemUuid, const QUrl &url);
@@ -137,7 +137,7 @@ public:
     QVariantMap toVMap();
     void fromVMap(const QVariantMap &qvm);
 
-protected:
+private:
     QList<QSharedPointer<Item>> items;
     QHash<QUuid, QSharedPointer<Item>> itemsByUuid;
     //QList<QUuid> queue;
@@ -156,7 +156,7 @@ protected:
 class QueuePlaylist : public Playlist {
     Q_OBJECT
 public:
-    QueuePlaylist(const QString &title = QString());
+    explicit QueuePlaylist(const QString &title = QString());
 
     PlaylistItem first();
     PlaylistItem takeFirst();
@@ -164,10 +164,10 @@ public:
     void toggle(const QUuid &playlistUuid, const QList<QUuid> &uuids, QList<QUuid> &added, QList<int> &removed);
     void toggleFromPlaylist(const QUuid &playlistUuid, QList<QUuid> &added, QList<int> &removedIndices);
     void appendItems(const QUuid &playlistUuid, const QList<QUuid> &itemsToAdd);
-    void addItems(const QUuid &where, const QList<QSharedPointer<Item> > &itemsToAdd);
-    void removeItem(const QUuid &itemUuid);
+    void addItems(const QUuid &where, const QList<QSharedPointer<Item> > &itemsToAdd) override;
+    void removeItem(const QUuid &itemUuid) override;
     void removeItems(const QList<QUuid> &itemsToRemove);
-    void clear();
+    void clear() override;
     int contains(const QList<QUuid> &itemsToCheck);
 
 private:
@@ -230,7 +230,7 @@ signals:
 
 public slots:
     void filterPlaylist(QSharedPointer<Playlist> list, QString text);
-    void clearPlaylistFilter(QSharedPointer<Playlist> &list);
+    void clearPlaylistFilter(QSharedPointer<Playlist> const &list);
 
 private:
     static void findNeedles(const QString &text, const QStringList &needles,

--- a/playlistwindow.h
+++ b/playlistwindow.h
@@ -129,7 +129,7 @@ private slots:
     void sortPlaylistByLabel(const QUuid &playlistUuid);
     void sortPlaylistByUrl(const QUuid &playlistUuid);
     void shufflePlaylist(const QUuid &playlistUuid, bool shuffle);
-    void refreshPlaylist(const QUuid & playlistUuid);
+    void refreshPlaylist(const QUuid &playlistUuid);
     void restorePlaylist(const QUuid &playlistUuid);
 
     void self_visibilityChanged();

--- a/qthelper.hpp
+++ b/qthelper.hpp
@@ -39,14 +39,13 @@
 #include <QSharedPointer>
 #include <QMetaType>
 
-namespace mpv {
-namespace qt {
+namespace mpv::qt {
 
 // Wrapper around mpv_handle. Does refcounting under the hood.
 class Handle
 {
     struct container {
-        container(mpv_handle *h) : mpv(h) {}
+        explicit container(mpv_handle *h) : mpv(h) {}
         ~container() { mpv_terminate_destroy(mpv); }
         mpv_handle *mpv;
     };
@@ -103,7 +102,7 @@ static inline QVariant node_to_variant(const mpv_node *node)
 }
 
 struct node_builder {
-    node_builder(const QVariant& v) {
+    explicit node_builder(const QVariant &v) {
         set(&node_, v);
     }
     ~node_builder() {
@@ -222,7 +221,7 @@ private:
  */
 struct node_autofree {
     mpv_node *ptr;
-    node_autofree(mpv_node *a_ptr) : ptr(a_ptr) {}
+    explicit node_autofree(mpv_node *a_ptr) : ptr(a_ptr) {}
     ~node_autofree() { mpv_free_node_contents(ptr); }
 };
 
@@ -372,7 +371,6 @@ static inline QVariant command(mpv_handle *ctx, const QVariant &args)
     return node_to_variant(&res);
 }
 
-}
 }
 
 Q_DECLARE_METATYPE(mpv::qt::ErrorReturn)

--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -31,7 +31,7 @@ struct FilterWindow {
     inline FilterWindow &resizable_() { resizable = true; return *this; }
 };
 
-static QMap<QString,FilterWindow> filterWindows {
+static const QMap<QString,FilterWindow> filterWindows {
     { "box",        FilterWindow().radius_(1) },
     { "triangle",   FilterWindow().radius_(1) },
     { "bartlett",   FilterWindow().radius_(1) },
@@ -73,7 +73,7 @@ struct FilterKernel : public FilterWindow {
     inline FilterKernel &cutoff_(double v) { cutoff = v; return *this; }
 };
 
-static QMap<QString,FilterKernel> filterKernels {
+static const QMap<QString,FilterKernel> filterKernels {
     { "bilinear",           FilterKernel() },
     { "bicubic_fast",       FilterKernel() },
     { "oversample",         FilterKernel() },
@@ -243,7 +243,7 @@ QMap<QString, std::function<void (QObject *, const QVariant &)> > Setting::class
 
 
 
-static QStringList internalLogos = {
+static const QStringList internalLogos = {
     ":/not-a-real-resource.png",
     ":/images/logo/cinema-screen.svg",
     ":/images/logo/triangle-circle.svg",
@@ -252,13 +252,7 @@ static QStringList internalLogos = {
 
 
 
-Setting &Setting::operator =(const Setting &s)
-{
-    name = s.name;
-    widget = s.widget;
-    value = s.value;
-    return *this;
-}
+Setting &Setting::operator =(const Setting &s) = default;
 
 void Setting::sendToControl()
 {
@@ -504,7 +498,7 @@ void SettingsWindow::updateAcceptedSettings() {
     acceptedKeyMap = actionEditor->toVMap();
 }
 
-SettingMap SettingsWindow::generateSettingMap(QWidget *root)
+SettingMap SettingsWindow::generateSettingMap(QWidget *root) const
 {
     SettingMap settingMap;
 
@@ -529,7 +523,7 @@ SettingMap SettingsWindow::generateSettingMap(QWidget *root)
         QObjectList children = item->children();
         foreach(QObject *child, children) {
             if (child->inherits("QWidget") || child->inherits("QLayout"))
-            toParse.append(child);
+                toParse.append(child);
         }
     }
     return settingMap;
@@ -594,7 +588,7 @@ void SettingsWindow::updateLogoWidget()
     logoWidget->setLogo(selectedLogo());
 }
 
-QString SettingsWindow::selectedLogo()
+QString SettingsWindow::selectedLogo() const
 {
     return ui->logoExternal->isChecked()
                                 ? ui->logoExternalLocation->text()
@@ -763,7 +757,7 @@ void SettingsWindow::sendSignals()
         emit speedStepAdditive(WIDGET_LOOKUP(ui->playbackSpeedStepAdditive).toBool());
     }
     setAudioFilter("stereotools", "balance_out=" +
-        QString().number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
+        QString::number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
     emit stepTimeNormal(WIDGET_LOOKUP(ui->playbackNormalStep).toInt());
     emit stepTimeLarge(WIDGET_LOOKUP(ui->playbackLargeStep).toInt());
 
@@ -1204,7 +1198,7 @@ void SettingsWindow::restoreColorControls()
 void SettingsWindow::restoreAudioSettings()
 {
     setAudioFilter("stereotools", "balance_out=" +
-        QString().number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
+        QString::number(WIDGET_LOOKUP(ui->audioBalance).toDouble()/100), true);
 }
 
 void SettingsWindow::colorPick_clicked(QLineEdit *colorValue)
@@ -1218,16 +1212,16 @@ void SettingsWindow::colorPick_clicked(QLineEdit *colorValue)
     colorValue->setFocus();
 }
 
-void SettingsWindow::colorPick_changed(QLineEdit *colorValue, QPushButton *colorPick)
+void SettingsWindow::colorPick_changed(const QLineEdit *colorValue, QPushButton *colorPick)
 {
     colorPick->setStyleSheet(QString("background: #%1").arg(colorValue->text()));
 }
 
-QList<MpvOption> SettingsWindow::parseMpvOptions(const QString& optionsInline)
+QList<MpvOption> SettingsWindow::parseMpvOptions(const QString &optionsInline) const
 {
     QList<MpvOption> mpvOptions;
     const QStringList options = optionsInline.split(' ', Qt::SkipEmptyParts);
-    for (const QString& option : options) {
+    for (const QString &option : options) {
         int equalPos = option.indexOf('=');
         if (equalPos > 0) {
             QString name = option.left(equalPos).trimmed();
@@ -1489,8 +1483,8 @@ void SettingsWindow::on_fullscreenHideControls_toggled(bool checked)
 
 void SettingsWindow::on_audioBalance_valueChanged(int value)
 {
-    QToolTip::showText(QCursor::pos(), QString().number(value), ui->audioBalance);
-    setAudioFilter("stereotools", "balance_out=" + QString().number((double) value/100), true);
+    QToolTip::showText(QCursor::pos(), QString::number(value), ui->audioBalance);
+    setAudioFilter("stereotools", "balance_out=" + QString::number((double) value/100), true);
 }
 
 void SettingsWindow::on_playbackAutoZoom_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -17,10 +17,10 @@
 
 class Setting {
 public:
-    Setting() {}
-    Setting(const Setting &s) : name(s.name), widget(s.widget), value(s.value) {}
-    Setting(QString name, QWidget *widget, QVariant value) : name(name), widget(widget), value(value) {}
-    Setting& operator =(const Setting &s);
+    Setting() = default;
+    Setting(const Setting &s) = default;
+    Setting(QString name, QWidget *widget, QVariant const &value) : name(name), widget(widget), value(value) {}
+    Setting &operator =(const Setting &s);
     void sendToControl();
     void fetchFromControl();
 
@@ -71,10 +71,10 @@ private:
     void setupFullscreenCombo();
     void setupUnimplementedWidgets();
     void updateAcceptedSettings();
-    SettingMap generateSettingMap(QWidget *root);
+    SettingMap generateSettingMap(QWidget *root) const;
     void generateVideoPresets();
     void updateLogoWidget();
-    QString selectedLogo();
+    QString selectedLogo() const;
     QString channelSwitcher();
 
 signals:
@@ -224,8 +224,8 @@ private slots:
     void restoreColorControls();
     void restoreAudioSettings();
     void colorPick_clicked(QLineEdit *colorValue);
-    void colorPick_changed(QLineEdit *colorValue, QPushButton *colorPick);
-    QList<MpvOption> parseMpvOptions(const QString& optionsInline);
+    void colorPick_changed(const QLineEdit *colorValue, QPushButton *colorPick);
+    QList<MpvOption> parseMpvOptions(const QString &optionsInline) const;
 
     bool settingsOrKeyMapChanged();
 

--- a/thumbnailerwindow.cpp
+++ b/thumbnailerwindow.cpp
@@ -490,7 +490,7 @@ void MpvThumbnailDrawer::alwaysUpdate()
 
 void MpvThumbnailDrawer::render_update(void *ctx)
 {
-    QMetaObject::invokeMethod(reinterpret_cast<MpvThumbnailDrawer*>(ctx), "alwaysUpdate");
+    QMetaObject::invokeMethod(static_cast<MpvThumbnailDrawer*>(ctx), "alwaysUpdate");
 }
 
 void MpvThumbnailDrawer::initMpv()

--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -233,7 +233,7 @@ QWidget *ButtonDelegate::createEditor(QWidget *parent, const QStyleOptionViewIte
 {
     Q_UNUSED(option)
     Q_UNUSED(index)
-    return qobject_cast<QWidget*>(new ButtonWidget(parent));
+    return new ButtonWidget(parent);
 }
 
 void ButtonDelegate::setEditorData(QWidget *editor, const QModelIndex &index) const

--- a/widgets/actioneditor.h
+++ b/widgets/actioneditor.h
@@ -20,7 +20,7 @@ class ActionEditor : public QTableView
 {
     Q_OBJECT
 public:
-    ActionEditor(QWidget *parent = nullptr);
+    explicit ActionEditor(QWidget *parent = nullptr);
 
     void setCommands(const QList<Command> &commands);
     Command getCommand(int index) const;
@@ -50,7 +50,7 @@ private:
 class ShortcutWidget :public QWidget {
     Q_OBJECT
 public:
-    ShortcutWidget(QWidget *parent = nullptr);
+    explicit ShortcutWidget(QWidget *parent = nullptr);
     void setKeySequence(const QKeySequence &keySequence);
     QKeySequence keySequence();
 
@@ -71,11 +71,11 @@ private:
 class ShortcutDelegate : public QStyledItemDelegate {
     Q_OBJECT
 public:
-    ShortcutDelegate(QObject *parent = nullptr);
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    explicit ShortcutDelegate(QObject *parent = nullptr);
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
     ActionEditor *owner = nullptr;
@@ -87,7 +87,7 @@ private:
 class ButtonWidget : public QWidget {
     Q_OBJECT
 public:
-    ButtonWidget(QWidget * parent = nullptr);
+    explicit ButtonWidget(QWidget * parent = nullptr);
     void setState(const MouseState &state);
     MouseState state() const;
 
@@ -111,11 +111,11 @@ private:
 class ButtonDelegate : public QStyledItemDelegate {
     Q_OBJECT
 public:
-    ButtonDelegate(QObject *parent = nullptr, bool fullscreen = false);
-    virtual QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    virtual void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    virtual void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-    virtual void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    explicit ButtonDelegate(QObject *parent = nullptr, bool fullscreen = false);
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
     ActionEditor *owner = nullptr;

--- a/widgets/drawncollection.cpp
+++ b/widgets/drawncollection.cpp
@@ -72,9 +72,9 @@ void DrawnCollection::addPlaylist(QUuid playlistUuid)
 
 QUuid DrawnCollection::currentPlaylistUuid()
 {
-    auto ci = reinterpret_cast<CollectionItem*>(currentItem());
+    auto ci = static_cast<CollectionItem*>(currentItem());
     if (!ci)
-        ci = reinterpret_cast<CollectionItem*>(item(0));
+        ci = static_cast<CollectionItem*>(item(0));
     return ci ? ci->uuid() : QUuid();
 }
 
@@ -92,7 +92,7 @@ void DrawnCollection::self_currentRowChanged(int currentRow)
 {
     QUuid playlistUuid;
     if (currentRow != -1)
-        playlistUuid = reinterpret_cast<CollectionItem*>(this->item(currentRow))->uuid();
+        playlistUuid = static_cast<CollectionItem*>(this->item(currentRow))->uuid();
     emit playlistSelected(playlistUuid);
 }
 

--- a/widgets/drawncollection.h
+++ b/widgets/drawncollection.h
@@ -9,17 +9,17 @@ class CollectionPainter : public QAbstractItemDelegate
 {
     Q_OBJECT
 public:
-    CollectionPainter(QObject *parent = nullptr);
+    explicit CollectionPainter(QObject *parent = nullptr);
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
-               const QModelIndex &index) const;
+               const QModelIndex &index) const override;
     QSize sizeHint(const QStyleOptionViewItem &option,
-                   const QModelIndex &index) const;
+                   const QModelIndex &index) const override;
 };
 
 class CollectionItem : public QListWidgetItem
 {
 public:
-    CollectionItem(QUuid playlistUuid, QListWidget *parent = nullptr);
+    explicit CollectionItem(QUuid playlistUuid, QListWidget *parent = nullptr);
     QUuid uuid();
 private:
     QUuid playlistUuid_;
@@ -30,7 +30,7 @@ class DrawnCollection : public QListWidget
 {
     Q_OBJECT
 public:
-    DrawnCollection(QSharedPointer<PlaylistCollection> collection, QWidget *parent = nullptr);
+    explicit DrawnCollection(QSharedPointer<PlaylistCollection> collection, QWidget *parent = nullptr);
     QSharedPointer<PlaylistCollection> collection();
 
     void addPlaylist(QUuid playlistUuid);

--- a/widgets/drawnplaylist.cpp
+++ b/widgets/drawnplaylist.cpp
@@ -152,9 +152,9 @@ QUuid DrawnPlaylist::uuid() const
 
 QUuid DrawnPlaylist::currentItemUuid() const
 {
-    PlayItem *item = reinterpret_cast<PlayItem*>(currentItem());
+    PlayItem *item = static_cast<PlayItem*>(currentItem());
     if (!item)
-        item = reinterpret_cast<PlayItem*>(QListWidget::item(0));
+        item = static_cast<PlayItem*>(QListWidget::item(0));
     if (item)
         return item->uuid();
     return QUuid();
@@ -238,7 +238,7 @@ void DrawnPlaylist::removeItem(QUuid itemUuid)
     if (playlist && playlist->contains(itemUuid))
         playlist->removeItem(itemUuid);
     auto matchingRows = findItems(itemUuid.toString(), Qt::MatchExactly);
-    if (matchingRows.length() > 0)
+    if (!matchingRows.isEmpty())
         takeItem(row(matchingRows[0]));
 }
 
@@ -393,19 +393,19 @@ void DrawnPlaylist::self_currentItemChanged(QListWidgetItem *current,
 {
     Q_UNUSED(previous)
     QUuid itemUuid;
-    if (current && !(itemUuid=reinterpret_cast<PlayItem*>(current)->uuid()).isNull())
+    if (current && !(itemUuid=static_cast<PlayItem*>(current)->uuid()).isNull())
         lastSelectedItem = itemUuid;
 }
 
 void DrawnPlaylist::self_itemDoubleClicked(QListWidgetItem *item)
 {
-    PlayItem *playItem = reinterpret_cast<PlayItem*>(item);
+    PlayItem *playItem = static_cast<PlayItem*>(item);
     emit itemDesiredByDoubleClick(playItem->playlistUuid(), playItem->uuid());
 }
 
 void DrawnPlaylist::self_customContextMenuRequested(const QPoint &p)
 {
-    PlayItem *playItem = reinterpret_cast<PlayItem*>(this->itemAt(p));
+    PlayItem *playItem = static_cast<PlayItem*>(this->itemAt(p));
     QUuid playItemUuid = playItem ? playItem->uuid() : QUuid();
     emit contextMenuRequested(p, playlistUuid_, playItemUuid);
 }

--- a/widgets/drawnplaylist.h
+++ b/widgets/drawnplaylist.h
@@ -13,17 +13,17 @@ class PlaylistSearcher;
 class PlayPainter : public QAbstractItemDelegate {
     Q_OBJECT
 public:
-    PlayPainter(QObject *parent = nullptr);
+    explicit PlayPainter(QObject *parent = nullptr);
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
-               const QModelIndex &index) const;
+               const QModelIndex &index) const override;
     QSize sizeHint(const QStyleOptionViewItem &option,
-                   const QModelIndex &index) const;
+                   const QModelIndex &index) const override;
 };
 
 
 class PlayItem : public QListWidgetItem {
 public:
-    PlayItem(const QUuid &itemUuid = QUuid(), const QUuid &playlistUuid = QUuid(), QListWidget *parent = nullptr);
+    explicit PlayItem(const QUuid &itemUuid = QUuid(), const QUuid &playlistUuid = QUuid(), QListWidget *parent = nullptr);
     ~PlayItem();
 
     QUuid playlistUuid();
@@ -41,7 +41,7 @@ private:
 class DrawnPlaylist : public QListWidget {
     Q_OBJECT
 public:
-    DrawnPlaylist(QSharedPointer<PlaylistCollection> collection, QWidget *parent = nullptr);
+    explicit DrawnPlaylist(QSharedPointer<PlaylistCollection> collection, QWidget *parent = nullptr);
     ~DrawnPlaylist();
     void setCollection(QSharedPointer<PlaylistCollection> collection);
     virtual QSharedPointer<Playlist> playlist() const;
@@ -79,7 +79,7 @@ public:
     void repopulateItems();
 
 protected:
-    bool event(QEvent *e);
+    bool event(QEvent *e) override;
 
 private:
     QSharedPointer<PlaylistCollection> collection_;
@@ -135,8 +135,8 @@ class DrawnQueue : public DrawnPlaylist {
     Q_OBJECT
 public:
     DrawnQueue();
-    virtual QSharedPointer<Playlist> playlist() const;
-    void addItem(QUuid itemUuid);
+    QSharedPointer<Playlist> playlist() const override;
+    void addItem(QUuid itemUuid) override;
 };
 
 class PlaylistSelectionPrivate;

--- a/widgets/drawnslider.cpp
+++ b/widgets/drawnslider.cpp
@@ -124,7 +124,7 @@ void DrawnSlider::paintEvent(QPaintEvent *event)
 {
     Q_UNUSED(event)
     QPalette pal;
-    pal = reinterpret_cast<QWidget*>(parentWidget())->palette();
+    pal = parentWidget()->palette();
     if (highContrast) {
         grooveBorder = pal.color(QPalette::Normal, QPalette::Text);
         grooveFill   = pal.color(QPalette::Normal, QPalette::Window);
@@ -413,7 +413,7 @@ void MediaSlider::makeHandle()
     }
 }
 
-void MediaSlider::enterEvent(QEvent *event)
+void MediaSlider::enterEvent(QEnterEvent *event)
 {
     Q_UNUSED(event)
     emit hoverBegin();

--- a/widgets/drawnslider.h
+++ b/widgets/drawnslider.h
@@ -42,8 +42,8 @@ protected:
     double valueToX(double value);
     double xToValue(double x);
 
-    void paintEvent(QPaintEvent *event);
-    void resizeEvent(QResizeEvent *event);
+    void paintEvent(QPaintEvent *event) override;
+    void resizeEvent(QResizeEvent *event) override;
 
     bool highContrast = false;
     bool redrawHandle = true;
@@ -59,9 +59,9 @@ protected:
     int handleWidth, handleHeight, marginX, marginY, paddingHeight;
 
 private:
-    void mousePressEvent(QMouseEvent *ev);
-    void mouseReleaseEvent(QMouseEvent *ev);
-    void mouseMoveEvent(QMouseEvent *ev);
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+    void mouseMoveEvent(QMouseEvent *ev) override;
 
     bool isDragging = false;
     double xPosition = 0.0;
@@ -89,12 +89,12 @@ signals:
     void hoverValue(double position, QString chapterInfo, double x);
 
 protected:
-    void resizeEvent(QResizeEvent *event);
-    void makeBackground();
-    void makeHandle();
-    void enterEvent(QEvent *event);
-    void leaveEvent(QEvent *event);
-    void handleHover(double x);
+    void resizeEvent(QResizeEvent *event) override;
+    void makeBackground() override;
+    void makeHandle() override;
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+    void handleHover(double x) override;
 
     void updateLoopArea();
 
@@ -112,7 +112,7 @@ public:
     explicit VolumeSlider(QWidget *parent = nullptr);
 
 protected:
-    void makeBackground();
-    void makeHandle();
+    void makeBackground() override;
+    void makeHandle() override;
 };
 #endif // QDRAWNSLIDER_H

--- a/widgets/drawnstatus.h
+++ b/widgets/drawnstatus.h
@@ -9,7 +9,7 @@ class StatusTime : public QWidget
     Q_OBJECT
 public:
     explicit StatusTime(QWidget *parent = nullptr);
-    virtual QSize minimumSizeHint() const;
+    QSize minimumSizeHint() const override;
 
     void setTime(double time, double duration);
     void setShortMode(bool shortened);
@@ -17,7 +17,7 @@ public:
 protected:
     void updateTimeFormat();
     void updateText();
-    void paintEvent(QPaintEvent *event);
+    void paintEvent(QPaintEvent *event) override;
 
 private:
     bool shortMode = false;

--- a/widgets/logowidget.h
+++ b/widgets/logowidget.h
@@ -36,9 +36,9 @@ public:
     void setLogoBackground(const QColor &color);
 
 protected:
-    void initializeGL();
-    void paintGL();
-    void resizeGL(int w, int h);
+    void initializeGL() override;
+    void paintGL() override;
+    void resizeGL(int w, int h) override;
 
 private:
     LogoDrawer *logoDrawer = nullptr;

--- a/widgets/paletteeditor.cpp
+++ b/widgets/paletteeditor.cpp
@@ -9,7 +9,7 @@
 
 
 
-typedef QList<QPair<QPalette::ColorRole,QString>> RoleLabels;
+using RoleLabels = QList<QPair<QPalette::ColorRole, QString>>;
 Q_GLOBAL_STATIC_WITH_ARGS(RoleLabels, roleText, ({
     { QPalette::WindowText, QObject::tr("Window text") },
     { QPalette::Button, QObject::tr("Button") },
@@ -33,7 +33,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(RoleLabels, roleText, ({
     { QPalette::ToolTipText, QObject::tr("Tooltip text") }
 }));
 
-typedef QList<QPair<QPalette::ColorGroup,QString>> GroupLabels;
+using GroupLabels = QList<QPair<QPalette::ColorGroup, QString>>;
 Q_GLOBAL_STATIC_WITH_ARGS(GroupLabels, groupText, ({
     { QPalette::Active, QObject::tr("Active") },
     { QPalette::Disabled, QObject::tr("Disabled") },
@@ -84,7 +84,7 @@ void PaletteBox::mousePressEvent(QMouseEvent *event)
 
 PaletteEditor::PaletteEditor(QWidget *parent) : QWidget(parent)
 {
-    system = qApp->palette();
+    system = QApplication::palette();
     auto makeBox = [this](ColorPair data) {
         PaletteBox *box = new PaletteBox;
         PaletteEditor *owner = this;
@@ -101,16 +101,16 @@ PaletteEditor::PaletteEditor(QWidget *parent) : QWidget(parent)
     QGridLayout *layout = new QGridLayout();
 
     // First row - labels
-    for (auto &gtt : *groupText)
-        layout->addWidget(new QLabel(gtt.second), row, 1 + col++);
+    for (auto const &[colorGroup, colorGroupTitle] : *groupText)
+        layout->addWidget(new QLabel(colorGroupTitle), row, 1 + col++);
     row++;
 
     // Middle rows - colorboxes
-    for (auto &role : *roleText) {
+    for (auto const &[colorRole, colorRoleTitle] : *roleText) {
         col = 0;
-        layout->addWidget(new QLabel(role.second), row, col++);
-        for (auto &group : *groupText)
-            layout->addWidget(makeBox({group.first,role.first}), row, col++);
+        layout->addWidget(new QLabel(colorRoleTitle), row, col++);
+        for (auto const &[colorGroup, colorGroupTitle] : *groupText)
+            layout->addWidget(makeBox({colorGroup, colorRole}), row, col++);
         row++;
     }
 

--- a/widgets/paletteeditor.h
+++ b/widgets/paletteeditor.h
@@ -21,8 +21,8 @@ public slots:
     void setValue(const QColor &c);
 
 protected:
-    void paintEvent(QPaintEvent *event);
-    void mousePressEvent(QMouseEvent *event);
+    void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
 
 private:
     QColor color;
@@ -36,9 +36,9 @@ class PaletteEditor : public QWidget
     Q_PROPERTY(QVariant value READ variant WRITE setVariant NOTIFY valueChanged)
 
 public:
-    typedef QPair<QPalette::ColorGroup,QPalette::ColorRole> ColorPair;
-    typedef QMap<ColorPair,PaletteBox*> BoxMap;
-    typedef QMap<ColorPair,QColor> PaletteEntries;
+    using ColorPair = QPair<QPalette::ColorGroup, QPalette::ColorRole>;
+    using BoxMap = QMap<ColorPair, PaletteBox *>;
+    using PaletteEntries = QMap<ColorPair, QColor>;
 
     explicit PaletteEditor(QWidget *parent = nullptr);
     QPalette palette();

--- a/widgets/screencombo.cpp
+++ b/widgets/screencombo.cpp
@@ -49,7 +49,7 @@ void ScreenCombo::populateItems()
 {
     this->clear();
     this->addItem(tr("Current"));
-    for (auto screen : qApp->screens()) {
+    for (auto screen : QApplication::screens()) {
         this->addItem(Helpers::screenToVisualName(screen));
         if (!Platform::isUnix) {
             QObject::disconnect(screen, &QScreen::geometryChanged,

--- a/widgets/screencombo.h
+++ b/widgets/screencombo.h
@@ -7,7 +7,7 @@ class ScreenCombo : public QComboBox
     Q_OBJECT
     Q_PROPERTY (QString currentScreenName READ currentScreenName WRITE setCurrentScreenName)
 public:
-    ScreenCombo(QWidget *parent);
+    explicit ScreenCombo(QWidget *parent);
     QString currentScreenName();
     void setCurrentScreenName(QString name);
 

--- a/widgets/tooltip.cpp
+++ b/widgets/tooltip.cpp
@@ -34,7 +34,7 @@ Tooltip::~Tooltip()
     textLabel = nullptr;
 }
 
-void Tooltip::show(const QString &text, QPoint &where, int mainWindowWidth, QString &textTemplate)
+void Tooltip::show(const QString &text, const QPoint &where, int mainWindowWidth, const QString &textTemplate)
 {
     textLabel->setText(text);
     auto rect = QFontMetrics(font()).boundingRect(textTemplate);
@@ -45,7 +45,7 @@ void Tooltip::show(const QString &text, QPoint &where, int mainWindowWidth, QStr
     textLabel->setVisible(true);
 }
 
-void Tooltip::setPosition(QPoint &where, int mainWindowWidth)
+void Tooltip::setPosition(const QPoint &where, int mainWindowWidth)
 {
     int tooltipWidth = textLabel->width();
     int xPos = where.x() - std::round(tooltipWidth / 2);

--- a/widgets/tooltip.h
+++ b/widgets/tooltip.h
@@ -7,11 +7,11 @@ class Tooltip : public QWidget {
     public:
         explicit Tooltip(QWidget *parent = nullptr);
         ~Tooltip();
-        void show(const QString &text, QPoint &where, int mainWindowWidth, QString &textTemplate);
+        void show(const QString &text, const QPoint &where, int mainWindowWidth, const QString &textTemplate);
         void hide();
 
     private:
-        void setPosition(QPoint &where, int mainWindowWidth);
+        void setPosition(const QPoint &where, int mainWindowWidth);
 
         QLabel *textLabel;
         bool aspectRatioSet = false;

--- a/widgets/videopreview.cpp
+++ b/widgets/videopreview.cpp
@@ -54,7 +54,7 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     aspectRatioSet = false;
 }
 
-void VideoPreview::show(const QString &text, double videoPosition, QPoint where, int mainWindowWidth)
+void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)
 {
     textLabel->setText(text);
     mpv->setTime(videoPosition);
@@ -64,7 +64,7 @@ void VideoPreview::show(const QString &text, double videoPosition, QPoint where,
     show();
 }
 
-void VideoPreview::setPreviewPosition(QPoint where, int mainWindowWidth)
+void VideoPreview::setPreviewPosition(const QPoint &where, int mainWindowWidth)
 {
     int tooltipWidth = videoWidget->width();
     int xPos = where.x() - std::round(tooltipWidth / 2);

--- a/widgets/videopreview.h
+++ b/widgets/videopreview.h
@@ -9,11 +9,11 @@ class VideoPreview : public QWidget {
         explicit VideoPreview(QWidget *parent = nullptr);
         ~VideoPreview();
         void openFile(const QUrl &fileUrl);
-        void show(const QString &text, double videoPosition, QPoint where, int mainWindowWidth);
+        void show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth);
         void hide();
         
     private:
-        void setPreviewPosition(QPoint where, int mainWindowWidth);
+        void setPreviewPosition(const QPoint &where, int mainWindowWidth);
         void show();
         void updateWidth(double newAspect);
 


### PR DESCRIPTION
- Add override keyword
- Use auto type to avoid code redundancy
- Replace reinterpret_cast by static_cast
- Set global variables as const
- Explicitely use static functions
- Pass large parameters as const reference
- Mark constructor as explicit
- Use default constructor
- Use C++ "using" instead of typedef for type alias
- Follow recommended practices for boolean tests
- Use constexpr char instead of static char
- Use structured binding declaration instead of QPair for code clarity
- Fix a few minor errors