### PR TITLE
windowmanager: Always try to restore mainwindow state

### DIFF
--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -94,8 +94,7 @@ void WindowManager::restoreAppWindow(MainWindow *window, const CliInfo &cliInfo)
     else
         window->show();
     window->raise();
-    if (data.contains(keyState))
-        window->setState(data[keyState].toMap());
+    window->setState(data[keyState].toMap());
 }
 
 void WindowManager::restoreDocks(QMainWindow *dockHost, QList<QDockWidget *> dockWidgets)


### PR DESCRIPTION
Otherwise, on first start when geometry_v2.json doesn't exist, the `defaultValue` of `map.value` isn't used in `MainWindow::setState`.

In particular, this means that the "High precision" mode of the status bar gets enabled on the first start - while that state isn't shown in the context menu, before getting disabled afterwards.

Fixes: 17f69913a025e292ced3f504a12f4ede5fb29b38 ("Support changing status time format by click and add remaining and percentage modes")