### PR TITLE
helpers: Revert to older method to get color scheme for fallback icons

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -7,7 +7,6 @@
 #include <cmath>
 #include <QRegularExpression>
 #include <QStandardPaths>
-#include <QStyleHints>
 #include "helpers.h"
 #include "logger.h"
 #include "platform/unify.h"
@@ -770,15 +769,11 @@ void IconThemer::setIconFolders(FolderMode folderMode,
 {
     folderMode_ = folderMode;
     if (fallbackFolder == autoIcons) {
-#if QT_VERSION < QT_VERSION_CHECK(6,5,0)
+        // QGuiApplication::styleHints()->colorScheme() isn't reliable
         const QPalette defaultPalette;
         const auto text = defaultPalette.color(QPalette::WindowText);
         const auto window = defaultPalette.color(QPalette::Window);
         fallbackFolder_ = text.lightness() > window.lightness() ? whiteIconsPath : blackIconsPath;
-#else
-        fallbackFolder_ = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark ?
-                                                                              whiteIconsPath : blackIconsPath;
-#endif
     }
     else
         fallbackFolder_ = fallbackFolder;


### PR DESCRIPTION
`QGuiApplication::styleHints()->colorScheme()` isn't as reliable as just comparing the lightness of text vs background.

Fixes: ba2ce4e86b9338460a5143200c850a102fb5f8c3 ("helpers: Implement newer method to get color scheme for fallback icons")

Fixes #734 ("Interface icons are barely visible").