### PR TITLE
Restore key shortcuts when translating the interface and remove unneeded function call

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1282,7 +1282,6 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
 {
     Q_UNUSED(event)
     sendSignals();
-    setCustomMpvOptions();
     ui->keysSearchField->clear();
     ui->videoPreset->setCurrentIndex(0);
 }


### PR DESCRIPTION
* settingswindow: Restore key shortcuts when translating the interface

> retranslateUi() resets the key shortcuts from the ui files, so we need to restore the saved ones.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/11f9a573fb1237cd4c3bb5111a081707d77db19d ("Apply language change immediately")

* settingdwindow: Don't call setCustomMpvOptions when closing window

> Since https://github.com/mpc-qt/mpc-qt/commit/5b9df18e10c439524ca1ca63c92e0ea289c67439 we call sendSignals() when closing the settings window and it already calls setCustomMpvOptions().