### PR TITLE
screensaver: Add missing interactive argument

### DIFF
--- a/src/platform/screensaver_unix.cpp
+++ b/src/platform/screensaver_unix.cpp
@@ -99,7 +99,7 @@ void ScreenSaverUnix::hibernateSystem()
     if (!isInhibiting)
         return;
 
-    QDBusPendingCall async = dbusLogin.asyncCall("Hibernate");
+    QDBusPendingCall async = dbusLogin.asyncCall("Hibernate", false);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished,
@@ -111,7 +111,7 @@ void ScreenSaverUnix::suspendSystem()
     if (!isInhibiting)
         return;
 
-    QDBusPendingCall async = dbusLogin.asyncCall("Suspend");
+    QDBusPendingCall async = dbusLogin.asyncCall("Suspend", false);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished,
@@ -123,7 +123,7 @@ void ScreenSaverUnix::shutdownSystem()
     if (!isInhibiting)
         return;
 
-    QDBusPendingCall async = dbusLogin.asyncCall("PowerOff");
+    QDBusPendingCall async = dbusLogin.asyncCall("PowerOff", false);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(async, this);
 
     connect(watcher, &QDBusPendingCallWatcher::finished,


### PR DESCRIPTION
org.freedesktop.login1.Manager Hibernate, Suspend and PowerOff require an interactive argument. It is used to control whether polkit should interactively ask the user for authentication credentials if required. These methods don't work without it.

Link: https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html

#814 ("[Feature request] after playback shutdown")