### PR TITLE
Reduce the size of buttons

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -130,7 +130,7 @@
               <number>6</number>
              </property>
              <property name="topMargin">
-              <number>3</number>
+              <number>0</number>
              </property>
              <property name="rightMargin">
               <number>6</number>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -123,6 +123,9 @@
           <item>
            <widget class="QWidget" name="controlbar" native="true">
             <layout class="QHBoxLayout" name="controlbarLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0">
+             <property name="spacing">
+              <number>2</number>
+             </property>
              <property name="leftMargin">
               <number>6</number>
              </property>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -148,6 +148,12 @@
                  <normalon>:/images/theme/black/media-playback-start.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="checkable">
                 <bool>true</bool>
                </property>
@@ -169,6 +175,12 @@
                  <normalon>:/images/theme/black/media-playback-pause.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="checkable">
                 <bool>true</bool>
                </property>
@@ -189,6 +201,12 @@
                 <iconset>
                  <normalon>:/images/theme/black/media-playback-stop.svg</normalon>
                 </iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="checkable">
                 <bool>true</bool>
@@ -219,7 +237,7 @@
                <property name="maximumSize">
                 <size>
                  <width>1</width>
-                 <height>40</height>
+                 <height>20</height>
                 </size>
                </property>
                <property name="orientation">
@@ -256,6 +274,12 @@
                  <normalon>:/images/theme/black/go-previous.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="flat">
                 <bool>true</bool>
                </property>
@@ -273,6 +297,12 @@
                 <iconset>
                  <normalon>:/images/theme/black/media-seek-backward.svg</normalon>
                 </iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="flat">
                 <bool>true</bool>
@@ -292,6 +322,12 @@
                  <normalon>:/images/theme/black/media-seek-forward.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="flat">
                 <bool>true</bool>
                </property>
@@ -309,6 +345,12 @@
                 <iconset>
                  <normalon>:/images/theme/black/go-next.svg</normalon>
                 </iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="flat">
                 <bool>true</bool>
@@ -336,7 +378,7 @@
                <property name="maximumSize">
                 <size>
                  <width>1</width>
-                 <height>40</height>
+                 <height>20</height>
                 </size>
                </property>
                <property name="orientation">
@@ -373,6 +415,12 @@
                  <normalon>:/images/theme/black/media-skip-backward.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="flat">
                 <bool>true</bool>
                </property>
@@ -396,6 +444,12 @@
                 <iconset>
                  <normalon>:/images/theme/black/media-skip-forward.svg</normalon>
                 </iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="flat">
                 <bool>true</bool>
@@ -423,7 +477,7 @@
                <property name="maximumSize">
                 <size>
                  <width>1</width>
-                 <height>40</height>
+                 <height>20</height>
                 </size>
                </property>
                <property name="orientation">
@@ -460,6 +514,12 @@
                  <normalon>:/images/theme/black/zone-in.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="flat">
                 <bool>true</bool>
                </property>
@@ -477,6 +537,12 @@
                 <iconset>
                  <normalon>:/images/theme/black/zone-out.svg</normalon>
                 </iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="flat">
                 <bool>true</bool>
@@ -509,6 +575,12 @@
                  <normalon>:/images/theme/black/view-media-subtitles.svg</normalon>
                 </iconset>
                </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
+               </property>
                <property name="checkable">
                 <bool>true</bool>
                </property>
@@ -526,6 +598,12 @@
                 <iconset>
                  <normaloff>:/images/theme/black/player-volume.svg</normaloff>
                  <normalon>:/images/theme/black/player-volume-muted.svg</normalon>:/images/theme/black/player-volume.svg</iconset>
+               </property>
+               <property name="iconSize">
+                <size>
+                 <width>12</width>
+                 <height>12</height>
+                </size>
                </property>
                <property name="checkable">
                 <bool>true</bool>

--- a/src/playlistwindow.ui
+++ b/src/playlistwindow.ui
@@ -105,6 +105,12 @@
            <normalon>:/images/theme/black/media-queue-visible.svg</normalon>
           </iconset>
          </property>
+         <property name="iconSize">
+          <size>
+           <width>12</width>
+           <height>12</height>
+          </size>
+         </property>
         </widget>
        </item>
       </layout>
@@ -122,6 +128,12 @@
           <normalon>:/images/theme/black/tab-new.svg</normalon>
          </iconset>
         </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
+        </property>
        </widget>
       </item>
       <item>
@@ -133,6 +145,12 @@
          <iconset>
           <normalon>:/images/theme/black/tab-close.svg</normalon>
          </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -146,6 +164,12 @@
           <normalon>:/images/theme/black/tab-duplicate.svg</normalon>
          </iconset>
         </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
+        </property>
        </widget>
       </item>
       <item>
@@ -158,6 +182,12 @@
           <normalon>:/images/theme/black/document-import.svg</normalon>
          </iconset>
         </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
+        </property>
        </widget>
       </item>
       <item>
@@ -169,6 +199,12 @@
          <iconset>
           <normalon>:/images/theme/black/document-export.svg</normalon>
          </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
         </property>
        </widget>
       </item>
@@ -184,6 +220,12 @@
          <iconset>
           <normalon>:/images/theme/black/view-media-queue.svg</normalon>
          </iconset>
+        </property>
+        <property name="iconSize">
+         <size>
+          <width>12</width>
+          <height>12</height>
+         </size>
         </property>
         <property name="checkable">
          <bool>true</bool>


### PR DESCRIPTION
* Reduce buttons size to 12px instead of default 16px

> And reduce controls vertical lines height to 20px.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/b7ec5c17cf1f68a9601651ad5a5fe12e5b59f2a8 which made the icons use all the available space in the buttons.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/820 ("[Suggestion] Smaller buttons and a little bit less space
> for control and seek bar").

* mainwindow: Reduce buttons spacing to 2px instead of default 6px

* mainwindow: Remove control bar top margin

> It improves the vertical centering of the controls between the the seek bar and the status bar.
> 
> It was only wasting useful space for the video, because the margin between the buttons and the seek bar is still larger than the margin between the buttons and the status bar.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/820 ("[Suggestion] Smaller buttons and a little bit less space for control and seek bar").