### PR TITLE
Don't percent-encode filename or path for thumbnails

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -505,8 +505,7 @@ QString Helpers::parseFormatEx(QString fmt, QUrl sourceUrl, QString filePath,
                                Helpers::Subtitles subtitles, double timeNav,
                                double timeBegin, double timeEnd)
 {
-    QString basename = QFileInfo(sourceUrl.toDisplayString().split('/').last())
-                       .completeBaseName();
+    QString basename = QFileInfo(sourceUrl.fileName()).completeBaseName();
     QString fileName = parseFormat(fmt, basename, disabled, subtitles, timeNav, timeBegin, timeEnd);
 
     // Filesystems typically support 255 characters for filename length

--- a/src/thumbnailerwindow.cpp
+++ b/src/thumbnailerwindow.cpp
@@ -90,7 +90,7 @@ void ThumbnailerWindow::open(QUrl sourceUrl)
     QString saveFile = Helpers::parseFormatEx(thumbFormat, sourceUrl, screenshotDirectory, screenshotFormat,
                                               Helpers::NothingDisabled, Helpers::SubtitlesDisabled,
                                               0.0, 0.0, 0.0);
-    ui->mediaSource->setText(sourceUrl.toString());
+    ui->mediaSource->setText(sourceUrl.path());
     ui->saveImage->setText(saveFile);
     ui->actionProgress->setValue(0);
     show();


### PR DESCRIPTION
`QUrl::toString()` returns a percent-encoded string, for instance in the case of [ and ].
`QUrl::path()` doesn't have that problem as it uses the `QUrl::FullyDecoded` format by default.
When combined with `QUrl::fileName()`, `QFileInfo::completeBaseName()` also returns a decoded string.
`QUrl::fileName()` returns the filename so we don't have to manually remove the directory path.
Sanitizing was already taken care of in
096f527e62fd3dd599836da92521f27ba5e3b4cd.

Fixes #759 (Don't percent-encode filename when saving thumbnails).