### PR TITLE
Support changing status time format by click, add remaining and percentage modes

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -415,7 +415,6 @@
     "tweaksPreferWayland": false,
     "tweaksSeekFramedrop": false,
     "tweaksShowChapterMarks": true,
-    "tweaksTimeShort": true,
     "tweaksTimeTooltip": false,
     "tweaksTimeTooltipLocation": 0,
     "tweaksVideoPreview": false,

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -282,30 +282,33 @@ QString Helpers::toDateFormatFixed(double time, Helpers::TimeFormat format)
 {
     if (format == ShortFormat || format == ShortHourFormat)
         time = std::round(time);
-    int t = int(time*1000 + 0.5);
-    if (t < 0)
-        t = 0;
+    QString prefix;
+    if (time < 0) {
+        time = abs(time);
+        prefix = "-";
+    }
+    int t = int(time*1000);
     int hr = t/3600000;
     int mn = t/60000 % 60;
     int se = t%60000 / 1000;
     int fr = t % 1000;
     switch (format) {
     case LongFormat:
-        return QString("%1:%2:%3.%4").arg(QString::number(hr))
+        return QString(prefix + "%1:%2:%3.%4").arg(QString::number(hr))
                 .arg(QString::number(mn),2,'0')
                 .arg(QString::number(se),2,'0')
                 .arg(QString::number(fr),3,'0');
     case ShortFormat:
-        return QString("%1:%2:%3").arg(QString::number(hr),2,'0')
+        return QString(prefix + "%1:%2:%3").arg(QString::number(hr),2,'0')
                 .arg(QString::number(mn),2,'0')
                 .arg(QString::number(se),2,'0');
     case LongHourFormat:
-        return QString("%1:%2.%3")
+        return QString(prefix + "%1:%2.%3")
                 .arg(QString::number(mn),2,'0')
                 .arg(QString::number(se),2,'0')
                 .arg(QString::number(fr),3,'0');
     case ShortHourFormat:
-        return QString("%1:%2")
+        return QString(prefix + "%1:%2")
                 .arg(QString::number(mn),2,'0')
                 .arg(QString::number(se),2,'0');
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -553,8 +553,6 @@ void Flow::setupMainWindowConnections()
             playbackManager, &PlaybackManager::setAfterPlaybackOnce);
     connect(mainWindow, &MainWindow::afterPlaybackAlways,
             playbackManager, &PlaybackManager::setAfterPlaybackAlways);
-    connect(mainWindow, &MainWindow::timeShortModeSet,
-            playbackManager, &PlaybackManager::setTimeShortMode);
     connect(mainWindow, &MainWindow::chapterPrevious,
             playbackManager, &PlaybackManager::navigateToPrevChapter);
     connect(mainWindow, &MainWindow::chapterNext,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -736,8 +736,6 @@ void Flow::setupSettingsConnections()
             mainWindow, &MainWindow::setVolumeMax);
     connect(settingsWindow, &SettingsWindow::subtitlesDelayStep,
             mainWindow, &MainWindow::setSubtitlesDelayStep);
-    connect(settingsWindow, &SettingsWindow::timeShorten,
-            mainWindow, &MainWindow::setTimeShortMode);
     connect(settingsWindow, &SettingsWindow::videoPreview,
             mainWindow, &MainWindow::setVideoPreview);
     connect(settingsWindow, &SettingsWindow::timeTooltip,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -191,7 +191,10 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionDisableVideoAspect) },
         { WRAP(ui->actionPlayVolumeMute) },
         { "volume", volumeSlider_->value() },
-        { "shownStatsPage", mpvObject_->selectedStatsPage() }
+        { "shownStatsPage", mpvObject_->selectedStatsPage() },
+        { "timeShortMode", timeShortMode },
+        { "timeRemainingMode", timeRemainingMode },
+        { "timePercentageMode", timePercentageMode }
     };
 #undef WRAP
 }
@@ -234,6 +237,9 @@ void MainWindow::setState(const QVariantMap &map)
     setVolumeMuteState(ui->actionPlayVolumeMute->isChecked(), true);
     setVolume(map.value("volume", 100).toInt(), true);
     setOSDPage(map.value("shownStatsPage",0).toInt());
+    setTimeShortMode(map.value("timeShortMode", true).toBool());
+    setTimeRemainingMode(map.value("timeRemainingMode", false).toBool());
+    setTimePercentageMode(map.value("timePercentageMode", false).toBool());
     updateOnTop();
 
 #undef UNWRAP
@@ -426,6 +432,11 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (fullscreenMode_)
         checkBottomArea(event->globalPosition());
+    if (mousePressedInsideStatustime) {
+        mousePressedInsideStatustime = false;
+        QWindow *parentWindow = this->window()->windowHandle();
+        parentWindow->startSystemMove();
+    }
 }
 
 static bool insideWidget(QPoint p, QWidget const *widget) {
@@ -440,9 +451,10 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
     QPoint pos = event->globalPosition().toPoint();
     bool isInMpvw = mpvw ? insideWidget(pos, mpvw) : false;
     bool isInBottomArea = ui->bottomArea->isVisible() ? insideWidget(pos, ui->bottomArea) : false;
+    mousePressedInsideStatustime = insideWidget(pos, statusTime);
     if (isInMpvw && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseDown)))
         event->accept();
-    else if (isInBottomArea)  {
+    else if (isInBottomArea && !mousePressedInsideStatustime)  {
         QWindow *parentWindow = this->window()->windowHandle();
         parentWindow->startSystemMove();
     }
@@ -463,10 +475,17 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QPoint pos = event->globalPosition().toPoint();
     bool ok = mpvw ? insideWidget(pos, mpvw) : false;
-    if (ok && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseUp)))
-        event->accept();
-    else
-        QMainWindow::mouseReleaseEvent(event);
+    if (mousePressedInsideStatustime && insideWidget(pos, statusTime)) {
+        if (event->button() == Qt::MouseButton::LeftButton)
+            setTimeRemainingMode(!timeRemainingMode);
+    }
+    else {
+        if (ok && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseUp)))
+            event->accept();
+        else
+            QMainWindow::mouseReleaseEvent(event);
+    }
+    mousePressedInsideStatustime = false;
 }
 
 void MainWindow::wheelEvent(QWheelEvent *event)
@@ -572,8 +591,7 @@ void MainWindow::setFullscreenMode(bool fullscreenMode)
     QTimer::singleShot(50, this, [this]() {
         positionSlider_->update();
         volumeSlider_->update();
-        timePosition->update();
-        timeDuration->update();
+        statusTime->update();
     });
     emit fullscreenModeChanged(fullscreenMode_);
 }
@@ -814,10 +832,12 @@ void MainWindow::setupPlaylist()
 void MainWindow::setupStatus()
 {
     ui->tinyicon->setPixmap(renderPixmapFromSvg(tinyIconPath));
-    timePosition = new StatusTime();
-    ui->statusbarLayout->insertWidget(2, timePosition);
-    timeDuration = new StatusTime();
-    ui->statusbarLayout->insertWidget(4, timeDuration);
+    statusTime = new StatusTime();
+    statusTime->setCursor(Qt::PointingHandCursor);
+    statusTime->setContextMenuPolicy(Qt::CustomContextMenu);
+    ui->statusbarLayout->insertWidget(2, statusTime);
+    connect(statusTime, &StatusTime::customContextMenuRequested,
+            this, &MainWindow::statusTime_customContextMenuRequested);
 }
 
 void MainWindow::setupSizing()
@@ -1146,14 +1166,6 @@ void MainWindow::updateBottomAreaGeometry()
         sz -= QSize(playlistWindow_->width(), 0);
     ui->bottomArea->setGeometry(0, sz.height() - bottomAreaHeight,
                                 sz.width(), bottomAreaHeight);
-}
-
-void MainWindow::updateTime()
-{
-    double length = mpvObject_->playLength();
-    double time = mpvObject_->playTime();
-    timeDuration->setTime(length, length);
-    timePosition->setTime(time, length);
 }
 
 void MainWindow::updateFramedrops()
@@ -1852,9 +1864,9 @@ void MainWindow::setInfoColors(const QColor &foreground, const QColor &backgroun
 
 void MainWindow::setTime(double time, double length)
 {
-    positionSlider_->setMaximum(length >= 0 ? length : 0);
-    positionSlider_->setValue(time >= 0 ? time : 0);
-    updateTime();
+    positionSlider_->setMaximum(length);
+    positionSlider_->setValue(time);
+    statusTime->setTime(time, length);
 }
 
 void MainWindow::setMediaTitleWithFilename(const QString& title, const QString& filename)
@@ -2303,10 +2315,20 @@ void MainWindow::setSubtitlesDelayStep(int subtitlesDelayStep)
 
 void MainWindow::setTimeShortMode(bool shortened)
 {
-    timePosition->setShortMode(shortened);
-    timeDuration->setShortMode(shortened);
+    statusTime->setShortMode(shortened);
     timeShortMode = shortened;
-    emit timeShortModeSet(timeShortMode);
+}
+
+void MainWindow::setTimeRemainingMode(bool isRemaining)
+{
+    statusTime->setRemainingMode(isRemaining);
+    timeRemainingMode = isRemaining;
+}
+
+void MainWindow::setTimePercentageMode(bool isPercentage)
+{
+    statusTime->setPercentMode(isPercentage);
+    timePercentageMode = isPercentage;
 }
 
 void MainWindow::resetPlayAfterOnce()
@@ -3449,6 +3471,48 @@ void MainWindow::mpvw_customContextMenuRequested(const QPoint &pos)
     if (mpvw == nullptr)
         return;
     contextMenu->popup(mpvw->mapToGlobal(pos));
+}
+
+void MainWindow::statusTime_customContextMenuRequested(const QPointF &p)
+{
+    QMenu *m = new QMenu(this);
+    QAction *a;
+
+    bool isTimeRemaingMode = timeRemainingMode;
+    a = new QAction(m);
+    a->setText(tr("Remaining time"));
+    a->setCheckable(true);
+    a->setChecked(timeRemainingMode);
+    connect(a, &QAction::triggered,
+            this, [this, isTimeRemaingMode]() {
+        setTimeRemainingMode(!isTimeRemaingMode);
+    });
+    m->addAction(a);
+    
+    bool isTimeShortMode = timeShortMode;
+    a = new QAction(m);
+    a->setText(tr("High precision"));
+    a->setCheckable(true);
+    a->setChecked(!timeShortMode);
+    connect(a, &QAction::triggered,
+            this, [this, isTimeShortMode]() {
+        setTimeShortMode(!isTimeShortMode);
+    });
+    m->addAction(a);
+
+    bool isTimePercentageMode = timePercentageMode;
+    a = new QAction(m);
+    a->setText(tr("Show percentage"));
+    a->setCheckable(true);
+    a->setChecked(timePercentageMode);
+    connect(a, &QAction::triggered,
+            this, [this, isTimePercentageMode]() {
+        setTimePercentageMode(!isTimePercentageMode);
+    });
+    m->addAction(a);
+
+    m->exec(statusTime->mapToGlobal(p).toPoint());
+    delete m;
 }
 
 void MainWindow::position_sliderMoved(int position)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3529,7 +3529,7 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
 
     QString t = QString("%1%2%3").arg(Helpers::toDateFormatFixed(
                                             position,
-                                            timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
+                                            Helpers::ShortFormat),
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
     QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), timeTooltipAbove ? -1 : 65));
@@ -3538,7 +3538,7 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
     else if (tooltip) {
         QString textTemplate = QString("%1%2%3").arg(Helpers::toDateFormatFixed(
                                                         0,
-                                                        timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
+                                                        Helpers::ShortFormat),
                                                     chapterInfo.isEmpty() ? "" : " - ",
                                                     chapterInfo);
         tooltip->show(t, where, this->width(), textTemplate);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1008,6 +1008,7 @@ void MainWindow::setOSDPage(int page)
 void MainWindow::setUiEnabledState(bool enabled)
 {
     positionSlider_->setEnabled(enabled);
+    statusTime->setEnabled(enabled);
     if (!enabled) {
         positionSlider_->setLoopA(-1);
         positionSlider_->setLoopB(-1);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -104,7 +104,6 @@ private:
     void checkBottomArea(QPointF mousePosition);
     void leaveBottomArea();
     void updateBottomAreaGeometry();
-    void updateTime();
     void updateFramedrops();
     void updateBitrate();
     void updatePlaybackStatus();
@@ -177,7 +176,6 @@ signals:
     void favoriteCurrentTrack();
     void organizeFavorites();
     void fullscreenHideControls(bool checked);
-    void timeShortModeSet(bool timeShortMode);
     void repeatAfter();
     void audioFilter(QString filter, QString options, bool add);
     void videoFilter(QString filter, QString options, bool add);
@@ -286,6 +284,8 @@ public slots:
     void setSubtitlesEnabled(bool enabled, bool onInit = false);
     void setSubtitlesDelayStep(int subtitlesDelayStep);
     void setTimeShortMode(bool shortened);
+    void setTimeRemainingMode(bool isRemaining);
+    void setTimePercentageMode(bool isPercentage);
     void resetPlayAfterOnce();
     void setPlayAfterAlways(Helpers::AfterPlayback action);
     void setPlayAfterAlwaysDefault(Helpers::AfterPlayback action);
@@ -464,6 +464,7 @@ private slots:
     void on_actionPlaylistFinishSearching_triggered();
 
     void mpvw_customContextMenuRequested(const QPoint &pos);
+    void statusTime_customContextMenuRequested(const QPointF &p);
     void position_sliderMoved(int position);
     void position_hoverValue(double value, QString text, double mouseX);
     void position_hoverEnd();
@@ -492,8 +493,7 @@ private:
     VolumeSlider *volumeSlider_ = nullptr;
     VideoPreview *videoPreview = nullptr;
     Tooltip *tooltip = nullptr;
-    StatusTime *timePosition = nullptr;
-    StatusTime *timeDuration = nullptr;
+    StatusTime *statusTime = nullptr;
     PlaylistWindow *playlistWindow_ = nullptr;
     QMenu *contextMenu = nullptr;
     QMenu *trayMenu = nullptr;
@@ -521,7 +521,10 @@ private:
     bool timeTooltipShown = true;
     bool timeTooltipAbove = true;
     bool osdTimerOnSeek = false;
-    bool timeShortMode = false;
+    bool timeShortMode = true;
+    bool timeRemainingMode = false;
+    bool timePercentageMode = false;
+    bool mousePressedInsideStatustime = false;
 
     QString previousOpenDir;
     QSize noVideoSize_ = QSize(500,270);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -688,7 +688,7 @@
           </item>
           <item>
            <widget class="QWidget" name="statusbar" native="true">
-            <layout class="QHBoxLayout" name="statusbarLayout" stretch="0,1,0">
+            <layout class="QHBoxLayout" name="statusbarLayout" stretch="0,1">
              <property name="leftMargin">
               <number>6</number>
              </property>
@@ -708,13 +708,6 @@
               <widget class="QLabel" name="status">
                <property name="text">
                 <string>Stopped</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="timeGap">
-               <property name="text">
-                <string notr="true">/</string>
                </property>
               </widget>
              </item>

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -611,12 +611,6 @@ void PlaybackManager::setAfterPlaybackAlwaysDefault(Helpers::AfterPlayback mode)
     }
 }
 
-void PlaybackManager::setTimeShortMode(bool shortMode)
-{
-    timeShortMode = shortMode;
-    updateChapters();
-}
-
 void PlaybackManager::setSubtitlesPreferDefaultForced(bool forced)
 {
     subtitlesPreferDefaultForced = forced;
@@ -854,8 +848,7 @@ void PlaybackManager::updateChapters()
         for (QVariant const &v : chapters) {
             QMap<QString, QVariant> node = v.toMap();
             QString text = QString("[%1] - %2").arg(
-                    toDateFormatFixed(node["time"].toDouble(),
-                                    timeShortMode ? Helpers::ShortFormat : Helpers::LongFormat),
+                    toDateFormatFixed(node["time"].toDouble(), Helpers::ShortFormat),
                     node["title"].toString());
             Chapter item { node["time"].toDouble(), text };
             list.append(item);

--- a/src/manager.h
+++ b/src/manager.h
@@ -160,7 +160,6 @@ public slots:
     void setAfterPlaybackOnce(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlways(Helpers::AfterPlayback mode);
     void setAfterPlaybackAlwaysDefault(Helpers::AfterPlayback mode);
-    void setTimeShortMode(bool shortMode);
     void setSubtitlesPreferDefaultForced(bool forced);
     void setSubtitlesPreferExternal(bool external);
     void setSubtitlesIgnoreEmbedded(bool ignore);
@@ -273,8 +272,6 @@ private:
     bool fastSeek = true;
     bool folderFallback = false;
     bool appendToQuickPlaylist = false;
-
-    bool timeShortMode = false;
 
     PlaybackManager::AspectNameChanged showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;
 

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -40,8 +40,8 @@
 }
 
 MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
-    HANDLE_PROP("time-pos", self_playTimeChanged, toDouble, -1.0),
-    HANDLE_PROP("duration", self_playLengthChanged, toDouble, -1.0),
+    HANDLE_PROP("time-pos", self_playTimeChanged, toDouble, 0.0),
+    HANDLE_PROP("duration", self_playLengthChanged, toDouble, 0.0),
     HANDLE_PROP("seekable", seekableChanged, toBool, false),
     HANDLE_PROP("pause", pausedChanged, toBool, true),
     HANDLE_PROP("eof-reached", eofReachedChanged, toString, QString()),

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1069,7 +1069,6 @@ void SettingsWindow::sendSignals()
     emit fallbackToFolder(WIDGET_LOOKUP(ui->tweaksOpenNextFile).toBool());
     emit mpvMouseEvents(WIDGET_LOOKUP(ui->tweaksMpvMouseEvents).toBool());
     emit mpvKeyEvents(WIDGET_LOOKUP(ui->tweaksMpvKeyEvents).toBool());
-    emit timeShorten(WIDGET_LOOKUP(ui->tweaksTimeShort).toBool());
     emit videoPreview(WIDGET_LOOKUP(ui->tweaksVideoPreview).toBool());
     emit timeTooltip(WIDGET_LOOKUP(ui->tweaksTimeTooltip).toBool(),
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -178,7 +178,6 @@ signals:
     void fastSeek(bool yes);
     void fallbackToFolder(bool yes);
     void volumeMax(int maximum);
-    void timeShorten(bool yes);
     void mpvMouseEvents(bool yes);
     void mpvKeyEvents(bool yes);
     void videoPreview(bool enable);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7790,16 +7790,6 @@ media file played</string>
             </widget>
            </item>
            <item row="5" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksTimeShort">
-             <property name="text">
-              <string>Shorten the playback time indicator like mpc-hc</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksPreferWayland">
              <property name="enabled">
               <bool>false</bool>
@@ -7812,21 +7802,21 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0" colspan="2">
+           <item row="6" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvMouseEvents">
              <property name="text">
               <string>Send mouse events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="0" colspan="2">
+           <item row="7" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvKeyEvents">
              <property name="text">
               <string>Send key events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
+           <item row="8" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksVideoPreview">
              <property name="text">
               <string>Show video preview (restart required)</string>
@@ -7836,7 +7826,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="9" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="0,0">
              <item>
               <widget class="QCheckBox" name="tweaksTimeTooltip">
@@ -7873,14 +7863,14 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="11" column="0" colspan="2">
+           <item row="10" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
              <property name="text">
               <string>Show OSD timer on seek</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
+           <item row="11" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="0,1,0">
              <item>
               <widget class="QCheckBox" name="tweaksOsdFontChkBox">
@@ -7935,7 +7925,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="13" column="0" colspan="2">
+           <item row="12" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksMpvOptionsLayout" stretch="0,1">
              <item>
               <widget class="QCheckBox" name="tweaksMpvOptionsChkBox">
@@ -7968,7 +7958,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="14" column="0">
+           <item row="13" column="0">
             <spacer name="verticalSpacer_9">
              <property name="orientation">
               <enum>Qt::Orientation::Vertical</enum>

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -97,3 +97,8 @@ void StatusTime::paintEvent(QPaintEvent *event)
     p.drawText(rc, drawnText, QTextOption(Qt::AlignRight | Qt::AlignVCenter));
 }
 
+void StatusTime::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::EnabledChange)
+        setVisible(isEnabled());
+}

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -29,11 +29,23 @@ void StatusTime::setTime(double time, double duration)
 
 void StatusTime::setShortMode(bool shortened)
 {
-    if (shortMode == shortened)
-        return;
     shortMode = shortened;
     lastTextLength = 0;
     updateTimeFormat();
+    updateText();
+}
+
+void StatusTime::setRemainingMode(bool isRemaining)
+{
+    remainingMode = isRemaining;
+    lastTextLength = 0;
+    updateText();
+}
+
+void StatusTime::setPercentMode(bool isPercent)
+{
+    percentMode = isPercent;
+    lastTextLength = 0;
     updateText();
 }
 
@@ -51,7 +63,20 @@ void StatusTime::updateTimeFormat()
 
 void StatusTime::updateText()
 {
-    drawnText = Helpers::toDateFormatFixed(currentTime, timeFormat);
+    double time = currentTime;
+    if (remainingMode)
+        time = currentTime - currentDuration;
+
+    drawnText = Helpers::toDateFormatFixed(time, timeFormat);
+    drawnText.append(" / ");
+    drawnText.append(Helpers::toDateFormatFixed(currentDuration, timeFormat));
+
+    if (percentMode) {
+        double durationNotNull = currentDuration == 0 ? 1 : currentDuration;
+        drawnText.append(QString(tr(" (%1%)")).arg(QLocale().toString(currentTime / durationNotNull * 100,
+                                                                'f',
+                                                                1)));
+    }
     int drawnTextLength = drawnText.length();
     if (drawnTextLength != lastTextLength) {
         setMinimumSize(minimumSizeHint());

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -13,6 +13,8 @@ public:
 
     void setTime(double time, double duration);
     void setShortMode(bool shortened);
+    void setRemainingMode(bool isRemaining);
+    void setPercentMode(bool isPercent);
 
 protected:
     void updateTimeFormat();
@@ -21,6 +23,8 @@ protected:
 
 private:
     bool shortMode = false;
+    bool remainingMode = false;
+    bool percentMode = false;
     Helpers::TimeFormat timeFormat = Helpers::LongFormat;
     double currentTime = 0;
     double currentDuration = 0;

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -20,6 +20,7 @@ protected:
     void updateTimeFormat();
     void updateText();
     void paintEvent(QPaintEvent *event) override;
+    void changeEvent(QEvent *event) override;
 
 private:
     bool shortMode = false;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1222,6 +1222,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3920,10 +3932,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4361,6 +4369,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1342,6 +1342,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Obertura ràpida</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Sense arxius preferits</translation>
     </message>
@@ -4157,7 +4169,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>Escurçar l&apos;indicador de la reproducció igual que mpc-hc</translation>
+        <translation type="vanished">Escurçar l&apos;indicador de la reproducció igual que mpc-hc</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4605,6 +4617,13 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1350,6 +1350,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Schnelles Öffnen</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Keine Dateien favorisiert</translation>
     </message>
@@ -4149,7 +4161,7 @@ media file played</source>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>Verkürzen der Wiedergabezeitanzeige (wie bei mpc-hc)</translation>
+        <translation type="vanished">Verkürzen der Wiedergabezeitanzeige (wie bei mpc-hc)</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4589,6 +4601,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1350,6 +1350,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Quick Open</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>No files favorited</translation>
     </message>
@@ -4189,7 +4201,7 @@ media file played</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>Shorten the playback time indicator like mpc-hc</translation>
+        <translation type="vanished">Shorten the playback time indicator like mpc-hc</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4641,6 +4653,13 @@ media file played</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1310,6 +1310,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Apertura rápida</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>No hay archivos favoritos</translation>
     </message>
@@ -4032,10 +4044,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4469,6 +4477,13 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1258,6 +1258,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Pika Avaus</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Ei Suosikkitiedostoja</translation>
     </message>
@@ -3898,10 +3910,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4335,6 +4343,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1303,6 +1303,18 @@ Voulez-vous l&apos;utiliser pour &quot;%3&quot; à la place&#x202f;?</translatio
         <translation>Ouverture rapide</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Aucun fichier dans les favoris</translation>
     </message>
@@ -4110,7 +4122,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>Raccourcir l’indicateur de temps de lecture comme mpc-hc</translation>
+        <translation type="vanished">Raccourcir l’indicateur de temps de lecture comme mpc-hc</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4563,6 +4575,13 @@ fichier média lu</translation>
     <message>
         <source>File title</source>
         <translation>Titre du fichier</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1334,6 +1334,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Buka Cepat</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Tidak ada berkas unggulan</translation>
     </message>
@@ -3984,10 +3996,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4425,6 +4433,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1310,6 +1310,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Apri rapidamente</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3984,10 +3996,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4421,6 +4429,13 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1351,6 +1351,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>クイック再生</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>お気に入りファイルがありません</translation>
     </message>
@@ -4178,7 +4190,7 @@ media file played</source>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>MPC-HC のように再生時間インジケーターを短くする</translation>
+        <translation type="vanished">MPC-HC のように再生時間インジケーターを短くする</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4631,6 +4643,13 @@ media file played</source>
     <message>
         <source>File title</source>
         <translation>ファイル タイトル</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1222,6 +1222,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Hurtigåpning</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Ingen filer favorittmerket</translation>
     </message>
@@ -3845,10 +3857,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4278,6 +4286,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1222,6 +1222,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3896,10 +3908,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4341,6 +4349,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1242,6 +1242,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Sem arquivos favoritos</translation>
     </message>
@@ -3948,10 +3960,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4393,6 +4401,13 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1342,6 +1342,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Быстро открыть</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Нет избранных файлов</translation>
     </message>
@@ -4129,7 +4141,7 @@ media file played</source>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>Укоротить индикатор времени воспроизведения</translation>
+        <translation type="vanished">Укоротить индикатор времени воспроизведения</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4581,6 +4593,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1342,6 +1342,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>விரைவாக திறந்திருக்கும்</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>கோப்புகள் இல்லை</translation>
     </message>
@@ -4157,7 +4169,7 @@ media file played</source>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>MPC-HC போன்ற பிளேபேக் நேரக் காட்டியை சுருக்கவும்</translation>
+        <translation type="vanished">MPC-HC போன்ற பிளேபேக் நேரக் காட்டியை சுருக்கவும்</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4609,6 +4621,13 @@ media file played</source>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1342,6 +1342,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>Tez Aç</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>Sık kullanılanlara eklenen dosya yok</translation>
     </message>
@@ -4145,7 +4157,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>mpc-hc gibi oynatma zamanı göstergesini kısalt</translation>
+        <translation type="vanished">mpc-hc gibi oynatma zamanı göstergesini kısalt</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4601,6 +4613,13 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>File title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1351,6 +1351,18 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <translation>快速打开</translation>
     </message>
     <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>No files favorited</source>
         <translation>没有收藏的文件</translation>
     </message>
@@ -4070,7 +4082,7 @@ media file played</source>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
-        <translation>缩短播放时间指示器，如 MPC-HC</translation>
+        <translation type="vanished">缩短播放时间指示器，如 MPC-HC</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4507,6 +4519,13 @@ media file played</source>
     <message>
         <source>File title</source>
         <translation>文件标题</translation>
+    </message>
+</context>
+<context>
+    <name>StatusTime</name>
+    <message>
+        <source> (%1%)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
* Support changing status time format by click and add remaining and percentage modes

> Remaining mode shows the how much time is remaining; percentage mode shows completion.
> A left click switches between normal and remaining time mode.
> The context menu allows enabling "Remaining time", "High precision" and "Show percentage".
> 
> Uses only one StatusTime widget. This avoids what seems like a Qt bug
> where the widgets would quickly wobble when their widths change.
> 
> Unlike MPC-HC, moving the player from that position still works.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/463 (Feature request: high precision timestamp in right click
> option).
* Always use playback time short mode in tooltip and chapters

> The status time widget is where the high precision mode makes most sense.
> 
> Follows the  behavior of MPC-HC.
> 
> Follow-up to and partially reverts
> https://github.com/mpc-qt/mpc-qt/commit/b06e81dcb7e6312abfcdd083a08fe375f50d1b82 before which the seekbar
> tooltip and chapters never used the playback time short mode.
* Don't show StatusTime when player is stopped

> Avoids showing the status time when nothing useful is available. Mirrors
> the behavior of Drawnslider.
> 
> We may want to mirror the behavior of MPC-HC in the future: hide the
> status time only when no file is loaded and show otherwise its total
> length (and keep it loaded). MPC-HC seems to pause the file and move the
> position back to 0, but that keeps the last image visible.