### PR TITLE
tooltip: Remove unused aspectRatioSet variable

### DIFF
--- a/src/widgets/tooltip.h
+++ b/src/widgets/tooltip.h
@@ -14,7 +14,6 @@ class Tooltip : public QWidget {
         void setPosition(const QPoint &where, int mainWindowWidth);
 
         QLabel *textLabel;
-        bool aspectRatioSet = false;
         QPoint bottomLeft;
     };
 


### PR DESCRIPTION
Leftover from videopreview code.

Follow-up to ab7ce73c1b380b8d392d7a6b644d4569d59893fd.