### PR TITLE
settingswindow: Implement Screenshot directory browse button

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1531,6 +1531,19 @@ void SettingsWindow::on_screenshotDirectorySet_toggled(bool checked)
     ui->screenshotDirectoryBrowse->setEnabled(checked);
 }
 
+void SettingsWindow::on_screenshotDirectoryBrowse_clicked()
+{
+    static QFileDialog::Options options = QFileDialog::Options();
+#ifdef Q_OS_MAC
+    options.setFlag(QFileDialog::DontUseNativeDialog)
+#endif
+    QString dir = QFileDialog::getExistingDirectory(this, "", "", options);
+    if (dir.isEmpty())
+        return;
+
+    ui->screenshotDirectoryValue->setText(dir);
+}
+
 // REMOVEME: Disable auto zoom in Wayland mode as window centering isn't possible yet
 void SettingsWindow::on_tweaksPreferWayland_toggled(bool checked)
 {

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -303,6 +303,8 @@ private slots:
 
     void on_screenshotDirectorySet_toggled(bool checked);
 
+    void on_screenshotDirectoryBrowse_clicked();
+
     void on_tweaksPreferWayland_toggled(bool checked);
 
     void on_tweaksTimeTooltip_toggled(bool checked);


### PR DESCRIPTION
The left sidebar of the Select Folder dialog is buggy (too narrow by default and resizing it makes it disappear). Either a Qt or a KDE bug.