### PR TITLE
mainwindow: Don't start window move while in fullscreen

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -458,7 +458,7 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (fullscreenMode_)
         checkBottomArea(event->globalPosition());
-    if (mousePressedInBottomArea) {
+    else if (mousePressedInBottomArea) {
         mousePressedInBottomArea = false;
         QWindow *parentWindow = this->window()->windowHandle();
         parentWindow->startSystemMove();


### PR DESCRIPTION
Otherwise, the window can be moved from the bottom bar even while in fullscreen on Windows.

Fixes: 029fe5b73917dd717b3d7c8b0bcd055730b374b4 ("Allow the window to be moved by dragging the bottom section")
See #843 ("Feature request: Option to disable window dragging with left mouse button by toolbar or viewport")