### PR TITLE
Add move subtitles vertically feature

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -2206,6 +2206,9 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesCopy);
     ui->menuPlaySubtitles->addAction(ui->actionDecreaseSubtitlesDelay);
     ui->menuPlaySubtitles->addAction(ui->actionIncreaseSubtitlesDelay);
+    ui->menuPlaySubtitles->addMenu(ui->menuPlaySubtitlesMove);
+    ui->menuPlaySubtitlesMove->addAction(ui->actionMoveSubtitlesUp);
+    ui->menuPlaySubtitlesMove->addAction(ui->actionMoveSubtitlesDown);
     subtitleTracksGroup->actions().constFirst()->setChecked(true);
 }
 
@@ -3210,6 +3213,16 @@ void MainWindow::on_actionDecreaseSubtitlesDelay_triggered()
 void MainWindow::on_actionIncreaseSubtitlesDelay_triggered()
 {
     mpvObject_->setSubtitlesDelay(subtitlesDelayStep);
+}
+
+void MainWindow::on_actionMoveSubtitlesUp_triggered()
+{
+    mpvObject_->moveSubtitlesVertically(10);
+}
+
+void MainWindow::on_actionMoveSubtitlesDown_triggered()
+{
+    mpvObject_->moveSubtitlesVertically(-10);
 }
 
 void MainWindow::on_actionPlayLoopStart_triggered()

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -423,6 +423,8 @@ private slots:
     void on_actionPlaySubtitlesCopy_triggered();
     void on_actionDecreaseSubtitlesDelay_triggered();
     void on_actionIncreaseSubtitlesDelay_triggered();
+    void on_actionMoveSubtitlesUp_triggered();
+    void on_actionMoveSubtitlesDown_triggered();
 
     void on_actionPlayLoopStart_triggered();
     void on_actionPlayLoopEnd_triggered();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -905,7 +905,13 @@
      <addaction name="actionPlaySubtitlesCopy"/>
      <addaction name="actionDecreaseSubtitlesDelay"/>
      <addaction name="actionIncreaseSubtitlesDelay"/>
-     <addaction name="separator"/>
+    </widget>
+    <widget class="QMenu" name="menuPlaySubtitlesMove">
+     <property name="title">
+      <string>&amp;Move</string>
+     </property>
+     <addaction name="actionMoveSubtitlesUp"/>
+     <addaction name="actionMoveSubtitlesDown"/>
     </widget>
     <widget class="QMenu" name="menuPlayVideo">
      <property name="title">
@@ -1014,6 +1020,7 @@
      <addaction name="actionPlayLoopUse"/>
      <addaction name="actionPlayLoopClear"/>
     </widget>
+    <addaction name="menuPlaySubtitlesMove"/>
     <addaction name="actionPlayPause"/>
     <addaction name="actionPlayStop"/>
     <addaction name="actionPlayFrameBackward"/>
@@ -2248,6 +2255,16 @@
    </property>
    <property name="shortcut">
     <string notr="true">F2</string>
+   </property>
+  </action>
+  <action name="actionMoveSubtitlesUp">
+   <property name="text">
+    <string>&amp;Up</string>
+   </property>
+  </action>
+  <action name="actionMoveSubtitlesDown">
+   <property name="text">
+    <string>&amp;Down</string>
    </property>
   </action>
   <action name="actionVideoFilterDeinterlace">

--- a/mpvwidget.cpp
+++ b/mpvwidget.cpp
@@ -452,6 +452,11 @@ void MpvObject::setSubtitlesDelay(int subDelayStep)
     showMessage(tr("Subtitles delay: %1 ms").arg(std::round(newSubDelay * 1000)));
 }
 
+void MpvObject::moveSubtitlesVertically(int diff)
+{
+    emit ctrlCommand(QVariantList({"add", "sub-margin-y", diff}));
+}
+
 void MpvObject::setVideoAspect(double aspectDiff)
 {
     setMpvPropertyVariant("video-aspect-override", aspect + aspectDiff);

--- a/mpvwidget.h
+++ b/mpvwidget.h
@@ -71,6 +71,7 @@ public:
     void setSubFile(QString filename);
     void addSubFile(QString filename);
     void setSubtitlesDelay(int subDelayStep);
+    void moveSubtitlesVertically(int diff);
     void setVideoAspect(double aspectDiff);
     void setVideoAspectPreset(double aspect);
     void disableVideoAspect(bool yes);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -92,6 +92,14 @@
         <translation>Abspielhäufigkeit: Verringern</translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>Seitenverhältnis ändern (höher)</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -92,6 +92,14 @@
         <translation>Extra Play Times: Decrement</translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>Decrease Aspect ratio</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -80,6 +80,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -92,6 +92,14 @@
         <translation>Lectures supplémentaires&#xa0;: Décrémenter</translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>Réduire le ratio d&apos;aspect</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -80,6 +80,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -92,6 +92,14 @@
         <translation>追加再生回数 : 減らす</translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>アスペクト比を下げる</translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -92,6 +92,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>4:3 Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -92,6 +92,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>Reduzir proporção da tela</translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -84,6 +84,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -92,6 +92,14 @@
         <translation>额外播放次数：减少</translation>
     </message>
     <message>
+        <source>Move Subtitles Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Move Subtitles Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Decrease Aspect ratio</source>
         <translation>减少长宽比</translation>
     </message>

--- a/widgets/actioneditor.cpp
+++ b/widgets/actioneditor.cpp
@@ -85,6 +85,8 @@ QString ActionEditor::getDescriptiveName(const QAction *action)
         { "actionViewOntopVideo",          tr("On Top: While Playing Video") },
         { "actionPlaylistExtraIncrement",  tr("Extra Play Times: Increment") },
         { "actionPlaylistExtraDecrement",  tr("Extra Play Times: Decrement") },
+        { "actionMoveSubtitlesUp",         tr("Move Subtitles Up") },
+        { "actionMoveSubtitlesDown",       tr("Move Subtitles Down") },
         { "action43VideoAspect",           tr("4:3 Aspect ratio") },
         { "actionDecreaseVideoAspect",     tr("Decrease Aspect ratio") },
         { "actionIncreaseVideoAspect",     tr("Increase Aspect ratio") },


### PR DESCRIPTION
* mainwindow: Add missing menus and reformat .ui file with Qt Designer

> The menuPlayAudioFilters and menuPlayVideoFilters were missing, so Qt
> Designer was removing them.

* Add move subtitles vertically feature

> No keys assigned by default.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/654 (Feature request: assign keys to (temporary) change subtitle
> vertical positioning).