### PR TITLE
mainwindow: Set focus to Play button after stopping playback

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2965,6 +2965,7 @@ void MainWindow::on_actionPlayStop_triggered()
     emit stopped();
     isPlaying = false;
     updateSize();
+    ui->play->setFocus();
 }
 
 void MainWindow::on_actionPlayFrameBackward_triggered()


### PR DESCRIPTION
Now that the Mute button isn't disabled anymore in the stopped state, it gets the focus after stopping playback. That means pressing the space bar won't reload the file like it used to. So we need to manually set the focus to the Play button.

Follow-up to (and fixes regression introduced by) 0378356cfb9f0d0e633065207f70aae2c36aab85.