### PR TITLE
Use digit grouping for big numbers and make the % symbol translatable everywhere

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1079,7 +1079,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string notr="true">%</string>
+                 <string>%</string>
                 </property>
                 <property name="minimum">
                  <number>1</number>
@@ -1110,7 +1110,7 @@ media file played</string>
                    <string>Auto</string>
                   </property>
                   <property name="suffix">
-                   <string notr="true">%</string>
+                   <string>%</string>
                   </property>
                   <property name="maximum">
                    <number>100</number>
@@ -1315,7 +1315,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string notr="true">%</string>
+                 <string>%</string>
                 </property>
                 <property name="minimum">
                  <number>25</number>
@@ -6297,7 +6297,7 @@ media file played</string>
                  </sizepolicy>
                 </property>
                 <property name="suffix">
-                 <string notr="true">%</string>
+                 <string>%</string>
                 </property>
                 <property name="maximum">
                  <number>100</number>

--- a/thumbnailerwindow.ui
+++ b/thumbnailerwindow.ui
@@ -76,6 +76,9 @@
        <property name="value">
         <number>0</number>
        </property>
+       <property name="format">
+        <string>%p%</string>
+       </property>
       </widget>
      </item>
      <item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4234,6 +4234,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4283,6 +4287,10 @@ media file played</source>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4438,6 +4438,10 @@ arxiu multimèdia reproduït</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4488,6 +4492,10 @@ arxiu multimèdia reproduït</translation>
     <message>
         <source>Save Thumbnails</source>
         <translation>Desar miniatures</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4414,6 +4414,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4463,6 +4467,10 @@ media file played</source>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4450,6 +4450,10 @@ media file played</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation>Append opened files to Quick Playlist</translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4500,6 +4504,10 @@ media file played</translation>
     <message>
         <source>Save Thumbnails</source>
         <translation>Save Thumbnails</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4306,6 +4306,10 @@ archivo multimedia reproducido</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4355,6 +4359,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4196,6 +4196,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4246,6 +4250,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>Tallenna Pikkukuvat</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1450,35 +1450,35 @@
     </message>
     <message>
         <source>&amp;50%</source>
-        <translation>&amp;50%</translation>
+        <translation>&amp;50 %</translation>
     </message>
     <message>
         <source>&amp;100%</source>
-        <translation>&amp;100%</translation>
+        <translation>&amp;100 %</translation>
     </message>
     <message>
         <source>&amp;200%</source>
-        <translation>&amp;200%</translation>
+        <translation>&amp;200 %</translation>
     </message>
     <message>
         <source>25%</source>
-        <translation>25%</translation>
+        <translation>25 %</translation>
     </message>
     <message>
         <source>&amp;75%</source>
-        <translation>&amp;75%</translation>
+        <translation>&amp;75 %</translation>
     </message>
     <message>
         <source>15&amp;0%</source>
-        <translation>15&amp;0%</translation>
+        <translation>15&amp;0 %</translation>
     </message>
     <message>
         <source>&amp;400%</source>
-        <translation>&amp;400%</translation>
+        <translation>&amp;400 %</translation>
     </message>
     <message>
         <source>&amp;300%</source>
-        <translation>&amp;300%</translation>
+        <translation>&amp;300 %</translation>
     </message>
     <message>
         <source>&amp;Previous Audio Track</source>
@@ -1797,11 +1797,11 @@
     <name>PlaybackManager</name>
     <message>
         <source>Speed: %1%</source>
-        <translation>Vitesse : %1%</translation>
+        <translation>Vitesse : %1 %</translation>
     </message>
     <message>
         <source>Volume: %1%</source>
-        <translation>Volume : %1%</translation>
+        <translation>Volume : %1 %</translation>
     </message>
     <message>
         <source>Mute: on</source>
@@ -3948,7 +3948,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Limiter le volume à 100% comme mpc-hc</translation>
+        <translation>Limiter le volume à 100 % comme mpc-hc</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4280,11 +4280,11 @@ fichier média lu</translation>
     </message>
     <message>
         <source>100%</source>
-        <translation>100%</translation>
+        <translation>100 %</translation>
     </message>
     <message>
         <source>25%</source>
-        <translation>25%</translation>
+        <translation>25 %</translation>
     </message>
     <message>
         <source>50%</source>
@@ -4292,23 +4292,23 @@ fichier média lu</translation>
     </message>
     <message>
         <source>75%</source>
-        <translation>75%</translation>
+        <translation>75 %</translation>
     </message>
     <message>
         <source>150%</source>
-        <translation>150%</translation>
+        <translation>150 %</translation>
     </message>
     <message>
         <source>200%</source>
-        <translation>200%</translation>
+        <translation>200 %</translation>
     </message>
     <message>
         <source>300%</source>
-        <translation>300%</translation>
+        <translation>300 %</translation>
     </message>
     <message>
         <source>400%</source>
-        <translation>400%</translation>
+        <translation>400 %</translation>
     </message>
     <message>
         <source>Show video preview</source>
@@ -4370,6 +4370,10 @@ fichier média lu</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation>Ajouter les fichiers ouverts à la liste rapide</translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation> %</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4387,7 +4391,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>%</source>
-        <translation>%</translation>
+        <translation> %</translation>
     </message>
     <message>
         <source>Width</source>
@@ -4420,6 +4424,10 @@ fichier média lu</translation>
     <message>
         <source>Save Thumbnails</source>
         <translation>Enregistrer les miniatures</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation>%p %</translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4286,6 +4286,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4336,6 +4340,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>Simpan Pra-tayang</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4278,6 +4278,10 @@ ogni file multimediale riprodotto</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4327,6 +4331,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4438,6 +4438,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation>開いたファイルをクイック再生リストに追加する</translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4488,6 +4492,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>サムネイルの保存</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4210,6 +4210,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4259,6 +4263,10 @@ media file played</source>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4254,6 +4254,10 @@ arquivo de mídia reproduzido</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4303,6 +4307,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Save Thumbnails</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%p%</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4410,6 +4410,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4460,6 +4464,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>Сохранить миниатюры</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4438,6 +4438,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4488,6 +4492,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>சிறு உருவங்களை சேமிக்கவும்</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4430,6 +4430,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4480,6 +4484,10 @@ yeni bir &amp;oynatıcı aç</translation>
     <message>
         <source>Save Thumbnails</source>
         <translation>Küçük Görselleri Kaydet</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4314,6 +4314,10 @@ media file played</source>
         <source>Append opened files to Quick Playlist</source>
         <translation>将打开的文件添加到快速播放列表</translation>
     </message>
+    <message>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>
@@ -4364,6 +4368,10 @@ media file played</source>
     <message>
         <source>Save Thumbnails</source>
         <translation>保存预览图</translation>
+    </message>
+    <message>
+        <source>%p%</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
* settingswindow: Use locale-defined digit grouping for big numbers
So that "20000 ms" will be shown as for instance "20 000 ms" or "20,000 ms".

* Make the % symbol translatable everywhere
While the symbol itself may not change, some languages add a space between it and the percent value.