### PR TITLE
drawnslider: Make seek bar, volume handles border and chapters brighter for dark themes

### DIFF
--- a/src/widgets/drawnslider.cpp
+++ b/src/widgets/drawnslider.cpp
@@ -148,8 +148,8 @@ void DrawnSlider::paintEvent(QPaintEvent *event)
             handleBorder = handleBorder.darker();
             markColor = markColor.darker();
         } else {
-            handleBorder = handleBorder.lighter();
-            markColor = markColor.lighter();
+            handleBorder = handleBorder.lighter(200);
+            markColor = markColor.lighter(200);
         }
     }
 


### PR DESCRIPTION
The seek bar handle is difficult to see when using a dark theme. The default 150 setting for QColor::lighter() doesn't seem enough.

Mentioned in:
#20 (With a dark system theme, everything looks great except the seek bar's seek handle)
#803 (Import - export themes & colors? (Question and/or request))