### PR TITLE
mainwindow: Show the correct tracks (1) as selected when set to -1

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2231,7 +2231,7 @@ void MainWindow::audioTrackSet(int64_t id)
 {
     if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length()) {
         if (id <= 0)
-            id = audioTracksGroup->actions().length();
+            id = 1;
         audioTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
@@ -2240,7 +2240,7 @@ void MainWindow::videoTrackSet(int64_t id)
 {
     if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length()) {
         if (id <= 0)
-            id = videoTracksGroup->actions().length();
+            id = 1;
         videoTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }
@@ -2249,7 +2249,7 @@ void MainWindow::subtitleTrackSet(int64_t id)
 {
     if (subtitleTracksGroup != nullptr && id <= subtitleTracksGroup->actions().length()) {
         if (id <= 0)
-            id = subtitleTracksGroup->actions().length();
+            id = 1;
         subtitleTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
     }
 }


### PR DESCRIPTION
Since 4125ebe101a686038698e8a8f43de039f8dc4bac, we now set tracks in `MpvObject::setAudioTrack` and `MpvObject::setVideoTrack` to the default value (track 1) when the id is -1 (no preferred track found).
This has revealed an existing bug in `MainWindow::audioTrackSet` and `MainWindow::videoTrackSet` which would then wrongly check the last radio button (in Audio and Video submenus) instead of the first one.

Fixes: 07d25b2de1fadd82d3fa8244a7c56c490180ef97 ("Add radio buttons in the Audio, Subtitles and Video Stream menus")
Fixes: b2b51c3722e0584f3dfb99506f2b201abf165f50 ("Let selected tracks get reset when opened from recent files")
Follow-up to (and fixes) 4125ebe101a686038698e8a8f43de039f8dc4bac ("Set audio and video tracks to 1 when nothing better can be guessed")