### PR TITLE
actioneditor: Add descriptive names for Previous & Next (Skip Backward & Forward)

### DIFF
--- a/src/widgets/actioneditor.cpp
+++ b/src/widgets/actioneditor.cpp
@@ -110,7 +110,9 @@ QString ActionEditor::getDescriptiveName(const QAction *action)
         { "actionResetMove",               tr("Reset Move") },
         { "actionRotateClockwise",         tr("Rotate Clockwise") },
         { "actionRotateCounterclockwise",  tr("Rotate Counterclockwise") },
-        { "actionResetRotate",             tr("Reset Rotate") }
+        { "actionResetRotate",             tr("Reset Rotate") },
+        { "actionNavigateChaptersPrevious",tr("Skip Backward / Previous") },
+        { "actionNavigateChaptersNext",    tr("Skip Forward / Next") }
     };
 
     QString actionDescription;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -144,6 +144,14 @@
         <translation>Zoom zurücksetzen</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -144,6 +144,14 @@
         <translation>Reset Zoom</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -132,6 +132,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -144,6 +144,14 @@
         <translation>Réinitialiser le zoom</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation>Raccourci déjà utilisé</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -132,6 +132,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -144,6 +144,14 @@
         <translation>ズームをリセット</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation>ショートカットは既に使用されています</translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -184,6 +184,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -144,6 +144,14 @@
         <translation>Resetar zoom</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -136,6 +136,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -136,6 +136,14 @@
         <translation>Yakınlaştırmayı Sıfırla</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -144,6 +144,14 @@
         <translation>重置缩放</translation>
     </message>
     <message>
+        <source>Skip Backward / Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Skip Forward / Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Shortcut already used</source>
         <translation>快捷键已使用</translation>
     </message>


### PR DESCRIPTION
Previous & Next are the same commands as the Skip Backward / Skip Forward buttons, so let's combine their names.

Fixes #695 (There's no keys for Skip Forward and Skip Backward).