### PR TITLE
mainwindow: Don't manually delete playlistWindow_

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -79,7 +79,6 @@ MainWindow::~MainWindow()
 {
     Logger::log("mainwindow", "~MainWindow");
     mpvObject_->setWidgetType(Helpers::NullWidget);
-    delete playlistWindow_;
     delete ui;
     ui = nullptr;
 }


### PR DESCRIPTION
Most likely made unnecessary by 5c778bf3c4c4d2dfafbe4ab59bc8a7655cb07f79.

Tested on Linux and Windows, it doesn't crash with After Playback > Exit.

Partially reverts ecb65324b851d4efe0f11678fa6cf572741067da.