### PR TITLE
settingswindow: Align widgets in Tweaks page and add restart required note to Video preview

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -7840,7 +7840,7 @@ media file played</string>
            <item row="9" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksVideoPreview">
              <property name="text">
-              <string>Show video preview</string>
+              <string>Show video preview (restart required)</string>
              </property>
              <property name="checked">
               <bool>true</bool>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4179,10 +4179,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4244,6 +4240,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4347,10 +4347,6 @@ arxiu multimèdia reproduït</translation>
         <translation>Buscar…</translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4452,6 +4448,10 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4319,10 +4319,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4424,6 +4420,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4360,7 +4360,7 @@ media file played</translation>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>Show video preview</translation>
+        <translation type="vanished">Show video preview</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4464,6 +4464,10 @@ media file played</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4215,10 +4215,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4320,6 +4316,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4101,10 +4101,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4206,6 +4202,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4312,7 +4312,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>Afficher l’aperçu vidéo</translation>
+        <translation type="vanished">Afficher l’aperçu vidéo</translation>
     </message>
     <message>
         <source>Remove subtitles additions for the deaf or hard-of-hearing (SDH)</source>
@@ -4384,6 +4384,10 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4191,10 +4191,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4296,6 +4292,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4187,10 +4187,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4292,6 +4288,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4348,7 +4348,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>ビデオプレビューの表示</translation>
+        <translation type="vanished">ビデオプレビューの表示</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4452,6 +4452,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4115,10 +4115,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4220,6 +4216,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4159,10 +4159,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>100%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4264,6 +4260,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4320,7 +4320,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>Показать предварительный просмотр видео</translation>
+        <translation type="vanished">Показать предварительный просмотр видео</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4424,6 +4424,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4348,7 +4348,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>வீடியோ முன்னோட்டத்தைக் காட்டு</translation>
+        <translation type="vanished">வீடியோ முன்னோட்டத்தைக் காட்டு</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4452,6 +4452,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4340,7 +4340,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>Video önizlemesini göster</translation>
+        <translation type="vanished">Video önizlemesini göster</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4444,6 +4444,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4224,7 +4224,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview</source>
-        <translation>显示视频预览</translation>
+        <translation type="vanished">显示视频预览</translation>
     </message>
     <message>
         <source>100%</source>
@@ -4328,6 +4328,10 @@ media file played</source>
     </message>
     <message>
         <source>Translucid background box</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
* settingswindow: Align widgets in Tweaks page
This is achieved by making sure widgets of each line are in the same
layout, adding a spacer in the bottom of the page, and adjusting stretch
factors and size policies.
The spacer is needed to make it show correctly in the Widget Designer.
* settingswindow: Add "restart required" note to Video preview option

Before:

<img width="548" height="536" alt="Copie d&#39;écran_20251121_105857" src="https://github.com/user-attachments/assets/6bfdcb84-b2df-4e21-bcba-de37da91ca7b" />


After:

<img width="548" height="523" alt="Copie d&#39;écran_20251121_112147" src="https://github.com/user-attachments/assets/255a0039-6378-42b6-b56b-c0c44a717b17" />



