### PR TITLE
Windows: Don't create start menu folder and show version in Windows Uninstall app

### DIFF
--- a/packaging/nsis/mpc-qt.nsi.in
+++ b/packaging/nsis/mpc-qt.nsi.in
@@ -211,7 +211,7 @@ Section "Install"
   IntOp $INSTALLED_SIZE $INSTALLED_SIZE + 367
 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
-                   "DisplayName" "MPC-QT"
+                   "DisplayName" "MPC-QT @VERSTR_WIN@"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
                    "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
@@ -223,13 +223,13 @@ Section "Install"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
                    "InstallLocation" "$INSTDIR"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
+                   "DisplayVersion" "@VERSTR_WIN@"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
                    "Publisher" "The MPC-QT developers"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
-                   "HelpLink" "https://github.com/mpc-qt/mpc-qt"
+                   "HelpLink" "https://mpc-qt.github.io/"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
                    "URLUpdateInfo" "https://github.com/mpc-qt/mpc-qt/releases"
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
-                   "URLInfoAbout" "https://mpc-qt.github.io/"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \
                    "DisplayIcon" "$INSTDIR\mpc-qt.exe"
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\MPC-QT" \


### PR DESCRIPTION
* packaging: Don't create start menu folder on Windows

> There's only one shortcut so a folder isn't needed.

* packaging: Add version information for Windows "Uninstall" app

> And remove URLInfoAbout and use its URL (amin website) for the HelpLink.
> The Windows Uninstaller app can only show two lines (in this case
> Version + one URL).