### PR TITLE
settingswindow: Resend mpv options signals when applying settings

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1247,8 +1247,10 @@ void SettingsWindow::on_buttonBox_clicked(QAbstractButton *button)
         sendAcceptedSettings();
         actionEditor->updateActions();
     }
-    if (buttonRole == QDialogButtonBox::ApplyRole)
+    if (buttonRole == QDialogButtonBox::ApplyRole) {
+        sendSignals();
         ui->buttonBox->button(QDialogButtonBox::Apply)->setEnabled(false);
+    }
     else
         close();
 }


### PR DESCRIPTION
Since the settings window doesn't get closed when applying settings, we need to resend the mpv options signals so that the new options are immediately applied.

Fixes regression introduced by 5b9df18e10c439524ca1ca63c92e0ea289c67439.