### PR TITLE
settingswindow: Increase maximum values for normal and large playback steps

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1151,7 +1151,7 @@ media file played</string>
                  <number>1</number>
                 </property>
                 <property name="maximum">
-                 <number>60000</number>
+                 <number>2000000000</number>
                 </property>
                 <property name="value">
                  <number>5000</number>
@@ -1180,7 +1180,7 @@ media file played</string>
                  <number>1</number>
                 </property>
                 <property name="maximum">
-                 <number>60000</number>
+                 <number>2000000000</number>
                 </property>
                 <property name="value">
                  <number>20000</number>


### PR DESCRIPTION
Increases them from 60 seconds to 2 000 000 000 seconds (a little more than 23 days), close to actual 64-bit integer limit.

Note that mpv actually uses a double for the maximum seek size, so there would be no practical limit if we switched to that. Not that it would make much sense.

Fixes #627 (Long skip max duration is 60 seconds).