### PR TITLE
mainwindow: Only trigger window move after mouse move

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -455,8 +455,8 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (fullscreenMode_)
         checkBottomArea(event->globalPosition());
-    if (mousePressedInsideStatustime) {
-        mousePressedInsideStatustime = false;
+    if (mousePressedInBottomArea) {
+        mousePressedInBottomArea = false;
         QWindow *parentWindow = this->window()->windowHandle();
         parentWindow->startSystemMove();
     }
@@ -473,14 +473,9 @@ void MainWindow::mousePressEvent(QMouseEvent *event)
 {
     QPoint pos = event->globalPosition().toPoint();
     bool isInMpvw = mpvw ? insideWidget(pos, mpvw) : false;
-    bool isInBottomArea = ui->bottomArea->isVisible() ? insideWidget(pos, ui->bottomArea) : false;
-    mousePressedInsideStatustime = insideWidget(pos, statusTime);
+    mousePressedInBottomArea = ui->bottomArea->isVisible() ? insideWidget(pos, ui->bottomArea) : false;
     if (isInMpvw && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseDown)))
         event->accept();
-    else if (isInBottomArea && !mousePressedInsideStatustime)  {
-        QWindow *parentWindow = this->window()->windowHandle();
-        parentWindow->startSystemMove();
-    }
     else
         QMainWindow::mousePressEvent(event);
 }
@@ -498,7 +493,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QPoint pos = event->globalPosition().toPoint();
     bool ok = mpvw ? insideWidget(pos, mpvw) : false;
-    if (mousePressedInsideStatustime && insideWidget(pos, statusTime)) {
+    if (mousePressedInBottomArea && insideWidget(pos, statusTime)) {
         if (event->button() == Qt::MouseButton::LeftButton)
             setTimeRemainingMode(!timeRemainingMode);
     }
@@ -508,7 +503,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
         else
             QMainWindow::mouseReleaseEvent(event);
     }
-    mousePressedInsideStatustime = false;
+    mousePressedInBottomArea = false;
 }
 
 void MainWindow::wheelEvent(QWheelEvent *event)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -526,7 +526,7 @@ private:
     bool timeShortMode = true;
     bool timeRemainingMode = false;
     bool timePercentageMode = false;
-    bool mousePressedInsideStatustime = false;
+    bool mousePressedInBottomArea = false;
 
     QString previousOpenDir;
     QSize noVideoSize_ = QSize(500,270);


### PR DESCRIPTION
On Windows, (wrongly) initiating a window move before the mouse has actually moved prevents any enterEvent from being received until the user triggers an action to cancel that partially-initiated move.

Fixes: 029fe5b73917dd717b3d7c8b0bcd055730b374b4 ("Allow the window to be moved by dragging the bottom section")
Fixes #840 ("[Bug] Hover is not working on the seek bar in a certain case").