### PR TITLE
helpers: Save key shortcuts in English

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -1301,7 +1301,7 @@ QString Command::toString() const { return action->text(); }
 
 QVariantMap Command::toVMap() const
 {
-    return QVariantMap({{"keys", keys},
+    return QVariantMap({{"keys", keys.toString()},
                         {"fullscreen", mouseFullscreen.toVMap()},
                         {"windowed", mouseWindowed.toVMap()}});
 }


### PR DESCRIPTION
We need to explicitly use QKeySequence.toString() to get the key
sequence in the QKeySequence::PortableText format.
Otherwise, QJsonObject::fromVariantMap incorrectly uses the QKeySequence::NativeText format.
Maybe because "NativeText" is alphabetically before "PortableText"?

This was especially noticeable when running the AppImage version (which sets the English Qt version) before/after a native build version.

This bug was mentioned in 237f36abf464b0e63540fc5d546e9616565b7477.

#695.