### PR TITLE
mainwindow: Empty Quick Playlist when opening file with Quick Open File

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2448,7 +2448,7 @@ void MainWindow::on_actionFileOpenQuick_triggered()
     QList<QUrl> urls = doQuickOpenFileDialog();
     if (urls.isEmpty())
         return;
-    emit severalFilesOpened(urls);
+    emit severalFilesOpened(urls, true);
 }
 
 void MainWindow::on_actionFileOpen_triggered()


### PR DESCRIPTION
When the playlist panel is opened, that command is replaced by "Quick Add To Playlist" which works as expected.

But when it's not, the user probably doesn't want to append the file and play it right now. Instead, the intended behavior is probably to replace the current file with the new file. Like what the "Open File..." command does.

Most importantly, emptying the Quick Playlist also means that the "next file in folder" command keeps working.

Since 0471a87f84bfd85a99ad77a46205e21830add949, there's an option to append opened files to the playlist which restores the old behavior of that command.

Apart from the IPC and the HTTP server, the "Open Directory..." command is the only one which doesn't replace the content of the Quick Playlist when it calls `PlaybackManager::openSeveralFiles`.
We may want to change that behavior so that it appends to the current playlist when the playlist panel is opened, and switches to the Quick Playlist and empties it otherwise. That would work like "Quick Open File" / "Quick Add To Playlist" but for a full directory.