### PR TITLE
actioneditor: Use translated version of key sequences in key editor

### DIFF
--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -51,7 +51,7 @@ void ActionEditor::setCommands(const QList<Command> &commands)
         QString actionDescription = getDescriptiveName(commands[i].action);
         QList<QStandardItem*> items = {
             new QStandardItem(actionDescription),
-            new QStandardItem(commands[i].action->shortcut().toString()),
+            new QStandardItem(commands[i].action->shortcut().toString(QKeySequence::NativeText)),
             new QStandardItem(commands[i].mouseWindowed.toString()),
             new QStandardItem(commands[i].mouseFullscreen.toString()),
         };


### PR DESCRIPTION
Otherwise, the key sequences are only translated after they get the focus.

For some reason, they key sequences are saved in the file with the QKeySequence::NativeText format instead of the default QKeySequence::PortableText format for QKeySequence::toString(). This commit doesn't affect that behavior.