### PR TITLE
Set default Volume Increase/Decrease shortcuts to Up/Down

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1652,7 +1652,7 @@
     <string>&amp;Increase</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Ctrl+Shift+Up</string>
+    <string notr="true">Up</string>
    </property>
   </action>
   <action name="actionPlayVolumeDown">
@@ -1660,7 +1660,7 @@
     <string>&amp;Decrease</string>
    </property>
    <property name="shortcut">
-    <string notr="true">Ctrl+Shift+Down</string>
+    <string notr="true">Down</string>
    </property>
   </action>
   <action name="actionPlayVolumeMute">

--- a/src/widgets/drawnplaylist.cpp
+++ b/src/widgets/drawnplaylist.cpp
@@ -344,7 +344,8 @@ bool DrawnPlaylist::event(QEvent *e)
         goto end;
     if (e->type() == QEvent::ShortcutOverride) {
         QKeyEvent *ke = static_cast<QKeyEvent*>(e);
-        if (ke->key() == Qt::Key_PageUp || ke->key() == Qt::Key_PageDown) {
+        if (ke->key() == Qt::Key_PageUp || ke->key() == Qt::Key_PageDown
+            || ke->key() == Qt::Key_Up || ke->key() == Qt::Key_Down) {
             e->accept();
             return true;
         }


### PR DESCRIPTION
The Up/Down keys are used by MPC-HC for Volume Increase/Decrease.

PageUp/PageDown were already being overridden, so this adds the Up/Down keys.
This means that these keys won't work as usual when a playlist has the focus and will instead move inside the playlist.

Fixes #831 ("arrow keys for volume").