### PR TITLE
ci: Use release versions of ffmpeg, libass, libplacebo and mpv for AppImage

### DIFF
--- a/.github/actions/data/mpv-build/use-libass-release
+++ b/.github/actions/data/mpv-build/use-libass-release
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+export LC_ALL=C
+
+scripts/switch-branch libass release

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -57,12 +57,17 @@ jobs:
       with:
         repository: "mpv-player/mpv-build"
         path: mpv-build
-    - name: Copy build options
+    - name: Copy build options and script
       run: |
         cp .github/actions/data/build_options/* mpv-build/
+        cp .github/actions/data/mpv-build/* mpv-build/
     - name: Get mpv dependencies
       run: |
         cd mpv-build
+        ./use-ffmpeg-release
+        ./use-libass-release
+        ./use-libplacebo-release
+        ./use-mpv-release
         sed -i '/libdisplay-info-dev/d' debian/control
         ./update
         cp debian/changelog.TEMPLATE debian/changelog


### PR DESCRIPTION
The mpv build scripts don't support using a release of libass, so we use our own script.