### PR TITLE
Better processing and sorting of [new] playlist items

### DIFF
--- a/helpers.h
+++ b/helpers.h
@@ -12,6 +12,7 @@
 #include <QDate>
 #include <QTime>
 #include <QDir>
+#include <QCollator>
 
 extern const char autoIcons[];
 extern const char blackIconsPath[];
@@ -66,6 +67,8 @@ namespace Helpers {
     QString subsOpenFilter();
     bool urlSurvivesFilter(const QUrl &url, bool onlyAudioVideo);
     QList<QUrl> filterUrls(const QList<QUrl> &urls);
+    bool compareUrls(const QUrl &a, const QUrl &b, const QCollator &collator);
+    QString normalizedSuffix(const QFileInfo &fileInfo);
     QRect vmapToRect(const QVariantMap &m);
     QVariantMap rectToVmap(const QRect &r);
     bool sizeFromString(QSize &size, const QString &text);

--- a/playlistwindow.cpp
+++ b/playlistwindow.cpp
@@ -761,13 +761,15 @@ void PlaylistWindow::sortPlaylistByUrl(const QUuid &playlistUuid)
     auto qdp = widgets.value(playlistUuid, nullptr);
     if (!qdp)
         return;
-    auto converter = [](QSharedPointer<Item> i) {
-        return i->url().toDisplayString();
-    };
-    auto lessThan = [](const QString &a, const QString &b) {
-        return a < b;
-    };
-    qdp->sort<QString>(converter, lessThan);
+
+    QCollator collator;
+    collator.setCaseSensitivity(Qt::CaseInsensitive);
+    collator.setNumericMode(true);
+
+    using namespace std::placeholders;
+    auto converter = [](QSharedPointer<Item> i) { return i->url(); };
+    auto comparer = std::bind(&Helpers::compareUrls, _1, _2, collator);
+    qdp->sort<QUrl>(converter, comparer);
 }
 
 void PlaylistWindow::shufflePlaylist(const QUuid &playlistUuid, bool shuffle)


### PR DESCRIPTION
This makes sorting of playlist items done in a more "natural" manner, that being case insensitively and with proper handling of numerals.

Helpers::filterUrls has also received these changes:
- Circular symlinks are now checked and skipped.
- Directory traversal is now done separately from top-level files and uses QDirIterator, avoiding recursion and giving slightly better performance.
- Retrieval of normalized file suffixes has been slightly optimized and unified into its own method, used here and elsewhere as applicable.
- Resultant items are now sorted (with the new routine).