### PR TITLE
Simplify subtitles settings and remove redundant options

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -369,7 +369,6 @@
     "subtitlePlacementX": 1,
     "subtitlePlacementY": 2,
     "subtitlesAssOverride": 0,
-    "subtitlesAutoloadExternal": true,
     "subtitlesAutoloadMatch": 0,
     "subtitlesAutoloadPath": "",
     "subtitlesClearOnSeek": false,

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1046,9 +1046,8 @@ void SettingsWindow::sendSignals()
     emit subsPreferDefaultForced(WIDGET_LOOKUP(ui->subtitlesPreferDefaultForced_v3).toBool());
     emit subsPreferExternal(WIDGET_LOOKUP(ui->subtitlesPreferExternal).toBool());
     emit subsIgnoreEmbeded(WIDGET_LOOKUP(ui->subtitlesIgnoreEmbedded).toBool());
-    bool subsAutoload = WIDGET_LOOKUP(ui->subtitlesAutoloadExternal).toBool();
     emit option("sub-filter-sdh", WIDGET_LOOKUP(ui->subtitlesRemoveSdh).toBool());
-    emit option("sub-auto", subsAutoload ? WIDGET_TO_TEXT(ui->subtitlesAutoloadMatch) : QString("no"));
+    emit option("sub-auto", WIDGET_TO_TEXT(ui->subtitlesAutoloadMatch));
     emit option("sub-file-paths", WIDGET_PLACEHOLD_LOOKUP(ui->subtitlesAutoloadPath).split(';'));
 
     emit screenshotDirectory(

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -6172,7 +6172,7 @@ media file played</string>
           <property name="enabled">
            <bool>true</bool>
           </property>
-          <layout class="QVBoxLayout" name="subtitlesPageLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,1">
+          <layout class="QVBoxLayout" name="subtitlesPageLayout" stretch="0,0,0,0,0,0,0,0,0,0,1">
            <item>
             <widget class="QCheckBox" name="subtitlesPreferDefaultForced_v3">
              <property name="text">
@@ -6197,16 +6197,6 @@ media file played</string>
             <widget class="QCheckBox" name="subtitlesIgnoreEmbedded">
              <property name="text">
               <string>Ignore embedded subtitles</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="subtitlesAutoloadExternal">
-             <property name="text">
-              <string>Automatically load external subtitles</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -8484,22 +8474,6 @@ media file played</string>
     <hint type="destinationlabel">
      <x>264</x>
      <y>84</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>subtitlesAutoloadExternal</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>subtitlesAutoloadBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>339</x>
-     <y>168</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>340</x>
-     <y>178</y>
     </hint>
    </hints>
   </connection>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -3556,10 +3556,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -3869,7 +3869,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Carregar subtítols externs automàticament</translation>
+        <translation type="vanished">Carregar subtítols externs automàticament</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -3871,7 +3871,7 @@ media file played</source>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Externe Untertitel automatisch laden</translation>
+        <translation type="vanished">Externe Untertitel automatisch laden</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -3901,7 +3901,7 @@ media file played</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Automatically load external subtitles</translation>
+        <translation type="vanished">Automatically load external subtitles</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -3749,7 +3749,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Cargar automáticamente subtítulos externos</translation>
+        <translation type="vanished">Cargar automáticamente subtítulos externos</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3566,10 +3566,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -3823,7 +3823,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Charger automatiquement les sous-titres externes</translation>
+        <translation type="vanished">Charger automatiquement les sous-titres externes</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -3695,7 +3695,7 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Muat otomatis subtitle eksternal</translation>
+        <translation type="vanished">Muat otomatis subtitle eksternal</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -3684,10 +3684,6 @@ ogni file multimediale riprodotto</translation>
         <translation>Preferisci tracce sottotitoli forzate e/o predefinite</translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation>Carica automaticamente dai percorsi</translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -3891,7 +3891,7 @@ media file played</source>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>外部字幕を自動的に読み込む</translation>
+        <translation type="vanished">外部字幕を自動的に読み込む</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -3525,10 +3525,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3544,10 +3544,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -3588,10 +3588,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Automatically load external subtitles</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Autoload paths</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -3845,7 +3845,7 @@ media file played</source>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Автоматически загружать внешние субтитры</translation>
+        <translation type="vanished">Автоматически загружать внешние субтитры</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -3869,7 +3869,7 @@ media file played</source>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>வெளிப்புற வசன வரிகள் தானாக ஏற்றவும்</translation>
+        <translation type="vanished">வெளிப்புற வசன வரிகள் தானாக ஏற்றவும்</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -3857,7 +3857,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>Dış altyazıları kendiliğinden yükle</translation>
+        <translation type="vanished">Dış altyazıları kendiliğinden yükle</translation>
     </message>
     <message>
         <source>Autoload paths</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -3803,7 +3803,7 @@ media file played</source>
     </message>
     <message>
         <source>Automatically load external subtitles</source>
-        <translation>自动加载外部字幕</translation>
+        <translation type="vanished">自动加载外部字幕</translation>
     </message>
     <message>
         <source>Autoload paths</source>


### PR DESCRIPTION
* settingswindow: Remove unimplemented duplicate subtitles settings

> Remove subtitlePlacementBox and subtitlesAssOverride which are already implemented by the combination of https://github.com/mpc-qt/mpc-qt/commit/18298432d9b5196c896935bd9a9f9f27d40f4057 and https://github.com/mpc-qt/mpc-qt/commit/cbb5bb423249657dd35bcb69835c25d6e705a6ce.

* settingswindow: Regroup subtitle settings from the Misc and Main pages

> They don't contain enough settings to require two pages.

* settingswindow: Always load external subtitles

>It seems likely that users would want to load external subtitles, so let's remove the "Automatically load external subtitles" option.
>Disabling the "Prefer external subtitles over embedded subtitles" option achieves essentially the same result.