### PR TITLE
data: Use SPDX format for project_license in Appstream metainfo file

### DIFF
--- a/data/io.github.mpc_qt.mpc-qt.metainfo.xml
+++ b/data/io.github.mpc_qt.mpc-qt.metainfo.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
  <id>io.github.mpc_qt.mpc-qt</id>
  <metadata_license>CC0-1.0</metadata_license>
- <project_license>GPL-2.0+</project_license>
+ <project_license>GPL-2.0-or-later</project_license>
  <name>MPC-QT</name>
  <summary>Media Player Classic reimplemented with Qt and libmpv</summary>
  <launchable type="desktop-id">io.github.mpc_qt.mpc-qt.desktop</launchable>


### PR DESCRIPTION
The Appstream <project_license> should be an SPDX license expression.

Link: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-project_license
Link: https://spdx.github.io/spdx-spec/v3.0.1/annexes/spdx-license-expressions/