### PR TITLE
Disable window Auto zoom by default and rename its header to Window

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -270,7 +270,7 @@
     "playbackAudioTracks": "",
     "playbackAutoCenterWindow": true,
     "playbackAutoFitFactor": 75,
-    "playbackAutoZoom": true,
+    "playbackAutoZoom": false,
     "playbackAutoZoomMethod": 3,
     "playbackLargeStep": 20000,
     "playbackLoopImages": true,

--- a/settingswindow.ui
+++ b/settingswindow.ui
@@ -1219,9 +1219,6 @@ media file played</string>
                 <property name="text">
                  <string>Auto zoom</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
                </widget>
               </item>
               <item row="0" column="1">


### PR DESCRIPTION
* settingswindow: Rename Output to Window (in Playback)

> Since these settings change the window size it's easier to understand
> what they do.
* settingswindow: Disable window Auto zoom by default

> With "remember last window geometry" enabled by default, users expect
> the main window to open with the same size. Though the window auto zoom
> feature resizes the window and overrides that setting when opening a
> file.
> 
> We already disable it by default on Wayland since
> https://github.com/mpc-qt/mpc-qt/commit/16a527b7af02b37afbb5410c8a2482405af446a9.