### PR TITLE
playlistwindow: select tab on right click, move Clear command to tab menu and add Rename command

### DIFF
--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -529,6 +529,30 @@ void PlaylistWindow::duplicateTab()
     addNewTab(remote->uuid(), remote->title());
 }
 
+void PlaylistWindow::renameTab()
+{
+    auto widget = static_cast<DrawnPlaylist *>(ui->tabWidget->currentWidget());
+    QUuid tabUuid = widget->uuid();
+    if (tabUuid.isNull())
+        return;
+    QInputDialog *qid = new QInputDialog(this);
+    qid->setAttribute(Qt::WA_DeleteOnClose);
+    qid->setWindowModality(Qt::ApplicationModal);
+    qid->setWindowTitle(tr("Enter playlist name"));
+    qid->setTextValue(ui->tabWidget->tabText(ui->tabWidget->currentIndex()).replace("&", ""));
+    connect(qid, &QInputDialog::accepted, this, [this, widget, tabUuid, qid]() {
+        int tabIndex = ui->tabWidget->indexOf(widget);
+        if (tabIndex < 0)
+            return;
+        auto pl = PlaylistCollection::getSingleton()->getPlaylist(tabUuid);
+        if (!pl)
+            return;
+        pl->setTitle(qid->textValue());
+        ui->tabWidget->setTabText(tabIndex, qid->textValue().replace("&", "+"));
+    });
+    qid->show();
+}
+
 void PlaylistWindow::importTab()
 {
     static QFileDialog::Options options = QFileDialog::Options();
@@ -1060,35 +1084,23 @@ void PlaylistWindow::on_tabWidget_tabBarClicked(int index)
 
 void PlaylistWindow::on_tabWidget_tabBarDoubleClicked(int index)
 {
-    auto widget = static_cast<DrawnPlaylist *>(ui->tabWidget->widget(index));
-    QUuid tabUuid = widget->uuid();
-    if (tabUuid.isNull())
-        return;
-    QInputDialog *qid = new QInputDialog(this);
-    qid->setAttribute(Qt::WA_DeleteOnClose);
-    qid->setWindowModality(Qt::ApplicationModal);
-    qid->setWindowTitle(tr("Enter playlist name"));
-    qid->setTextValue(ui->tabWidget->tabText(index).replace("&", ""));
-    connect(qid, &QInputDialog::accepted, this, [this, widget, tabUuid, qid]() {
-        int tabIndex = ui->tabWidget->indexOf(widget);
-        if (tabIndex < 0)
-            return;
-        auto pl = PlaylistCollection::getSingleton()->getPlaylist(tabUuid);
-        if (!pl)
-            return;
-        pl->setTitle(qid->textValue());
-        ui->tabWidget->setTabText(tabIndex, qid->textValue().replace("&", "+"));
-    });
-    qid->show();
+    Q_UNUSED(index);
+    renameTab();
 }
 
 void PlaylistWindow::on_tabWidget_customContextMenuRequested(const QPoint &pos)
 {
+    auto widget = static_cast<DrawnPlaylist *>(ui->tabWidget->currentWidget());
+    bool isQuickPlaylist = widget->uuid().isNull();
+
     QMenu *m = new QMenu(this);
     m->addAction(tr("&New Playlist"), this, SLOT(newTab()));
     m->addAction(tr("&Remove Playlist"), this, SLOT(closeTab()));
     m->addAction(tr("&Clear Playlist"), this, SLOT(playlist_removeAllRequested()));
     m->addAction(tr("&Duplicate Playlist"), this, SLOT(duplicateTab()));
+    QAction *renameTab = m->addAction(tr("&Rename Playlist"), this, SLOT(renameTab()));
+    if (isQuickPlaylist)
+        renameTab->setEnabled(false);
     m->addAction(tr("&Import Playlist"), this, SLOT(importTab()));
     m->addAction(tr("&Export Playlist"), this, SLOT(exportTab()));
     m->exec(ui->tabWidget->mapToGlobal(pos));

--- a/src/playlistwindow.h
+++ b/src/playlistwindow.h
@@ -97,6 +97,7 @@ public slots:
     void newTab();
     void closeTab();
     void duplicateTab();
+    void renameTab();
     void importTab();
     void exportTab();
 

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1994,6 +1994,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2166,6 +2166,10 @@
         <translation>&amp;Duplicar llista de reproducció</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Importar llista de reproducció</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2166,6 +2166,10 @@
         <translation>Playlist &amp;duplizieren</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>Playlist &amp;importieren</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2190,6 +2190,10 @@
         <translation>&amp;Duplicate Playlist</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Import Playlist</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2066,6 +2066,10 @@
         <translation>&amp;Duplicar la lista de reproducción</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Importar una lista de reproducción</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2030,6 +2030,10 @@
         <translation>&amp;Kopioi Soittolista</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Tuo Soittolista</translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2106,6 +2106,10 @@
         <translation>&amp;Dupliquer la liste</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Importer une liste</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2102,6 +2102,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation type="unfinished">&amp;Impor Daftar Putar</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2058,6 +2058,10 @@
         <translation>&amp;Duplica scaletta</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Importa scaletta</translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2178,6 +2178,10 @@
         <translation>再生リストを複製(&amp;D)</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>再生リストのインポート(&amp;I)</translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1970,6 +1970,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1994,6 +1994,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2014,6 +2014,10 @@
         <translation>&amp;Duplicar Playlist</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Importar Playlist</translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2146,6 +2146,10 @@
         <translation>&amp;Дублировать список воспроизведения</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp;Импортировать список воспроизведения</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2166,6 +2166,10 @@
         <translation>&amp; நகல் பிளேலிச்ட்</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>&amp; பிளேலிச்ட்டை இறக்குமதி செய்யுங்கள்</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2166,6 +2166,10 @@
         <translation>Oyn&amp;atma Listesini Çoğalt</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>Oynatma Listesi İç&amp;e Aktar</translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2134,6 +2134,10 @@
         <translation>分割播放列表(&amp;D)</translation>
     </message>
     <message>
+        <source>&amp;Rename Playlist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Import Playlist</source>
         <translation>导入播放列表(&amp;I)</translation>
     </message>


### PR DESCRIPTION
* playlistwindow: Select clicked tab on right click

> Removes and ambiguity about which tab is affected by the tab commands.
* playlistwindow: Move "Clear" (Playlist) command to tab menu and rename it

> Having the "Clear" (Playlist) command just above the "Remove" (Playlist
> item) command means that the user can remove all items by error when
> quickly removing many items (see https://github.com/mpc-qt/mpc-qt/issues/374).
> And since there is no key shortcut to remove an item, that menu command
> is the only way to do it.
* playlistwindow: Add "Rename Playlist" command to tab menu

> The Rename feature required double clicking a tab to rename it.
> 
> The new Rename command is disabled instead of hidden for the Quick
> Playlist tab to preserve the menu size and commands positions.