### PR TITLE
ci: Remove sdl2 mpv option for AppImage

### DIFF
--- a/.github/actions/data/build_options/mpv_options
+++ b/.github/actions/data/build_options/mpv_options
@@ -2,7 +2,6 @@
 -Dbuild-date=false
 -Dcdda=enabled
 -Ddvdnav=enabled
--Dsdl2=enabled
 -Dsndio=disabled
 -Ddvbin=enabled
 -Djack=disabled


### PR DESCRIPTION
This option has been removed from mpv's meson file and makes our AppImage action fail.

See https://github.com/mpc-qt/mpc-qt/pull/620.