### PR TITLE
mainwindow: Silence qt log warning about on_actionPlayVolumeMute_toggled

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3279,6 +3279,11 @@ void MainWindow::on_actionPlayVolumeDown_triggered()
     volumeSlider_->setValue(newvol);
 }
 
+void MainWindow::on_actionPlayVolumeMute_toggled(bool checked)
+{
+    on_actionPlayVolumeMute_toggled(checked, false);
+}
+
 void MainWindow::on_actionPlayVolumeMute_toggled(bool checked, bool onInit)
 {
     emit volumeMuteChanged(checked, onInit);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -433,7 +433,8 @@ private slots:
 
     void on_actionPlayVolumeUp_triggered();
     void on_actionPlayVolumeDown_triggered();
-    void on_actionPlayVolumeMute_toggled(bool checked, bool onInit = false);
+    void on_actionPlayVolumeMute_toggled(bool checked);
+    void on_actionPlayVolumeMute_toggled(bool checked, bool onInit);
 
     void on_actionPlayAfterOnceExit_triggered();
     void on_actionPlayAfterOnceStandby_triggered();


### PR DESCRIPTION
It was "[qt] warn: QMetaObject::connectSlotsByName: No matching signal for on_actionPlayVolumeMute_toggled(bool,bool)".