### PR TITLE
settingswindow: Implement subtitles black background box

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1031,6 +1031,15 @@ void SettingsWindow::sendSignals()
     else
         emit option("sub-back-color", "#00000000");
 
+    if (WIDGET_LOOKUP(ui->subsBackgroundBoxEnabled).toBool()) {
+        emit option("sub-border-style", "background-box");
+        emit option("sub-shadow-offset", 0);
+        emit option("sub-back-color", WIDGET_LOOKUP(ui->subsBackgroundBoxTranslucid).toBool() ?
+                                        "#99000000" : "#FF000000");
+    }
+    else
+        emit option("sub-border-style", "outline-and-shadow");
+
     emit subsPreferDefaultForced(WIDGET_LOOKUP(ui->subtitlesPreferDefaultForced_v3).toBool());
     emit subsPreferExternal(WIDGET_LOOKUP(ui->subtitlesPreferExternal).toBool());
     emit subsIgnoreEmbeded(WIDGET_LOOKUP(ui->subtitlesIgnoreEmbedded).toBool());
@@ -1494,6 +1503,15 @@ void SettingsWindow::on_ccICCBrowse_clicked()
         return;
 
     ui->ccICCLocation->setText(file);
+}
+
+void SettingsWindow::on_subsBackgroundBoxEnabled_toggled(bool checked)
+{
+    ui->subsBackgroundBoxTranslucid->setEnabled(checked);
+    ui->subsShadowEnabled->setEnabled(!checked);
+    on_subsShadowEnabled_toggled(!checked);
+    if (checked)
+        ui->subsShadowEnabled->setChecked(false);
 }
 
 void SettingsWindow::on_subsShadowEnabled_toggled(bool checked)

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -297,6 +297,8 @@ private slots:
 
     void on_ccICCBrowse_clicked();
 
+    void on_subsBackgroundBoxEnabled_toggled(bool checked);
+
     void on_subsShadowEnabled_toggled(bool checked);
 
     void on_screenshotDirectorySet_toggled(bool checked);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6449,6 +6449,12 @@ media file played</string>
                <layout class="QVBoxLayout" name="subsDefaultLayoutLeft" stretch="0,0">
                 <item>
                  <widget class="QGroupBox" name="fontBox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="title">
                    <string>Font</string>
                   </property>
@@ -6503,18 +6509,34 @@ media file played</string>
                      </property>
                     </widget>
                    </item>
+                   <item row="4" column="1">
+                    <spacer name="verticalSpacer_7">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
                   </layout>
                  </widget>
                 </item>
                 <item>
                  <widget class="QGroupBox" name="borderBox">
-                  <property name="title">
-                   <string>Border style</string>
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
                   </property>
-                  <layout class="QFormLayout" name="borderBoxLayout">
-                   <property name="fieldGrowthPolicy">
-                    <enum>QFormLayout::FieldGrowthPolicy::AllNonFixedFieldsGrow</enum>
-                   </property>
+                  <property name="title">
+                   <string>Border and background style</string>
+                  </property>
+                  <layout class="QGridLayout" name="borderBoxLayout">
                    <item row="0" column="0">
                     <widget class="QLabel" name="borderSizeLabel">
                      <property name="text">
@@ -6531,6 +6553,42 @@ media file played</string>
                       <number>3</number>
                      </property>
                     </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QCheckBox" name="subsBackgroundBoxEnabled">
+                     <property name="text">
+                      <string>Enable background box</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0">
+                    <widget class="QCheckBox" name="subsBackgroundBoxTranslucid">
+                     <property name="enabled">
+                      <bool>false</bool>
+                     </property>
+                     <property name="text">
+                      <string>Translucid background box</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0">
+                    <spacer name="verticalSpacer_8">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
                    </item>
                   </layout>
                  </widget>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -3467,10 +3467,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4236,6 +4232,18 @@ media file played</source>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -3660,7 +3660,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Estil de la vora</translation>
+        <translation type="vanished">Estil de la vora</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4441,6 +4441,18 @@ arxiu multimèdia reproduït</translation>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -3647,10 +3647,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4416,6 +4412,18 @@ media file played</source>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3672,7 +3672,7 @@ media file played</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Border style</translation>
+        <translation type="vanished">Border style</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4453,6 +4453,18 @@ media file played</translation>
     <message>
         <source>%</source>
         <translation>%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3556,7 +3556,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Estilo del borde</translation>
+        <translation type="vanished">Estilo del borde</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4309,6 +4309,18 @@ archivo multimedia reproducido</translation>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3453,10 +3453,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4198,6 +4194,18 @@ media file played</source>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -3592,7 +3592,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Style de bordure</translation>
+        <translation type="vanished">Style de bordure</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4373,6 +4373,18 @@ fichier média lu</translation>
     <message>
         <source>%</source>
         <translation> %</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3535,10 +3535,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4288,6 +4284,18 @@ media file played</source>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3528,7 +3528,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Stile bordo</translation>
+        <translation type="vanished">Stile bordo</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4280,6 +4280,18 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -3660,7 +3660,7 @@ media file played</source>
     </message>
     <message>
         <source>Border style</source>
-        <translation>境界線のスタイル</translation>
+        <translation type="vanished">境界線のスタイル</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4441,6 +4441,18 @@ media file played</source>
     <message>
         <source>%</source>
         <translation>%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3451,10 +3451,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4212,6 +4208,18 @@ media file played</source>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -3483,10 +3483,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Border style</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Border size</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4256,6 +4252,18 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3636,7 +3636,7 @@ media file played</source>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Стиль границ</translation>
+        <translation type="vanished">Стиль границ</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4413,6 +4413,18 @@ media file played</source>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -3660,7 +3660,7 @@ media file played</source>
     </message>
     <message>
         <source>Border style</source>
-        <translation>எல்லை நடை</translation>
+        <translation type="vanished">எல்லை நடை</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4441,6 +4441,18 @@ media file played</source>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -3648,7 +3648,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Border style</source>
-        <translation>Kenarlık biçemi</translation>
+        <translation type="vanished">Kenarlık biçemi</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4433,6 +4433,18 @@ yeni bir &amp;oynatıcı aç</translation>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3572,7 +3572,7 @@ media file played</source>
     </message>
     <message>
         <source>Border style</source>
-        <translation>粗体样式</translation>
+        <translation type="vanished">粗体样式</translation>
     </message>
     <message>
         <source>Border size</source>
@@ -4317,6 +4317,18 @@ media file played</source>
     <message>
         <source>%</source>
         <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <source>Enable background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Border and background style</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Shows an opaque or 90% translucid black background box for subtitles.

Settings shown in the same settings box as border style as that setting affects the background box.

Fixes #632 (Feature request: black/opaque background box for subtitles).

<img width="959" height="737" alt="image" src="https://github.com/user-attachments/assets/6ab87d01-6a30-4d79-b386-aa614eef9046" />
