### PR TITLE
mainwindow: Use current file folder for Quick Open

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -1302,14 +1302,11 @@ QList<QUrl> MainWindow::doQuickOpenFileDialog()
     options = QFileDialog::DontUseNativeDialog;
 #endif
     QList<QUrl> urls;
-    static QUrl lastDir;
     static QString filter;
     if (filter.isEmpty())
         filter = Helpers::fileOpenFilter();
 
-    urls = QFileDialog::getOpenFileUrls(this, tr("Quick Open"), lastDir, filter, nullptr, options);
-    if (!urls.isEmpty())
-        lastDir = urls[0];
+    urls = QFileDialog::getOpenFileUrls(this, tr("Quick Open"), currentFile, filter, nullptr, options);
     return urls;
 }
 


### PR DESCRIPTION
And default to the user folder when no file has been opened yet (no change).

The default folder was the user folder, even if a file had already been opened from the file browser or the recents.