### PR TITLE
Update icons and colors on system theme or palette change

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -780,6 +780,11 @@ void IconThemer::setIconFolders(FolderMode folderMode, const QString &customFold
         updateButton(data);
 }
 
+void IconThemer::updateIcons()
+{
+    setIconFolders(folderMode_, customFolder_);
+}
+
 void IconThemer::updateButton(const IconData &data)
 {
     QString nameToUse = data.iconNormal;

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -90,6 +90,7 @@ public:
     QIcon fetchIcon(const QString &name);
     void updateButton(const IconData &data);
     void setIconFolders(IconThemer::FolderMode folderMode, const QString &customFolder);
+    void updateIcons();
 
 private:
     QList<IconData> iconDataList;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -376,6 +376,21 @@ void MainWindow::resizeEvent(QResizeEvent *event)
     resizePlaylistToFit();
 }
 
+void MainWindow::changeEvent(QEvent *event)
+{
+    if (event->type() == QEvent::ThemeChange || event->type() == QEvent::PaletteChange) {
+        positionSlider_->applicationPaletteChanged();
+        volumeSlider_->applicationPaletteChanged();
+        themer.updateIcons();
+        playlistWindow_->updateIcons();
+        ui->menubar->setStyle(ui->menubar->style());
+        if (tooltip)
+            tooltip->updatePalette();
+        if (videoPreview)
+            videoPreview->updatePalette();
+    }
+}
+
 bool MainWindow::eventFilter(QObject *object, QEvent *event)
 {
     bool insideMpv = mpvw ? object == mpvw : false;
@@ -390,9 +405,6 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
         else if (event->type() == QEvent::Enter)
             mpvObject_->setIsInBottomArea(true);
     }
-
-    if (event->type() == QEvent::ApplicationPaletteChange)
-        positionSlider_->applicationPaletteChanged();
 
     if (Platform::isWindows && event->type() == QEvent::KeyPress) {
         QKeyEvent *ke = static_cast<QKeyEvent*>(event);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -53,6 +53,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *event);
+    void changeEvent(QEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event);
     void closeEvent(QCloseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);

--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -295,6 +295,11 @@ void PlaylistWindow::tabsFromVList(const QVariantList &qvl)
     updatePlaylistHasItems();
 }
 
+void PlaylistWindow::updateIcons()
+{
+    themer.updateIcons();
+}
+
 bool PlaylistWindow::eventFilter(QObject *obj, QEvent *event)
 {
     Q_UNUSED(obj)

--- a/src/playlistwindow.h
+++ b/src/playlistwindow.h
@@ -47,6 +47,8 @@ public:
     QVariantList tabsToVList(bool saveQuickPlaylist) const;
     void tabsFromVList(const QVariantList &qvl);
 
+    void updateIcons();
+
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
     void dragEnterEvent(QDragEnterEvent *event);

--- a/src/widgets/tooltip.cpp
+++ b/src/widgets/tooltip.cpp
@@ -1,4 +1,4 @@
-#include <QToolTip>
+#include <QApplication>
 #include "tooltip.h"
 
 static constexpr char logModule[] =  "tooltip";
@@ -11,19 +11,7 @@ Tooltip::Tooltip(QWidget *parent) : QWidget(parent)
     textLabel->setAlignment(Qt::AlignCenter);
 
     textLabel->setAutoFillBackground(true);
-    QPalette tooltipPalette = QToolTip::palette();
-    QPalette customPalette = this->palette();
-    customPalette.setColor(QPalette::Window, tooltipPalette.color(QPalette::ToolTipBase));
-    customPalette.setColor(QPalette::WindowText, tooltipPalette.color(QPalette::ToolTipText));
-    textLabel->setPalette(customPalette);
-    textLabel->setStyleSheet(R"(
-        QLabel {
-            background-color: palette(Window);
-            color: palette(WindowText);
-            border: 1px solid palette(Light);
-            border-radius: 4px;
-        }
-    )");
+    updatePalette();
 
     hide();
     this->setVisible(false);
@@ -33,6 +21,22 @@ Tooltip::~Tooltip()
 {
     delete textLabel;
     textLabel = nullptr;
+}
+
+void Tooltip::updatePalette()
+{
+    QPalette palette = QApplication::palette();
+    QString css = QString(
+        "background-color: %1;"
+        "color: %2;"
+        "border: 1px solid %3;"
+        "border-radius: 4px;"
+    )
+    .arg(palette.color(QPalette::ToolTipBase).name(),
+        palette.color(QPalette::ToolTipText).name(),
+        palette.color(QPalette::Mid).name());
+
+    textLabel->setStyleSheet(css);
 }
 
 void Tooltip::show(const QString &text, const QPoint &where, int mainWindowWidth, const QString &textTemplate)

--- a/src/widgets/tooltip.h
+++ b/src/widgets/tooltip.h
@@ -7,6 +7,7 @@ class Tooltip : public QWidget {
     public:
         explicit Tooltip(QWidget *parent = nullptr);
         ~Tooltip();
+        void updatePalette();
         void show(const QString &text, const QPoint &where, int mainWindowWidth, const QString &textTemplate);
         void hide();
 

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -1,4 +1,4 @@
-#include <QToolTip>
+#include <QApplication>
 #include "videopreview.h"
 
 static constexpr char logModule[] =  "videopreview";
@@ -15,11 +15,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     textLabel->setAlignment(Qt::AlignCenter);
 
     textLabel->setAutoFillBackground(true);
-    QPalette tooltipPalette = QToolTip::palette();
-    QPalette customPalette = this->palette();
-    customPalette.setColor(QPalette::Window, tooltipPalette.color(QPalette::ToolTipBase));
-    customPalette.setColor(QPalette::WindowText, tooltipPalette.color(QPalette::ToolTipText));
-    textLabel->setPalette(customPalette);
+    updatePalette();
 
     emit mpv->ctrlSetOptionVariant("vo", "libmpv");
     emit mpv->ctrlSetOptionVariant("keep-open", true);
@@ -55,6 +51,14 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     mpv->urlOpen(fileUrl);
     mpv->setPaused(true);
     aspectRatioSet = false;
+}
+
+void VideoPreview::updatePalette()
+{
+    QPalette palette = QApplication::palette();
+    palette.setColor(QPalette::Window, palette.color(QPalette::ToolTipBase));
+    palette.setColor(QPalette::WindowText, palette.color(QPalette::ToolTipText));
+    textLabel->setPalette(palette);
 }
 
 void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -9,6 +9,7 @@ class VideoPreview : public QWidget {
         explicit VideoPreview(QWidget *parent = nullptr);
         ~VideoPreview();
         void openFile(const QUrl &fileUrl);
+        void updatePalette();
         void show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth);
         void hide();
         


### PR DESCRIPTION
The built-in icons were not getting updated.
Same thing for colors for drawnslider widget on system theme change and tooltip and videopreview widgets for both system theme and palette change.