### PR TITLE
manager: Reset filename on stop

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -302,6 +302,7 @@ void PlaybackManager::unpausePlayer()
 void PlaybackManager::stopPlayer()
 {
     nowPlayingItem = QUuid();
+    nowPlaying_ = QUrl();
     mpvObject_->stopPlayback();
 }
 


### PR DESCRIPTION
Otherwise, the filename stays shown in the title bar and the information panel after the player is stopped.

Fixes: 2fd63932224a309c37ec01ad7235e9ea2994cf78 ("Improve Player Title bar settings")
Fixes: d2c16b13a62be6c95a01b1ab05eb38b80806d14f ("Show the title in the information bar")