### PR TITLE
videopreview: Don't open file if empty

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -50,6 +50,8 @@ VideoPreview::~VideoPreview()
 
 void VideoPreview::openFile(const QUrl &fileUrl)
 {
+    if (fileUrl.isEmpty())
+        return;
     mpv->urlOpen(fileUrl);
     mpv->setPaused(true);
     aspectRatioSet = false;


### PR DESCRIPTION
Avoids "error: Cannot open file '': No such file or directory" when starting MPC-QT.

Fixes: 7981a40657a965c3b0a67242a2559527312f0192 ("Add a video preview to the seekbar")