### PR TITLE
settingswindow: Allow editing audioSpdifCodecs and add a tooltip

### DIFF
--- a/settingswindow.cpp
+++ b/settingswindow.cpp
@@ -1507,6 +1507,11 @@ void SettingsWindow::on_ccICCBrowse_clicked()
     ui->ccICCLocation->setText(file);
 }
 
+void SettingsWindow::on_audioSpdif_toggled(bool checked)
+{
+    ui->audioSpdifCodecs->setEnabled(checked);
+}
+
 void SettingsWindow::on_subsBackgroundBoxEnabled_toggled(bool checked)
 {
     ui->subsBackgroundBoxTranslucid->setEnabled(checked);

--- a/settingswindow.h
+++ b/settingswindow.h
@@ -297,6 +297,8 @@ private slots:
 
     void on_ccICCBrowse_clicked();
 
+    void on_audioSpdif_toggled(bool checked);
+
     void on_subsBackgroundBoxEnabled_toggled(bool checked);
 
     void on_subsShadowEnabled_toggled(bool checked);

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -5851,6 +5851,9 @@ media file played</string>
                   </item>
                   <item row="1" column="0">
                    <widget class="QCheckBox" name="audioSpdif">
+                    <property name="toolTip">
+                     <string>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</string>
+                    </property>
                     <property name="text">
                      <string>Use S/PDIF when available</string>
                     </property>
@@ -7891,7 +7894,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="3">
+           <item row="12" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="0,1,0">
              <item>
               <widget class="QCheckBox" name="tweaksOsdFontChkBox">

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4338,6 +4338,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4546,6 +4546,10 @@ arxiu multimèdia reproduït</translation>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4518,6 +4518,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4562,6 +4562,10 @@ media file played</translation>
         <source>Show video preview (restart required)</source>
         <translation>Show video preview (restart required)</translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4414,6 +4414,10 @@ archivo multimedia reproducido</translation>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4300,6 +4300,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4482,6 +4482,10 @@ fichier média lu</translation>
         <source>Show video preview (restart required)</source>
         <translation>Afficher l&apos;aperçu vidéo (redémarrage requis)</translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4390,6 +4390,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4386,6 +4386,10 @@ ogni file multimediale riprodotto</translation>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4550,6 +4550,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation>ビデオ プレビューを表示 (再起動が必要です)</translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4314,6 +4314,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4358,6 +4358,10 @@ arquivo de mídia reproduzido</translation>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4522,6 +4522,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4550,6 +4550,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4542,6 +4542,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4426,6 +4426,10 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation>显示视频预览（需重新启动）</translation>
     </message>
+    <message>
+        <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD. Per mpv documentation for --audio-spdif=<codecs>.