### PR TITLE
Trigger Play from stopped state when clicking on mpvWidget

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -860,6 +860,8 @@ void Flow::setupMpvObjectConnections()
             mainWindow, &MainWindow::setChapterTitle);
     connect(mpvObject, &MpvObject::aspectNameChanged,
             mainWindow, &MainWindow::setAspectName);
+    connect(mpvObject, &MpvObject::mouseReleased,
+            mainWindow, &MainWindow::mpvObject_mouseReleased);
 
     // settingswindow -> log
     auto logger = Logger::singleton();

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2366,6 +2366,14 @@ void MainWindow::libraryWindowClosed()
     ui->actionViewHideLibrary->setChecked(false);
 }
 
+void MainWindow::mpvObject_mouseReleased()
+{
+    if (!isPlaying) {
+        emit playCurrentItemRequested();
+        return;
+    }
+}
+
 void MainWindow::setPlaylistVisibleState(bool yes) {
     Logger::log("mainwindow", "setPlaylistVisibleState");
     if (fullscreenMode_ || !ui || mainwindowIsClosing)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -298,6 +298,7 @@ public slots:
     void setVideoPreviewItem(QUrl itemUrl);
     void logWindowClosed();
     void libraryWindowClosed();
+    void mpvObject_mouseReleased();
 
 private slots:
     void on_actionFileOpenQuick_triggered();

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -1154,6 +1154,7 @@ void MpvGlWidget::mouseReleaseEvent(QMouseEvent *event)
         return;
     }
     QOpenGLWidget::mouseReleaseEvent(event);
+    emit mpvObject->mouseReleased();
 }
 
 void MpvGlWidget::keyPressEvent(QKeyEvent *event)

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -163,6 +163,7 @@ signals:
 
     void mouseMoved(int x, int y);
     void mousePress(int x, int y, int btn);
+    void mouseReleased();
     void keyPress(int key);
     void keyRelease(int key);
 


### PR DESCRIPTION
Makes it possible to play - while in stopped state - the selected (Quick) playlist item by a click on the "video" widget.
The typical use case is opening MPC-QT and clicking in the center of the window to resume the previous video.