### PR TITLE
main: Save only the path part of screenshot location

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1443,7 +1443,7 @@ void Flow::mainwindow_takeImage(Helpers::ScreenshotRender render)
     // Only remember the screenshot dir if the user picked a different one from the default
     if (!lastScreenshotDir.isEmpty() ||
             QFileInfo(QUrl::fromLocalFile(picFile).toLocalFile()).path() != lastScreenshotDir)
-        lastScreenshotDir = picFile;
+        lastScreenshotDir = QFileInfo(QUrl::fromLocalFile(picFile).toLocalFile()).path();
 
     // Copy the temp file to the desired location, then delete it
     QFile tf(tempFile);


### PR DESCRIPTION
If we save both the screenshot path and name, the next screenshot gets saved in a new folder named as the previous screenshot filename.

I seem to remember that when I tested the original commit, using only the path part didn't work, but maybe it was just a temporary Qt bug.

Fixes: 8a127d10a1560cb368e0476bb7b0d5dfd27fca6d ("Remember screenshot directory for session")