### PR TITLE
settingswindow: Let pipewire set its own buffer and reduce pulse buffer

### DIFF
--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -5872,13 +5872,13 @@ media file played</string>
                      <bool>true</bool>
                     </property>
                     <property name="minimum">
-                     <number>1</number>
+                     <number>0</number>
                     </property>
                     <property name="maximum">
                      <number>2000</number>
                     </property>
                     <property name="value">
-                     <number>20</number>
+                     <number>0</number>
                     </property>
                    </widget>
                   </item>
@@ -5911,7 +5911,7 @@ media file played</string>
                      <number>2000</number>
                     </property>
                     <property name="value">
-                     <number>250</number>
+                     <number>100</number>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
The special "0" setting means that the default pipewire system buffer settings are used. This is the default mpv behavior (from 20 ms) since 0.36.

The pulse buffer was also reduced to 100 ms (from 250 ms) in mpv 0.29.

Link: https://github.com/mpv-player/mpv/commit/cb6b4af1d7711e31b1a58d3771f779fbd5079351 (pipewire)
Link: https://github.com/mpv-player/mpv/commit/66810c155030883231cbfed3a83093e21c69d9b8 (pulse)