### PR TITLE
main: Store lock file in mpc-qt settings folder

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -270,7 +270,7 @@ void Flow::detectMode() {
 
     if (programMode == PrimaryMode) {
         QString lockFilePath =
-            QDir::tempPath() + QLatin1Char('/') + QLatin1String("mpc-qt.lock");
+            Storage::fetchConfigPath() + QLatin1Char('/') + QLatin1String("mpc-qt.lock");
         std::unique_ptr<QLockFile> lockFile = std::make_unique<QLockFile>(lockFilePath);
         lockFile->setStaleLockTime(0);
         while (!lockFile->tryLock()) {


### PR DESCRIPTION
Makes it possible for different users on the same computer to open MPC-QT concurrently as each user will have one lock file.

Follow-up to 1f88fb3507ee5b18b5719614db33db258b454a40.