### PR TITLE
mainwindow: Rename Edit menu to Playlist

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -646,7 +646,7 @@ void MainWindow::setupTrayIcon()
 {
     trayMenu = new QMenu(this);
     trayMenu->addMenu(ui->menuFile);
-    trayMenu->addMenu(ui->menuEdit);
+    trayMenu->addMenu(ui->menuPlaylist);
     trayMenu->addMenu(ui->menuView);
     trayMenu->addMenu(ui->menuPlay);
     trayMenu->addMenu(ui->menuNavigate);

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1070,9 +1070,9 @@
     <addaction name="actionHelpAbout"/>
     <addaction name="actionHelpAboutQt"/>
    </widget>
-   <widget class="QMenu" name="menuEdit">
+   <widget class="QMenu" name="menuPlaylist">
     <property name="title">
-     <string>&amp;Edit</string>
+     <string>&amp;Playlist</string>
     </property>
     <widget class="QMenu" name="menuPlay_Times">
      <property name="title">
@@ -1105,7 +1105,7 @@
     <addaction name="actionPlaylistExport"/>
    </widget>
    <addaction name="menuFile"/>
-   <addaction name="menuEdit"/>
+   <addaction name="menuPlaylist"/>
    <addaction name="menuView"/>
    <addaction name="menuPlay"/>
    <addaction name="menuNavigate"/>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -477,10 +477,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Extra Play Times</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1606,6 +1602,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation type="vanished">&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1754,6 +1754,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Bearbeiten</translation>
+        <translation type="vanished">&amp;Bearbeiten</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1754,6 +1754,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Edit</translation>
+        <translation type="vanished">&amp;Edit</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1766,6 +1766,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Editar</translation>
+        <translation type="vanished">&amp;Editar</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1654,6 +1654,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -470,7 +470,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Muokkaa</translation>
+        <translation type="vanished">&amp;Muokkaa</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1618,6 +1618,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -474,7 +474,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Édition</translation>
+        <translation type="vanished">&amp;Édition</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1690,6 +1690,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Edit</translation>
+        <translation type="vanished">&amp;Edit</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1710,6 +1710,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -470,7 +470,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Modifica</translation>
+        <translation type="vanished">&amp;Modifica</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1654,6 +1654,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>編集(&amp;E)</translation>
+        <translation type="vanished">編集(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1754,6 +1754,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -477,10 +477,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Extra Play Times</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1606,6 +1602,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -477,10 +477,6 @@
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>&amp;Extra Play Times</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1614,6 +1610,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>&amp;Правка</translation>
+        <translation type="vanished">&amp;Правка</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1734,6 +1734,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>திருத்து (&amp;e)</translation>
+        <translation type="vanished">திருத்து (&amp;e)</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1754,6 +1754,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>Dü&amp;zen</translation>
+        <translation type="vanished">Dü&amp;zen</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1754,6 +1754,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -478,7 +478,7 @@
     </message>
     <message>
         <source>&amp;Edit</source>
-        <translation>播放列表(&amp;E)</translation>
+        <translation type="vanished">播放列表(&amp;E)</translation>
     </message>
     <message>
         <source>&amp;Extra Play Times</source>
@@ -1710,6 +1710,10 @@
     </message>
     <message>
         <source>&amp;Horizontal Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Playlist</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
That menu only contains commands related to the playlist(s), so it's easier to understand what it does.

Suggested in #647.