### PR TITLE
mainwindow: Don't start playing on click in bottom area in fullscreen

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2442,7 +2442,7 @@ void MainWindow::libraryWindowClosed()
 
 void MainWindow::mpvObject_mouseReleased()
 {
-    if (!isPlaying) {
+    if (!isPlaying && !mousePressedInBottomArea) {
         emit playCurrentItemRequested();
         return;
     }
@@ -3161,7 +3161,8 @@ void MainWindow::on_actionViewOptions_triggered()
 
 void MainWindow::on_actionPlayPause_triggered()
 {
-    on_play_clicked();
+    if (!mousePressedInBottomArea)
+        on_play_clicked();
 }
 
 void MainWindow::on_actionPlayStop_triggered()


### PR DESCRIPTION
Fixes: e252ceeb07aad8aa47cbef9c6b3f6a3d5a71cdd5("Trigger Play from stopped state when clicking on mpvWidget")
Fixes: 5500c653344fbd56aee8fb1499488f8f7a8ff51f ("mainwindow: Make Play / Pause action trigger Play button")