### PR TITLE
Add support for transparency to all color settings

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1196,10 +1196,10 @@ void SettingsWindow::setCustomMpvOptions()
 void SettingsWindow::colorPick_clicked(QLineEdit *colorValue)
 {
     QColor initial = QString("#%1").arg(colorValue->text());
-    QColor selected = QColorDialog::getColor(initial, this);
+    QColor selected = QColorDialog::getColor(initial, this, QString(), QColorDialog::ShowAlphaChannel);
     if (!selected.isValid())
         return;
-    QString asText = selected.name().mid(1).toUpper();
+    QString asText = selected.name(QColor::HexArgb).mid(1).toUpper();
     colorValue->setText(asText);
     colorValue->setFocus();
 }

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -758,12 +758,12 @@ media file played</string>
                <layout class="QHBoxLayout" name="windowVideoLayout">
                 <item>
                  <widget class="QLineEdit" name="windowVideoValue">
-                  <property name="inputMask">
-                   <string>HHHHHH</string>
-                  </property>
-                  <property name="text">
-                   <string notr="true">000000</string>
-                  </property>
+                       <property name="inputMask">
+                        <string notr="true">HHHHHHHH</string>
+                       </property>
+                       <property name="text">
+                        <string notr="true">FF000000</string>
+                       </property>
                  </widget>
                 </item>
                 <item>
@@ -789,12 +789,12 @@ media file played</string>
                <layout class="QHBoxLayout" name="windowInfoBackgroundLayout">
                 <item>
                  <widget class="QLineEdit" name="windowInfoBackgroundValue">
-                  <property name="inputMask">
-                   <string>HHHHHH</string>
-                  </property>
-                  <property name="text">
-                   <string notr="true">000000</string>
-                  </property>
+                       <property name="inputMask">
+                        <string notr="true">HHHHHHHH</string>
+                       </property>
+                       <property name="text">
+                        <string notr="true">FF000000</string>
+                       </property>
                  </widget>
                 </item>
                 <item>
@@ -820,12 +820,12 @@ media file played</string>
                <layout class="QHBoxLayout" name="windowInfoForegroundLayout">
                 <item>
                  <widget class="QLineEdit" name="windowInfoForegroundValue">
-                  <property name="inputMask">
-                   <string>HHHHHH</string>
-                  </property>
-                  <property name="text">
-                   <string notr="true">FFFFFF</string>
-                  </property>
+                       <property name="inputMask">
+                        <string notr="true">HHHHHHHH</string>
+                       </property>
+                       <property name="text">
+                        <string notr="true">FFFFFFFF</string>
+                       </property>
                  </widget>
                 </item>
                 <item>
@@ -6745,10 +6745,10 @@ media file played</string>
                      <item>
                       <widget class="QLineEdit" name="subsColorValue">
                        <property name="inputMask">
-                        <string>HHHHHH</string>
+                        <string notr="true">HHHHHHHH</string>
                        </property>
                        <property name="text">
-                        <string notr="true">FFFF00</string>
+                        <string notr="true">FFFFFF00</string>
                        </property>
                       </widget>
                      </item>
@@ -6776,10 +6776,10 @@ media file played</string>
                      <item>
                       <widget class="QLineEdit" name="subsBorderColorValue">
                        <property name="inputMask">
-                        <string>HHHHHH</string>
+                        <string notr="true">HHHHHHHH</string>
                        </property>
                        <property name="text">
-                        <string notr="true">000000</string>
+                        <string notr="true">FF000000</string>
                        </property>
                       </widget>
                      </item>
@@ -6832,10 +6832,10 @@ media file played</string>
                         <bool>false</bool>
                        </property>
                        <property name="inputMask">
-                        <string>HHHHHH</string>
+                        <string notr="true">HHHHHHHH</string>
                        </property>
                        <property name="text">
-                        <string notr="true">000000</string>
+                        <string notr="true">FF000000</string>
                        </property>
                       </widget>
                      </item>

--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -43,7 +43,7 @@ Q_GLOBAL_STATIC_WITH_ARGS(GroupLabels, groupText, ({
 static constexpr char logModule[] =  "paletteeditor";
 
 
-PaletteBox::PaletteBox(QWidget *parent) : QWidget(parent), color(0,0,0)
+PaletteBox::PaletteBox(QWidget *parent) : QWidget(parent), color(0,0,0,255)
 {
 
 }
@@ -71,7 +71,7 @@ void PaletteBox::mousePressEvent(QMouseEvent *event)
 {
     if (event->button() == Qt::LeftButton) {
         event->accept();
-        QColor ret = QColorDialog::getColor(color, this);
+        QColor ret = QColorDialog::getColor(color, this, QString(), QColorDialog::ShowAlphaChannel);
         if (ret.isValid()) {
             setValue(ret);
             emit valueSelected(color);
@@ -162,7 +162,7 @@ QPalette PaletteEditor::variantToPalette(const QVariant &v)
     QPalette p = system;
     QVariantList array = v.toList();
     RoleLabels::ConstIterator it;
-    QVariant defaultValue("#000000");
+    QVariant defaultValue("#FF000000");
     int index = 0;
     for (it = roleText->constBegin(); it != roleText->constEnd(); it++) {
         QVariantList items = array.value(index++).toList();
@@ -179,9 +179,9 @@ QVariant PaletteEditor::paletteToVariant(const QPalette &p)
     RoleLabels::ConstIterator it;
     for (it = roleText->constBegin(); it != roleText->constEnd(); it++) {
         QVariantList items;
-        items.append(p.color(QPalette::Active, it->first).name());
-        items.append(p.color(QPalette::Disabled, it->first).name());
-        items.append(p.color(QPalette::Inactive, it->first).name());
+        items.append(p.color(QPalette::Active, it->first).name(QColor::HexArgb));
+        items.append(p.color(QPalette::Disabled, it->first).name(QColor::HexArgb));
+        items.append(p.color(QPalette::Inactive, it->first).name(QColor::HexArgb));
         array.append(QVariant(items));
     }
     return array;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2531,10 +2531,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2748,7 +2748,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2752,7 +2752,7 @@ media file played</source>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2780,7 +2780,7 @@ media file played</translation>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2647,10 +2647,6 @@ archivo multimedia reproducido</translation>
         <translation>Color de la ventana</translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation>Fondo de la información</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2565,10 +2565,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2701,7 +2701,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2631,10 +2631,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2624,7 +2624,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2769,7 +2769,7 @@ media file played</source>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2508,10 +2508,6 @@ media file played</source>
         <translation>Vindusfarge</translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation>Info-bakgrunn</translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2519,10 +2519,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2559,10 +2559,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>HHHHHH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Info Background</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2728,7 +2728,7 @@ media file played</source>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2748,7 +2748,7 @@ media file played</source>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>Hhhhhh</translation>
+        <translation type="vanished">Hhhhhh</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2744,7 +2744,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2717,7 +2717,7 @@ media file played</source>
     </message>
     <message>
         <source>HHHHHH</source>
-        <translation>HHHHHH</translation>
+        <translation type="vanished">HHHHHH</translation>
     </message>
     <message>
         <source>Info Background</source>


### PR DESCRIPTION
Shows the alpha channel setting in the color picker. 255 means opaque, 0 fully transparent.
For the HTML color code shown in settings, the first two hexadecimal numbers are for the transparency: FF means opaque, 00 fully transparent.
The transparency defaults to opaque when not specified.

Fixes #492 (Transparent video preview tooltip background).
Fixes #747 (UI for subtitle style should allow transparency).