### PR TITLE
manager: Sort files numerically when playing next/previous file in folder

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -873,14 +873,20 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta, bool replaceMpvPlayli
     int index;
     QString nextFile;
 
-
     if (url.isEmpty())
         return false;
     info = QFileInfo(url.toLocalFile());
     if (!info.exists())
         return false;
     dir = info.dir();
-    files = dir.entryList(QDir::Files, QDir::Name);
+    files = dir.entryList(QDir::Files);
+
+    // TODO: Use refactored Helpers::compareUrls as comparator and a sort function in Helpers
+    QCollator collator;
+    collator.setCaseSensitivity(Qt::CaseInsensitive);
+    collator.setNumericMode(true);
+    std::sort(files.begin(), files.end(), collator);
+
     index = files.indexOf(info.fileName());
     if (index == -1)
         return false;


### PR DESCRIPTION
This fixes order of 67.mkv vs 138.mkv files but doesn't address "test.mkv" vs "test 2.mkv".

The latter will need to use a refactored `Helpers::compareUrls` as comparator and a sort function in Helpers to avoid duplicating code.
`Helpers::compareUrls` would ideally use `QFileInfo` but that'll need more testing.