### PR TITLE
http: Fix Qt 6.10 QFILE_MAYBE_NODISCARD warning

### DIFF
--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -97,11 +97,10 @@ void HttpResponse::serveFile(QString filename)
     filename.replace("..", ".");
 
     QFile f(filename);
-    if (!f.exists()) {
+    if (!f.exists() || !f.open(QIODevice::ReadOnly)) {
         statusCode = HttpResponse::Http404NotFound;
         return;
     }
-    f.open(QIODevice::ReadOnly);
 
     auto extension = QFileInfo(filename).suffix();
     contentType = HttpServer::extensionToContentType(extension);


### PR DESCRIPTION
Warning message:
warning: ignoring return value of ‘virtual bool
QFile::open(QIODeviceBase::OpenMode)’, declared with attribute ‘nodiscard’ [-Wunused-result]