### PR TITLE
Fix C++23 deprecation warnings

### DIFF
--- a/ipc/http.cpp
+++ b/ipc/http.cpp
@@ -268,7 +268,7 @@ void HttpServer::self_newConnection()
 {
     while (auto sock = nextPendingConnection()) {
         connect(sock, &QTcpSocket::readyRead,
-                this, [=]() {
+                this, [this, sock]() {
             socket_readyRead(sock);
         });
     }

--- a/ipc/json.cpp
+++ b/ipc/json.cpp
@@ -166,7 +166,7 @@ void MpcQtServer::self_newConnection(QLocalSocket *socket)
         return;
     }
 
-    connect(socket, &QLocalSocket::readyRead, this, [=]() {
+    connect(socket, &QLocalSocket::readyRead, this, [this, socket]() {
         QList<QByteArray> dataList = socket->readAll().split('\n');
         for (const QByteArray &data : std::as_const(dataList)) {
             if(data.size())

--- a/playlist.h
+++ b/playlist.h
@@ -237,7 +237,7 @@ private:
                             QSet<QString> &found);
 
     QReadWriteLock bumpLock;
-    volatile int bumps_ = 0;
+    int bumps_ = 0;
 };
 
 


### PR DESCRIPTION
volatile isn't useful for multithreaded code and its use with increment/decrement operators is deprecated since C++20.
Implicit capture of "this" via "[=]" is deprecated since C++20.