### PR TITLE
manager: Don't store current tracks selection if auto selected

### DIFF
--- a/src/manager.h
+++ b/src/manager.h
@@ -254,11 +254,11 @@ private:
     QStringList audioLangPref;
     QStringList subtitleLangPref;
     int64_t videoTrackSelected = -1;
-    QUuid videoTrackSelectedFor;
+    bool videoTrackIsUserSelected = false;
     int64_t audioTrackSelected = -1;
-    QUuid audioTrackSelectedFor;
+    bool audioTrackIsUserSelected = false;
     int64_t subtitleTrackSelected = -1;
-    QUuid subtitleTrackSelectedFor;
+    bool subtitleTrackIsUserSelected = false;
     int64_t subtitleTrackActive = 0;
     bool subtitleEnabled = true;
     bool subtitlesIgnoreEmbedded = false;


### PR DESCRIPTION
Don't store current tracks selection in recents if auto selected (regression introduced by
4483f67559c737cfb5277076618a21184f4a58da).
Also fixes it for favorites.

Fixes an other regression introduced by the same commit but for next/previous track commands: the auto selected track wasn't the one used as a starting point.

Fixes (and partially reverts): 4483f67559c737cfb5277076618a21184f4a58da ("Only use recents selected tracks if they are for the current file")