### PR TITLE
Don't try to load non-existing subtitles files

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -705,7 +705,8 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
     mpvObject_->fileOpen(what.isLocalFile() ? what.toLocalFile()
                                             : QUrl::fromPercentEncoding(what.toEncoded()),
                          replaceMpvPlaylist);
-    mpvObject_->setSubFile(with.toString());
+    if (!with.isEmpty())
+        mpvObject_->setSubFile(with.toString());
     mpvObject_->setPaused(playbackStartPaused);
     playbackStartState = playbackStartPaused ? PausedState : PlayingState;
 

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -338,7 +338,7 @@ void MpvObject::urlOpen(QUrl url)
 
 void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist)
 {
-    setSubFile("\n");
+    clearSubFiles();
     //setStartTime(0.0);
     if (replaceMpvPlaylist)
         emit ctrlCommand(QStringList({"loadfile", filename}));
@@ -445,6 +445,11 @@ void MpvObject::setSubFile(QString filename)
 void MpvObject::addSubFile(QString filename)
 {
     emit ctrlCommand(QStringList({"sub-add", filename}));
+}
+
+void MpvObject::clearSubFiles()
+{
+    emit ctrlSetOptionVariant("sub-files-clr", "");
 }
 
 void MpvObject::setSubtitlesDelay(int subDelayStep)

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -173,6 +173,7 @@ private:
     void setMpvOptionVariant(QString name, const QVariant &value);
     void showCursor();
     void hideCursor();
+    void clearSubFiles();
 
 private slots:
     void ctrl_mpvPropertyChanged(QString name, const QVariant &v);


### PR DESCRIPTION
Avoids "error: Cannot open file '': No such file or directory" after loading a file.