### PR TITLE
settingswindow: Add QuickJS support for yt-dlp and enable auto EJS update

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -768,6 +768,7 @@ void SettingsWindow::sendSignals()
     emit afterPlaybackDefault(Helpers::AfterPlayback(WIDGET_LOOKUP(ui->afterPlaybackDefault).toInt()));
 
     emit option("ytdl-format", QString("bestvideo[height<=?%1]+bestaudio/best").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
+    emit option("ytdl-raw-options", "js-runtimes=quickjs,remote-components=ejs:github");
 
     emit zoomCenter(WIDGET_LOOKUP(ui->playbackAutoCenterWindow).toBool());
     double factor = WIDGET_LOOKUP(ui->playbackAutoFitFactor).toInt() / 100.0;


### PR DESCRIPTION
Since yt-dlp 2025.11.12, an external JavaScript runtime is needed.

While Deno support is enabled by default, its size is rather large (> 100 MB) in comparison to QuickJS (< 1 MB).

Auto EJS update lets yt-dlp download automatically from the yt-dlp repository and save in the drive cache the latest JS scripts needed for some websites (currently only YouTube).