### PR TITLE
main: Set a shorter stale time for the lock file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -284,7 +284,7 @@ void Flow::detectMode() {
         QString lockFilePath =
             Storage::fetchConfigPath() + QLatin1Char('/') + QLatin1String("mpc-qt.lock");
         std::unique_ptr<QLockFile> lockFile = std::make_unique<QLockFile>(lockFilePath);
-        lockFile->setStaleLockTime(0);
+        lockFile->setStaleLockTime(10000);
         while (!lockFile->tryLock()) {
             alreadyAServer = JsonServer::sendPayload(makePayload(), MpcQtServer::defaultSocketName());
             programMode = alreadyAServer ? EarlyQuitMode : PrimaryMode;


### PR DESCRIPTION
This is especially important for the Flatpak version which always uses the same PID. So in case of an unclean shutdown, the stale time is used to check if the lock file is still valid.
It was incorrectly set to never be stale. So let's set it to 10000 milliseconds.

Fixes #771.