### PR TITLE
settingswindow: Don't add the current directory to external audio search

### DIFF
--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -6112,7 +6112,7 @@ media file played</string>
                 <item>
                  <widget class="QLineEdit" name="audioAutoloadPath">
                   <property name="placeholderText">
-                   <string notr="true">.;./audio</string>
+                   <string notr="true">./audio</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
mpv already searches in it, so it just adds a duplicate audio track.

See also the equivalent for subtitles: db5bf29aed7607b9d350eb8d6ab15b4c59ddf74e.

Fixes #644 (External audio track has double entry in audio selector menu).