### PR TITLE
settingswindow: Show file name by default in title bar

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -302,7 +302,7 @@
     "playerTitleDisplayFullPath": false,
     "playerTitleDontPrefix": false,
     "playerTitleFileNameOnly": true,
-    "playerTitleReplaceName": true,
+    "playerTitleReplaceName": false,
     "playerTrayIcon": true,
     "playlistFormat": "%artist{# - }{Unknown Artist - }{}%title{#}{$}{$}",
     "pngColorspace": false,

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -342,9 +342,6 @@
                 <property name="text">
                  <string>Replace file name with title</string>
                 </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
                </widget>
               </item>
               <item>


### PR DESCRIPTION
This is the default setting in MPC-HC.
It also prevents problems with incorrect titles.