### PR TITLE
data: Add mpc to .desktop keywords and reorder them

### DIFF
--- a/data/io.github.mpc_qt.mpc-qt.desktop
+++ b/data/io.github.mpc_qt.mpc-qt.desktop
@@ -17,7 +17,7 @@ X-DBUS-ServiceName=
 X-DBUS-StartupType=
 X-KDE-SubstituteUID=false
 X-KDE-Username=
-Keywords=mpv;media;player;video;audio;tv;stream;
+Keywords=media;player;video;audio;mpv;tv;stream;mpc;
 Actions=newFreestandingWindow
 
 [Desktop Action newFreestandingWindow]


### PR DESCRIPTION
The mpc keyword makes it possible to find MPC-QT (in the launcher menu for instance) when typing just that (without the -qt part of the executable name).

The order is only important for the Flathub website where only the first keywords are shown.

Fixes #731 (Add mpc to the list of keywords in the .desktop file).