### PR TITLE
ci: Manually add vulkan dll for Windows

### DIFF
--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -32,6 +32,7 @@ jobs:
           mingw-w64-x86_64-boost
           mingw-w64-x86_64-mpv
           mingw-w64-x86_64-nsis
+          mingw-w64-x86_64-vulkan-loader
     - name: Avoid line ending issues on Windows
       run: git config --global core.autocrlf input
     - name: Download mpc-qt source

--- a/scripts/make-release-msys2.sh
+++ b/scripts/make-release-msys2.sh
@@ -91,6 +91,7 @@ done
 echo "Copying other dlls to $DEST"
 cp $MINGW_BINDIR/libjpeg-*.dll                "$DEST"
 cp $MINGW_BINDIR/libcrypto-*.dll              "$DEST"
+cp $MINGW_BINDIR/vulkan-*.dll                 "$DEST"
 
 echo "All required DLLs from $MINGW_BINDIR have been copied to $DEST."
 


### PR DESCRIPTION
Follow-up to 287763c809e32ae4c83ac40ae244282023db5c93.

Fixes #727 (The latest nightly build of libmpv.dll appears to have issues, failing to locate entry points).