### PR TITLE
Improve language override

### DIFF
--- a/src/favoriteswindow.cpp
+++ b/src/favoriteswindow.cpp
@@ -25,6 +25,11 @@ FavoritesWindow::~FavoritesWindow()
     delete ui;
 }
 
+void FavoritesWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void FavoritesWindow::setFiles(const QList<TrackInfo> &tracks)
 {
     fileList->setTracks(tracks);

--- a/src/favoriteswindow.h
+++ b/src/favoriteswindow.h
@@ -22,6 +22,7 @@ class FavoritesWindow : public QWidget
 public:
     explicit FavoritesWindow(QWidget *parent = nullptr);
     ~FavoritesWindow();
+    void updateLanguage();
 
 signals:
     void favoriteTracks(QList<TrackInfo> files, QList<TrackInfo> streams);

--- a/src/gotowindow.cpp
+++ b/src/gotowindow.cpp
@@ -23,6 +23,11 @@ GoToWindow::~GoToWindow()
     delete ui;
 }
 
+void GoToWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void GoToWindow::init(double currentTime, double maxTime, double fps)
 {
     maxTime_ = maxTime;

--- a/src/gotowindow.h
+++ b/src/gotowindow.h
@@ -14,6 +14,7 @@ class GoToWindow : public QWidget
 public:
     explicit GoToWindow(QWidget *parent = nullptr);
     ~GoToWindow();
+    void updateLanguage();
 
 signals:
     void goTo(double time);

--- a/src/librarywindow.cpp
+++ b/src/librarywindow.cpp
@@ -31,6 +31,11 @@ LibraryWindow::~LibraryWindow()
     delete ui;
 }
 
+void LibraryWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void LibraryWindow::refreshLibrary()
 {
     collectionWidget->repopulatePlaylists();

--- a/src/librarywindow.h
+++ b/src/librarywindow.h
@@ -20,6 +20,7 @@ class LibraryWindow : public QWidget
 public:
     explicit LibraryWindow(QWidget *parent = nullptr);
     ~LibraryWindow();
+    void updateLanguage();
 
 public slots:
     void refreshLibrary();

--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -29,6 +29,11 @@ LogWindow::~LogWindow()
     delete ui;
 }
 
+void LogWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void LogWindow::appendMessage(QString message)
 {
     ui->messages->appendPlainText(message);

--- a/src/logwindow.h
+++ b/src/logwindow.h
@@ -17,6 +17,7 @@ class LogWindow : public QWidget
 public:
     explicit LogWindow(QWidget *parent = nullptr);
     ~LogWindow();
+    void updateLanguage();
 
 signals:
     void windowClosed();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
     // Spin up the application
     Flow f;
     f.parseArgs();
-    f.setTranslation();
+    f.setTranslation(false);
     f.detectMode();
     if (f.earlyQuit())
         return 0;
@@ -445,12 +445,13 @@ void Flow::earlyPlatformOverride()
 }
 
 // Register the translations
-void Flow::setTranslation()
+void Flow::setTranslation(bool updateTranslations)
 {
     if (cliNoConfig)
         return;
     QLocale locale;
-    settings = storage.readVMap(fileSettings);
+    if (settings.empty())
+        settings = storage.readVMap(fileSettings);
     bool forceEnglish = settings.value("playerLanguageForceEnglish", false).toBool();
     if (forceEnglish)
         locale = QLocale("en");
@@ -460,6 +461,18 @@ void Flow::setTranslation()
 
     if (appTranslator.load(locale, "mpc-qt", "_", ":/i18n"))
         QApplication::installTranslator(&appTranslator);
+
+    if (updateTranslations) {
+        mainWindow->updateLanguage();
+        mainWindow->playlistWindow()->updateLanguage();
+        settingsWindow->updateLanguage();
+        propertiesWindow->updateLanguage();
+        favoritesWindow->updateLanguage();
+        gotoWindow->updateLanguage();
+        logWindow->updateLanguage();
+        libraryWindow->updateLanguage();
+        thumbnailerWindow->updateLanguage();
+    }
 }
 
 void Flow::readConfig()
@@ -1576,6 +1589,7 @@ void Flow::settingswindow_settingsData(const QVariantMap &settings)
     // The selected options have changed, so write them to disk
     this->settings = settings;
     writeConfig(true);
+    setTranslation(true);
     Logger::log(logModule, "settingswindow_settingsData");
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -39,7 +39,7 @@ public:
     void init();
     int run();
     bool earlyQuit();
-    void setTranslation();
+    void setTranslation(bool updateTranslations);
     static void earlyPlatformOverride();
     static bool isNvidiaGPU();
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -356,6 +356,11 @@ void MainWindow::setRemoveFileNotRecycle()
     ui->actionFileMoveToRecycleBin->setText(tr("Re&move File"));
 }
 
+void MainWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void MainWindow::resizePlaylistToFit()
 {
     if (ui->actionViewMusicMode->isChecked() && !playlistWindow_->isFloating()) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -50,6 +50,7 @@ public:
     void fixMpvwSize();
     void setActionPlayLoopUse();
     void setRemoveFileNotRecycle();
+    void updateLanguage();
 
 protected:
     void resizeEvent(QResizeEvent *event);

--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -300,6 +300,11 @@ void PlaylistWindow::updateIcons()
     themer.updateIcons();
 }
 
+void PlaylistWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 bool PlaylistWindow::eventFilter(QObject *obj, QEvent *event)
 {
     Q_UNUSED(obj)

--- a/src/playlistwindow.h
+++ b/src/playlistwindow.h
@@ -48,6 +48,7 @@ public:
     void tabsFromVList(const QVariantList &qvl);
 
     void updateIcons();
+    void updateLanguage();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);

--- a/src/propertieswindow.cpp
+++ b/src/propertieswindow.cpp
@@ -35,6 +35,11 @@ PropertiesWindow::~PropertiesWindow()
     delete ui;
 }
 
+void PropertiesWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void PropertiesWindow::setFileName(const QString &filename)
 {
     this->filename = filename;

--- a/src/propertieswindow.h
+++ b/src/propertieswindow.h
@@ -17,6 +17,7 @@ class PropertiesWindow : public QDialog
 public:
     explicit PropertiesWindow(QWidget *parent = nullptr);
     ~PropertiesWindow();
+    void updateLanguage();
 
 signals:
     void artistAndTitleChanged(QString artistAndTitle, QString filename);

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -381,6 +381,11 @@ void SettingsWindow::setWaylandOptions(bool isWayland, bool isWaylandMode)
     ui->tweaksPreferWayland->setEnabled(isWayland);
 }
 
+void SettingsWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void SettingsWindow::setupPageTree()
 {
     // Expand every item on pageTree

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -62,6 +62,7 @@ public:
     QVariantMap settings();
     QVariantMap keyMap();
     void setWaylandOptions(bool isWayland, bool isWaylandMode);
+    void updateLanguage();
 
 private:
     void setupPageTree();

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -280,9 +280,6 @@
            </item>
            <item row="1" column="0">
             <widget class="QGroupBox" name="playerLanguageBox">
-             <property name="toolTip">
-              <string>Requires restarting the application to apply changes</string>
-             </property>
              <property name="title">
               <string>Language Override</string>
              </property>

--- a/src/thumbnailerwindow.cpp
+++ b/src/thumbnailerwindow.cpp
@@ -48,6 +48,11 @@ ThumbnailerWindow::~ThumbnailerWindow()
     delete ui;
 }
 
+void ThumbnailerWindow::updateLanguage()
+{
+    ui->retranslateUi(this);
+}
+
 void ThumbnailerWindow::setScreenshotDirectory(QString folder)
 {
     screenshotDirectory = folder;

--- a/src/thumbnailerwindow.h
+++ b/src/thumbnailerwindow.h
@@ -21,6 +21,7 @@ class ThumbnailerWindow : public QWidget
 public:
     explicit ThumbnailerWindow(QWidget *parent = nullptr);
     ~ThumbnailerWindow();
+    void updateLanguage();
 
 public slots:
     void open(QUrl sourceUrl);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4224,10 +4224,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Search...</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4556,10 +4556,6 @@ arxiu multimèdia reproduït</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4536,10 +4536,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4593,7 +4593,7 @@ media file played</translation>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>Requires restarting the application to apply changes</translation>
+        <translation type="vanished">Requires restarting the application to apply changes</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4396,10 +4396,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4246,10 +4246,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4514,7 +4514,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>Le redémarrage de l&apos;application est nécessaire pour appliquer les changements</translation>
+        <translation type="vanished">Le redémarrage de l&apos;application est nécessaire pour appliquer les changements</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4336,10 +4336,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4332,10 +4332,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4582,7 +4582,7 @@ media file played</source>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>変更を適用するにはアプリケーションの再起動が必要です</translation>
+        <translation type="vanished">変更を適用するにはアプリケーションの再起動が必要です</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4001,10 +4001,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Append opened files to Quick Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4248,10 +4248,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4300,10 +4300,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Requires restarting the application to apply changes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>yt-dlp (web videos)</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4533,7 +4533,7 @@ media file played</source>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>Требуется перезапуск приложения для применения изменений</translation>
+        <translation type="vanished">Требуется перезапуск приложения для применения изменений</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4561,7 +4561,7 @@ media file played</source>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>மாற்றங்களைப் பயன்படுத்த விண்ணப்பத்தை மறுதொடக்கம் செய்ய வேண்டும்</translation>
+        <translation type="vanished">மாற்றங்களைப் பயன்படுத்த விண்ணப்பத்தை மறுதொடக்கம் செய்ய வேண்டும்</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4553,7 +4553,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>Değişikliklerin uygulanması için uygulamanın yeniden başlatılmasını gerektirir</translation>
+        <translation type="vanished">Değişikliklerin uygulanması için uygulamanın yeniden başlatılmasını gerektirir</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4458,7 +4458,7 @@ media file played</source>
     </message>
     <message>
         <source>Requires restarting the application to apply changes</source>
-        <translation>需要重启应用程序才能应用更改</translation>
+        <translation type="vanished">需要重启应用程序才能应用更改</translation>
     </message>
     <message>
         <source>yt-dlp (web videos)</source>


### PR DESCRIPTION
* Use a checkbox for language override to English in Player options

> Listing supported languages isn't very useful for most users (and
> translators) who most likely either want to use their locale or English.
> And since we don't plan to list all languages, keeping a combobox with
> two entries (locale and English) isn't great.
> 
> Users who forced English will need to enable that setting again.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/46ee182996fccd6ffbb706e7069236e1dbd50e9c.

* main: Don't load settings three times and ignore language setting with --no-config

> And move QTranslator objects to Flow.

* Apply language change immediately