### PR TITLE
settingswindow: Enable log file path widgets by default

### DIFF
--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -8102,9 +8102,6 @@ media file played</string>
               </item>
               <item row="3" column="0">
                <widget class="QLabel" name="logFilePathLabel">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
                 <property name="text">
                  <string>Path</string>
                 </property>
@@ -8114,9 +8111,6 @@ media file played</string>
                <layout class="QHBoxLayout" name="logFilePathLayout">
                 <item>
                  <widget class="QLineEdit" name="logFilePathValue">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
                   <property name="placeholderText">
                    <string notr="true">~/mpc-qt.log</string>
                   </property>
@@ -8124,9 +8118,6 @@ media file played</string>
                 </item>
                 <item>
                  <widget class="QPushButton" name="logFilePathBrowse">
-                  <property name="enabled">
-                   <bool>false</bool>
-                  </property>
                   <property name="text">
                    <string>...</string>
                   </property>


### PR DESCRIPTION
Since the log file is now enabled by default, its widgets must be enabled by default too.

Fixes: efa31e5762ed76370769f2c1fb25fe0838de7171 ("settingswindow: Enable more useful logging settings by default")