### PR TITLE
propertieswindow: Fix fields heights in Clip tab and reduce minimum window size

### DIFF
--- a/propertieswindow.ui
+++ b/propertieswindow.ui
@@ -21,6 +21,12 @@
   <layout class="QVBoxLayout" name="mainLayout">
    <item>
     <widget class="QTabWidget" name="tabWidget">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -170,7 +176,7 @@
        <item row="8" column="0" colspan="2">
         <widget class="QPlainTextEdit" name="detailsTracks">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -239,7 +245,7 @@
        <item row="2" column="0">
         <widget class="QLabel" name="clipTitleLabel">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -254,8 +260,17 @@
        </item>
        <item row="2" column="1">
         <widget class="QLabel" name="clipTitle">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string notr="true">-</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -332,7 +347,7 @@
        <item row="7" column="0">
         <widget class="QLabel" name="clipLocationLabel">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -348,7 +363,7 @@
        <item row="7" column="1">
         <widget class="QLabel" name="clipLocation">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -358,6 +373,9 @@
          </property>
          <property name="textFormat">
           <enum>Qt::TextFormat::PlainText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
          </property>
          <property name="wordWrap">
           <bool>true</bool>
@@ -387,7 +405,7 @@
        <item row="9" column="1">
         <widget class="QPlainTextEdit" name="clipDescription">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -409,6 +427,12 @@
       <layout class="QVBoxLayout" name="mediaInfoTabLayout">
        <item>
         <widget class="QPlainTextEdit" name="mediaInfoText">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="font">
           <font>
            <family>Monospace</family>


### PR DESCRIPTION
Don't resize clipTitle and clipLocation when resizing the window.

There's a bug with the height of clipTitle where it increases suddenly when resizing the window vertically, and only gets back to a normal size when resizing the window horizontally.

Before:
<img width="502" height="520" alt="Copie d&#39;écran_20251206_163614_r" src="https://github.com/user-attachments/assets/fd7c68e2-2d54-4608-8cf3-b0e387a7ed2f" />

After:
<img width="497" height="513" alt="Copie d&#39;écran_20251206_163717_r" src="https://github.com/user-attachments/assets/dbc77619-00e5-4584-9a1e-313dd1f88a6c" />
