### PR TITLE
Support resizing the video

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2159,6 +2159,12 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
     ui->menuPlayVideoZoom->addAction(ui->actionDecreaseZoom);
     ui->menuPlayVideoZoom->addAction(ui->actionIncreaseZoom);
     ui->menuPlayVideoZoom->addAction(ui->actionResetZoom);
+    ui->menuPlayVideo->addMenu(ui->menuPlayVideoResize);
+    ui->menuPlayVideoResize->addAction(ui->actionDecreaseWidth);
+    ui->menuPlayVideoResize->addAction(ui->actionIncreaseWidth);
+    ui->menuPlayVideoResize->addAction(ui->actionDecreaseHeight);
+    ui->menuPlayVideoResize->addAction(ui->actionIncreaseHeight);
+    ui->menuPlayVideoResize->addAction(ui->actionResetWidthHeight);
     videoTracksGroup->actions().constFirst()->setChecked(true);
     updateOnTop();
 }
@@ -2917,6 +2923,48 @@ void MainWindow::on_actionResetZoom_triggered()
 {
     videoZoom = 0;
     mpvObject_->setVideoZoom(videoZoom);
+}
+
+void MainWindow::on_actionDecreaseWidth_triggered()
+{
+    mpvObject_->disableVideoAspect(false);
+    ui->actionDisableVideoAspect->setChecked(false);
+    videoWidthScale -= 0.01;
+    mpvObject_->setVideoWidthScale(videoWidthScale);
+}
+
+void MainWindow::on_actionIncreaseWidth_triggered()
+{
+    mpvObject_->disableVideoAspect(false);
+    ui->actionDisableVideoAspect->setChecked(false);
+    videoWidthScale += 0.01;
+    mpvObject_->setVideoWidthScale(videoWidthScale);
+}
+
+void MainWindow::on_actionDecreaseHeight_triggered()
+{
+    mpvObject_->disableVideoAspect(false);
+    ui->actionDisableVideoAspect->setChecked(false);
+    videoHeightScale -= 0.01;
+    mpvObject_->setVideoHeightScale(videoHeightScale);
+}
+
+void MainWindow::on_actionIncreaseHeight_triggered()
+{
+    mpvObject_->disableVideoAspect(false);
+    ui->actionDisableVideoAspect->setChecked(false);
+    videoHeightScale += 0.01;
+    mpvObject_->setVideoHeightScale(videoHeightScale);
+}
+
+void MainWindow::on_actionResetWidthHeight_triggered()
+{
+    mpvObject_->disableVideoAspect(false);
+    ui->actionDisableVideoAspect->setChecked(false);
+    videoWidthScale = 1;
+    videoHeightScale = 1;
+    mpvObject_->setVideoWidthScale(videoWidthScale);
+    mpvObject_->setVideoHeightScale(videoHeightScale);
 }
 
 void MainWindow::on_actionViewOntopDefault_toggled(bool checked)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -372,6 +372,12 @@ private slots:
     void on_actionIncreaseZoom_triggered();
     void on_actionResetZoom_triggered();
 
+    void on_actionDecreaseWidth_triggered();
+    void on_actionIncreaseWidth_triggered();
+    void on_actionDecreaseHeight_triggered();
+    void on_actionIncreaseHeight_triggered();
+    void on_actionResetWidthHeight_triggered();
+
     void on_actionViewOntopDefault_toggled(bool checked);
     void on_actionViewOntopAlways_toggled(bool checked);
     void on_actionViewOntopPlaying_toggled(bool checked);
@@ -527,6 +533,8 @@ private:
     double videoBitrate = 0;
     double panScan = 0;
     double videoZoom = 0;
+    double videoWidthScale = 1;
+    double videoHeightScale = 1;
     QUrl currentFile;
     QString currentFilename;
     QString currentTitle;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -944,10 +944,21 @@
       <addaction name="actionIncreaseZoom"/>
       <addaction name="actionResetZoom"/>
      </widget>
+     <widget class="QMenu" name="menuPlayVideoResize">
+      <property name="title">
+       <string>&amp;Resize</string>
+      </property>
+      <addaction name="actionDecreaseWidth"/>
+      <addaction name="actionIncreaseWidth"/>
+      <addaction name="actionDecreaseHeight"/>
+      <addaction name="actionIncreaseHeight"/>
+      <addaction name="actionResetWidthHeight"/>
+     </widget>
      <addaction name="separator"/>
      <addaction name="menuPlayVideoAspect"/>
      <addaction name="menuPlayVideoPanScan"/>
      <addaction name="menuPlayVideoZoom"/>
+     <addaction name="menuPlayVideoResize"/>
     </widget>
     <widget class="QMenu" name="menuPlayVolume">
      <property name="title">
@@ -2329,6 +2340,31 @@
    </property>
    <property name="shortcut">
     <string notr="true">Ctrl+Shift+/</string>
+   </property>
+  </action>
+  <action name="actionDecreaseWidth">
+   <property name="text">
+    <string>&amp;Decrease Width</string>
+   </property>
+  </action>
+  <action name="actionIncreaseWidth">
+   <property name="text">
+    <string>&amp;Increase Width</string>
+   </property>
+  </action>
+  <action name="actionDecreaseHeight">
+   <property name="text">
+    <string>D&amp;ecrease Height</string>
+   </property>
+  </action>
+  <action name="actionIncreaseHeight">
+   <property name="text">
+    <string>I&amp;ncrease Height</string>
+   </property>
+  </action>
+  <action name="actionResetWidthHeight">
+   <property name="text">
+    <string>Re&amp;set Size</string>
    </property>
   </action>
   <action name="actionViewHideLog">

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -472,6 +472,16 @@ void MpvObject::setVideoZoom(double zoom)
     setMpvPropertyVariant("video-zoom", zoom);
 }
 
+void MpvObject::setVideoWidthScale(double scale)
+{
+    setMpvPropertyVariant("video-scale-x", scale);
+}
+
+void MpvObject::setVideoHeightScale(double scale)
+{
+    setMpvPropertyVariant("video-scale-y", scale);
+}
+
 int64_t MpvObject::chapter()
 {
     return chapter_;

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -75,6 +75,8 @@ public:
     void disableVideoAspect(bool yes);
     void setPanScan(double panScan);
     void setVideoZoom(double zoom);
+    void setVideoWidthScale(double scale);
+    void setVideoHeightScale(double scale);
 
     int64_t chapter();
     bool setChapter(int64_t chapter);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1520,6 +1520,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1668,6 +1668,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1668,6 +1668,30 @@
         <source>M&amp;aximum</source>
         <translation>M&amp;aximum</translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1680,6 +1680,30 @@
         <source>M&amp;aximum</source>
         <translation>M&amp;aximum</translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1568,6 +1568,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1532,6 +1532,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1604,6 +1604,30 @@
         <source>M&amp;aximum</source>
         <translation>M&amp;aximum</translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1624,6 +1624,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1568,6 +1568,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1668,6 +1668,30 @@
         <source>M&amp;aximum</source>
         <translation>最大(&amp;A)</translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1520,6 +1520,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1528,6 +1528,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1648,6 +1648,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1668,6 +1668,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1668,6 +1668,30 @@
         <source>M&amp;aximum</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1624,6 +1624,30 @@
         <source>M&amp;aximum</source>
         <translation>最大化(&amp;A)</translation>
     </message>
+    <message>
+        <source>&amp;Resize</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Decrease Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Increase Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>D&amp;ecrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>I&amp;ncrease Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Re&amp;set Size</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>MouseState</name>


### PR DESCRIPTION
Resizes the video without - unlike zoom - preserving the aspect ratio.

No shortcuts are assigned by default as this is likely a less used feature and it would use up the last available numerical shortcuts.

Fixes #352 (Video crop support or Zoom).