### PR TITLE
data: Small metainfo fixes

### DIFF
--- a/data/io.github.mpc_qt.mpc-qt.metainfo.xml
+++ b/data/io.github.mpc_qt.mpc-qt.metainfo.xml
@@ -28,16 +28,6 @@
   </ul>
  </description>
 
- <keywords>
-  <keyword>media</keyword>
-  <keyword>player</keyword>
-  <keyword>video</keyword>
-  <keyword>audio</keyword>
-  <keyword>mpv</keyword>
-  <keyword>tv</keyword>
-  <keyword>stream</keyword>
- </keywords>
-
  <screenshots>
   <screenshot type="default">
    <caption>Main window with video preview</caption>
@@ -59,6 +49,7 @@
 
  <url type="homepage">https://mpc-qt.github.io/</url>
  <url type="bugtracker">https://github.com/mpc-qt/mpc-qt/issues</url>
+ <url type="vcs-browser">https://github.com/mpc-qt/mpc-qt</url>
 
  <recommends>
   <control>keyboard</control>


### PR DESCRIPTION
Add vcs-browser URL to point to the source code repository

Also remove keywords from metadata.xml

**Categories and keywords**

> If there’s a [launchable](https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#launchable) defined for a desktop application, categories and keywords are pulled from the desktop file. Defining them separately in the Metainfo file will override the contents of the desktop file.

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords