### PR TITLE
mainwindow: Make Play / Pause action trigger Play button

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -376,15 +376,10 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         QKeyEvent *ke = static_cast<QKeyEvent*>(event);
         switch (ke->key()) {
         case Qt::Key_MediaPlay:
-            ke->accept();
-            if (ui->play->isEnabled())
-                on_play_clicked();
-            return true;
         case Qt::Key_MediaPause:
         case Qt::Key_MediaTogglePlayPause:
             ke->accept();
-            if (ui->actionPlayPause->isEnabled())
-                ui->actionPlayPause->activate(QAction::Trigger);
+            on_play_clicked();
             return true;
         case Qt::Key_MediaStop:
             ke->accept();
@@ -1000,7 +995,6 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->loopB->setEnabled(enabled);
 
     ui->pause->setChecked(false);
-    ui->actionPlayPause->setChecked(false);
 
     ui->actionFileOpenDevice->setEnabled(false);
     ui->actionFileClose->setEnabled(enabled);
@@ -1017,7 +1011,6 @@ void MainWindow::setUiEnabledState(bool enabled)
     ui->actionFileLoadSubtitle->setEnabled(enabled);
     ui->actionFileSaveSubtitle->setEnabled(enabled && false);
     ui->actionFileSubtitleDatabaseDownload->setEnabled(enabled && false);
-    ui->actionPlayPause->setEnabled(enabled);
     ui->actionPlayStop->setEnabled(enabled);
     ui->actionPlayFrameBackward->setEnabled(enabled);
     ui->actionPlayFrameForward->setEnabled(enabled);
@@ -2037,9 +2030,12 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state)
     isPaused = state == PlaybackManager::PausedState;
     setUiEnabledState(state != PlaybackManager::StoppedState);
     if (isPaused) {
-        ui->actionPlayPause->setChecked(true);
+        ui->actionPlayPause->setText(tr("&Play"));
         ui->pause->setChecked(true);
     }
+    else
+        ui->actionPlayPause->setText(tr("&Pause"));
+
     if (state == PlaybackManager::WaitingState) {
         mpvObject_->setLoopPoints(-1, -1);
         positionSlider_->setLoopA(-1);
@@ -3081,12 +3077,9 @@ void MainWindow::on_actionViewOptions_triggered()
     emit optionsOpenRequested();
 }
 
-void MainWindow::on_actionPlayPause_triggered(bool checked)
+void MainWindow::on_actionPlayPause_triggered()
 {
-    if (checked)
-        emit paused();
-    else
-        emit unpaused();
+    on_play_clicked();
 }
 
 void MainWindow::on_actionPlayStop_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -395,7 +395,7 @@ private slots:
 
     void on_actionViewOptions_triggered();
 
-    void on_actionPlayPause_triggered(bool checked);
+    void on_actionPlayPause_triggered();
     void on_actionPlayStop_triggered();
     void on_actionPlayFrameBackward_triggered();
     void on_actionPlayFrameForward_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -1508,11 +1508,8 @@
    </property>
   </action>
   <action name="actionPlayPause">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="text">
-    <string>&amp;Pause</string>
+    <string>&amp;Play</string>
    </property>
    <property name="shortcut">
     <string notr="true">Space</string>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -758,10 +762,6 @@
     </message>
     <message>
         <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1606,6 +1606,14 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1758,6 +1762,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1766,6 +1770,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1783,6 +1787,10 @@
     <message>
         <source>&amp;Playlist</source>
         <translation>&amp;Playlist</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1658,6 +1662,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -171,6 +171,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1622,6 +1626,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation>Diminuer le volume</translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1707,6 +1711,10 @@
     <message>
         <source>&amp;Playlist</source>
         <translation>L&amp;iste</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1714,6 +1718,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -171,6 +171,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1658,6 +1662,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation>音量を下げる</translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1771,6 +1775,10 @@
     <message>
         <source>&amp;Playlist</source>
         <translation>再生リスト(&amp;P)</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -175,6 +175,10 @@
         <source>Reset Rotate</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -754,10 +758,6 @@
     </message>
     <message>
         <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1574,6 +1574,14 @@
     </message>
     <message>
         <source>Running under %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -758,10 +762,6 @@
     </message>
     <message>
         <source>O</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1606,6 +1606,14 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1622,6 +1626,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1738,6 +1742,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1758,6 +1762,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -175,6 +175,10 @@
         <source>Volume Decrease</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1758,6 +1762,10 @@
     </message>
     <message>
         <source>&amp;Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -183,6 +183,10 @@
         <source>Volume Decrease</source>
         <translation>降低音量</translation>
     </message>
+    <message>
+        <source>Play / Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ButtonWidget</name>
@@ -1727,6 +1731,10 @@
     <message>
         <source>&amp;Playlist</source>
         <translation>播放列表(&amp;P)</translation>
+    </message>
+    <message>
+        <source>&amp;Play</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -67,6 +67,7 @@ void ActionEditor::setCommands(const QList<Command> &commands)
 QString ActionEditor::getDescriptiveName(const QAction *action)
 {
     QHash<QString, QString> nameToDescription = {
+        { "actionPlayPause",               tr("Play / Pause") },
         { "actionPlayVolumeUp",            tr("Volume Increase") },
         { "actionPlayVolumeDown",          tr("Volume Decrease") },
         { "actionPlayVolumeMute",          tr("Volume Mute") },


### PR DESCRIPTION
Dynamically rename the Pause action to Play or Pause.

Make it play the selected playlist (or by default the last played) item from the stopped state, like MPC-HC.

Since the Play button was focused on start, it was possible to trigger it with the space bar, which is also the default Play / Pause action key. But that stopped being the case if the user switched to fullscreen first or clicked the Mute button.

Most or all keyboards combine the Play and Pause keys. The Pause media key already triggered both Play and Pause and will now also trigger Play from the stopped state, as will the combined Play / Pause media key.