### PR TITLE
helpers: Fix custom icons path and add missing extension

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -740,8 +740,8 @@ void IconThemer::addIconData(const IconThemer::IconData &data)
 QIcon IconThemer::fetchIcon(const QString &name)
 {
     QDir customDir(customFolder_);
-    if (folderMode_ == CustomFolder && customDir.exists() && customDir.exists(name)) {
-        return QIcon(customFolder_ + name + ".svg");
+    if (folderMode_ == CustomFolder && customDir.exists() && customDir.exists(name + ".svg")) {
+        return QIcon(customDir.filePath(name + ".svg"));
     }
     QIcon icon;
     if (folderMode_ != SystemFolder) {


### PR DESCRIPTION
The icon name doesn't include the extension.
Without QDir::filePath(), the "/" or "\" isn't getting added between the dir path and the filename.

#803 (Import - export themes & colors? (Question and/or request))