### PR TITLE
Fix cursor hiding issues in fullscreen

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -382,8 +382,14 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     if ((insideMpv || object == playlistWindow_) && event->type() == QEvent::MouseMove) {
         this->mouseMoveEvent(static_cast<QMouseEvent*>(event));
     }
-    if (object == ui->bottomArea && event->type() == QEvent::Leave)
-        this->leaveBottomArea();
+    if (object == ui->bottomArea) {
+        if (event->type() == QEvent::Leave) {
+            this->leaveBottomArea();
+            mpvObject_->setIsInBottomArea(false);
+        }
+        else if (event->type() == QEvent::Enter)
+            mpvObject_->setIsInBottomArea(true);
+    }
 
     if (event->type() == QEvent::ApplicationPaletteChange)
         positionSlider_->applicationPaletteChanged();

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -403,6 +403,11 @@ void MpvObject::setMouseHideTime(int msec)
         hideTimer->start();
 }
 
+void MpvObject::setIsInBottomArea(bool entered)
+{
+    isInBottomArea = entered;
+}
+
 void MpvObject::setLogoUrl(const QString &filename)
 {
     if (widget)
@@ -745,7 +750,7 @@ void MpvObject::showCursor()
 
 void MpvObject::hideCursor()
 {
-    if (!widget)
+    if (!widget || isInBottomArea)
         return;
     auto w = widget->self()->window();
     if (widget->self()->cursor() == Qt::ArrowCursor || w->isFullScreen()

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -63,6 +63,7 @@ public:
     void seek(double amount, bool exact);
     void screenshot(const QString &fileName, Helpers::ScreenshotRender render);
     void setMouseHideTime(int msec);
+    void setIsInBottomArea(bool entered);
     void setLogoUrl(const QString &filename);
     void setLogoBackground(const QColor &color);
     void setAudioFilters(const QList<QPair<QString, QString>> &filtersList);
@@ -219,6 +220,8 @@ private:
 
     bool sendMouseEvents = false;
     bool sendKeyEvents = false;
+
+    bool isInBottomArea = false;
 };
 
 class MpvWidgetInterface


### PR DESCRIPTION
* mpvwidget: Fix hiding cursor when switching to fullscreen on Wayland

> If the mouse cursor is over the controls or the window menus in windowed
> mode, it wouldn't get hidden after switching to fullscreen. So we need
> to use the window method to change the cursor.
> 
> It doesn't work around the kwin_wayland bug mentioned in
> https://github.com/mpc-qt/mpc-qt/commit/4cfd05c5978577d037c8a468f6f2a8b35a4873e8 though.
> 
> Also updates comment for https://github.com/mpc-qt/mpc-qt/commit/682eda2425ac19fd379b7a1a4ae7472cd5a8ad80.

* Don't hide mouse cursor when over controls (bottomArea) in fullscreen

> This isn't a Wayland-specific issue.