### PR TITLE
ci: Add PPA for meson to make AppImage

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -43,6 +43,9 @@ jobs:
         for i in 1 2 3; do
           sudo add-apt-repository ppa:savoury1/multimedia && break || sleep 60
         done
+        for i in 1 2 3; do
+          sudo add-apt-repository ppa:kubuntu-ppa/backports-extra && break || sleep 60
+        done
     - name: Update packages
       run: |
         for i in 1 2 3; do


### PR DESCRIPTION
libplacebo now requires meson >=0.63.