### PR TITLE
settingswindow: Enable Alpha channel with HDR compute peak

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1393,6 +1393,13 @@ void SettingsWindow::on_videoPreset_currentIndexChanged(int index)
     }
 }
 
+void SettingsWindow::on_ccHdrCompute_currentIndexChanged(int index)
+{
+    // Alpha channel is needed for HDR Compute Peak
+    if (index < 2)
+        ui->videoUseAlpha->setChecked(true);
+}
+
 void SettingsWindow::on_screenshotFormat_currentIndexChanged(int index)
 {
     ui->screenshotFormatStack->setCurrentIndex(index);

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -261,6 +261,8 @@ private slots:
 
     void on_videoPreset_currentIndexChanged(int index);
 
+    void on_ccHdrCompute_currentIndexChanged(int index);
+
     void on_screenshotFormat_currentIndexChanged(int index);
 
     void on_jpgQuality_valueChanged(int value);


### PR DESCRIPTION
Fixes #22 (blackscreen while playing 4k 10 bit hdr).