### PR TITLE
settings: Use toggled signal instead of checkStateChanged for QCheckBox

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1289,15 +1289,15 @@ void SettingsWindow::on_playerOpenNew_toggled(bool checked)
         ui->playerAppendToQuickPlaylist->setChecked(false);
 }
 
-void SettingsWindow::on_playerAppendToQuickPlaylist_checkStateChanged(Qt::CheckState state)
+void SettingsWindow::on_playerAppendToQuickPlaylist_toggled(bool checked)
 {
-    if (state == Qt::Checked)
+    if (checked)
         ui->playerRememberQuickPlaylist->setChecked(false);
 }
 
-void SettingsWindow::on_playerKeepHistory_checkStateChanged(Qt::CheckState state)
+void SettingsWindow::on_playerKeepHistory_toggled(bool checked)
 {
-    bool playerKeepHistoryEnabled = state == Qt::Checked;
+    bool playerKeepHistoryEnabled = checked;
     ui->playerRememberFilePosition->setChecked(playerKeepHistoryEnabled);
     ui->playerRememberQuickPlaylist->setChecked(playerKeepHistoryEnabled);
     ui->playerKeepHistoryOnlyForVideos->setEnabled(playerKeepHistoryEnabled);
@@ -1319,9 +1319,9 @@ void SettingsWindow::on_interfaceIconsTheme_currentIndexChanged(int index)
     ui->interfaceIconsNotice->setEnabled(customIcons);
 }
 
-void SettingsWindow::on_interfaceWidgetCustom_checkStateChanged(Qt::CheckState state)
+void SettingsWindow::on_interfaceWidgetCustom_toggled(bool checked)
 {
-    ui->interfaceWidgetCustomScrollArea->setEnabled(state);
+    ui->interfaceWidgetCustomScrollArea->setEnabled(checked);
 }
 
 void SettingsWindow::on_interfaceIconsCustomBrowse_clicked()

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -236,13 +236,13 @@ private slots:
 
     void on_playerOpenNew_toggled(bool checked);
 
-    void on_playerAppendToQuickPlaylist_checkStateChanged(Qt::CheckState state);
+    void on_playerAppendToQuickPlaylist_toggled(bool checked);
 
-    void on_playerKeepHistory_checkStateChanged(Qt::CheckState state);
+    void on_playerKeepHistory_toggled(bool checked);
 
     void on_interfaceIconsTheme_currentIndexChanged(int index);
 
-    void on_interfaceWidgetCustom_checkStateChanged(Qt::CheckState state);
+    void on_interfaceWidgetCustom_toggled(bool checked);
 
     void on_interfaceIconsCustomBrowse_clicked();
 


### PR DESCRIPTION
The checkStateChanged QCheckBox signal requires Qt 6.7.

This means that the "keep history" related settings were not being enabled correctly for users of the AppImage, AppImage-derived packages and even the Linux native build executable built on Ubuntu 24.04.

Follow-up to 128cabca752196bad7fa372d0fced8be7212be6d (from 24.12), 0471a87f84bfd85a99ad77a46205e21830add949, b9d3d88bf27a8701c7057512d6fb13993235fc16 and 77df7184027f8b30aa805cb0532983bb9aaeef18.