### PR TITLE
Polish Settings window

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1520,6 +1520,12 @@ void SettingsWindow::on_subsShadowEnabled_toggled(bool checked)
     ui->subsShadowOffset->setEnabled(checked);
 }
 
+void SettingsWindow::on_screenshotDirectorySet_toggled(bool checked)
+{
+    ui->screenshotDirectoryValue->setEnabled(checked);
+    ui->screenshotDirectoryBrowse->setEnabled(checked);
+}
+
 // REMOVEME: Disable auto zoom in Wayland mode as window centering isn't possible yet
 void SettingsWindow::on_tweaksPreferWayland_toggled(bool checked)
 {

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -301,6 +301,8 @@ private slots:
 
     void on_subsShadowEnabled_toggled(bool checked);
 
+    void on_screenshotDirectorySet_toggled(bool checked);
+
     void on_tweaksPreferWayland_toggled(bool checked);
 
     void on_tweaksTimeTooltip_toggled(bool checked);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6977,6 +6977,9 @@ media file played</string>
           </layout>
          </widget>
          <widget class="QWidget" name="exportPage">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
           <layout class="QVBoxLayout" name="exportPageLayout">
            <item>
             <widget class="QGroupBox" name="screenshotDirectoryBox">
@@ -7021,6 +7024,9 @@ media file played</string>
               </item>
               <item row="1" column="0">
                <widget class="QLabel" name="screenshotEncodeLabel">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="text">
                  <string>Encode</string>
                 </property>
@@ -7030,6 +7036,9 @@ media file played</string>
                <layout class="QHBoxLayout" name="encodeDirectoryLayout">
                 <item>
                  <widget class="QCheckBox" name="encodeDirectorySet">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="text">
                    <string/>
                   </property>
@@ -7040,6 +7049,9 @@ media file played</string>
                 </item>
                 <item>
                  <widget class="QLineEdit" name="encodeDirectoryValue">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="placeholderText">
                    <string notr="true">~/Videos/mpc_encodes</string>
                   </property>
@@ -7047,6 +7059,9 @@ media file played</string>
                 </item>
                 <item>
                  <widget class="QPushButton" name="encodeDirectoryBrowse">
+                  <property name="enabled">
+                   <bool>false</bool>
+                  </property>
                   <property name="text">
                    <string>...</string>
                   </property>
@@ -7089,6 +7104,9 @@ media file played</string>
               </item>
               <item row="1" column="0">
                <widget class="QLabel" name="encodeTemplateLabel">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="text">
                  <string>Encode</string>
                 </property>
@@ -7096,6 +7114,9 @@ media file played</string>
               </item>
               <item row="1" column="1">
                <widget class="QLineEdit" name="encodeTemplate">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="placeholderText">
                  <string notr="true">%f_encode_%aP-%bP_[%t{yyyy.MM.dd_hh.mm.ss}]%s{_subs}%d{_novideo}{_noaudio}</string>
                 </property>


### PR DESCRIPTION
* settingswindow: Move "Auto zoom" setting at the top of Playback > Output

> Since "Auto zoom" enables/disables the other settings of Playback > Output, it should be at the top.

* settingswindow: Only enable widgets in Logging page when their value is used
* settingswindow: Disable "Open options" and "Title bar" checkboxes in Player page on start

> The playerAppendToQuickPlaylist and playerTitleReplaceName checkboxes
> weren't correctly getting disabled on start because the wrong event was
> being used.

* settingswindow: Only enable widgets in Logo page when their value is used
* settingswindow: Only enable widgets in Export page when their value is used

> And disable Encode-related ones since it's not implemented yet.

There's still a bunch of widgets in the Output and Audio pages to disable when their value isn't used.