### PR TITLE
mainwindow: Only hide/show step and subtitles buttons when playing

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2403,7 +2403,8 @@ void MainWindow::setVideoBitrate(double bitrate)
 void MainWindow::setIsVideo(bool isVideo)
 {
     isVideo_ = isVideo;
-    showStepAndSubsButtons(isVideo);
+    if (isPlaying)
+        showStepAndSubsButtons(isVideo);
 }
 
 void MainWindow::setVideoPreviewItem(QUrl itemUrl)


### PR DESCRIPTION
Otherwise, they would get hidden when stopping a video as mpv then reports no available video tracks.

Fixes: e67bd1d4889283a380de1a27511077183ad84168 ("mainwindow: Only show Step and subtitles buttons for videos")