### PR TITLE
mainwindow: Uncheck "Repeat" menu action when disabling loop

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2054,6 +2054,7 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state)
         mpvObject_->setLoopPoints(-1, -1);
         positionSlider_->setLoopA(-1);
         positionSlider_->setLoopB(-1);
+        ui->actionPlayLoopUse->setChecked(false);
     }
     ui->play->setChecked(state == PlaybackManager::PlayingState);
     ui->stop->setChecked(state == PlaybackManager::StoppedState);


### PR DESCRIPTION
Otherwise, after changing file, it stays in "Repeat" mode while not actually looping, and we have to press the key twice for it to work.