### PR TITLE
videopreview: Use relative seeking to keyframes

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -28,6 +28,8 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
 
     connect(mpv, &MpvObject::aspectChanged,
             this, &VideoPreview::updateWidth);
+    connect(mpv, &MpvObject::playTimeChanged,
+            this, &VideoPreview::positionChanged);
 
     shouldBeShown = false;
     hide();
@@ -51,6 +53,10 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     mpv->urlOpen(fileUrl);
     mpv->setPaused(true);
     aspectRatioSet = false;
+    currentPosition = 0;
+    lastRequestedPosition = -1;
+    lastHoverDirection = Direction::None;
+    isSeeking = false;
 }
 
 void VideoPreview::updatePalette()
@@ -64,11 +70,40 @@ void VideoPreview::updatePalette()
 void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)
 {
     textLabel->setText(text);
-    mpv->setTime(videoPosition);
-    mpv->setPaused(true);
+    requestedPosition = videoPosition;
+    if (!isSeeking)
+        seek();
     videoWidget->update();
     setPreviewPosition(where, mainWindowWidth);
     show();
+}
+
+void VideoPreview::seek()
+{
+    if (requestedPosition == currentPosition)
+        return;
+
+    Direction hoverDirection = Direction::None;
+    if (lastRequestedPosition != -1) {
+        if (requestedPosition < lastRequestedPosition)
+            hoverDirection = Direction::Backward;
+        else if (requestedPosition > lastRequestedPosition)
+            hoverDirection = Direction::Forward;
+    } else {
+        if (requestedPosition < currentPosition)
+            hoverDirection = Direction::Backward;
+        else if (requestedPosition > currentPosition)
+            hoverDirection = Direction::Forward;
+    }
+    if (hoverDirection == lastHoverDirection &&
+        ((hoverDirection == Direction::Forward && currentPosition > requestedPosition) ||
+        (hoverDirection == Direction::Backward && currentPosition < requestedPosition)))
+        return;
+
+    lastHoverDirection = hoverDirection;
+    lastRequestedPosition = requestedPosition;
+    isSeeking = true;
+    mpv->seek(requestedPosition - currentPosition, false);
 }
 
 void VideoPreview::setPreviewPosition(const QPoint &where, int mainWindowWidth)
@@ -98,6 +133,12 @@ void VideoPreview::updateWidth(double newAspect)
         hide();
 }
 
+void VideoPreview::positionChanged(double position)
+{
+    currentPosition = position;
+    isSeeking = false;
+}
+
 void VideoPreview::show()
 {
     if (!aspectRatioSet) {
@@ -114,4 +155,7 @@ void VideoPreview::hide() {
     shouldBeShown = false;
     videoWidget->move(-50000, -50000);
     textLabel->move(-50000, -50000);
+    lastRequestedPosition = -1;
+    lastHoverDirection = Direction::None;
+    mpv->setTime(0);
 }

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -14,13 +14,21 @@ class VideoPreview : public QWidget {
         void hide();
         
     private:
+        void seek();
         void setPreviewPosition(const QPoint &where, int mainWindowWidth);
         void show();
         void updateWidth(double newAspect);
+        void positionChanged(double position);
 
         QLabel *textLabel;
         MpvObject *mpv = nullptr;
         MpvGlWidget *videoWidget = nullptr;
+        double currentPosition = 0;
+        double requestedPosition = 0;
+        double lastRequestedPosition = 0;
+        bool isSeeking = false;
+        enum class Direction { None, Backward, Forward };
+        Direction lastHoverDirection = Direction::None;
         bool aspectRatioSet = false;
         bool shouldBeShown = false;
         QPoint previewBottomLeft;


### PR DESCRIPTION
This is a much faster way to seek than with "time-pos". The first frame appears 3–5× faster, and subsequent frames can be even faster, especially on slower devices such as a NAS, with hard-to-decode media, or when quickly moving the mouse over the seek bar. This is also faster than absolute seeking.

However, we must ensure that we do not seek back and forth between keyframes.
To achieve this, we check whether the mouse cursor is still moving forward or backward and whether the last seek has already overtaken the requested position. If so, we skip the seek.

We also ensure that only one seek is performed at a time so that the seek range remains correct.

This also fixes a bug where the last frame shown would briefly reappear when reopening the video preview.
This is resolved by seeking back to the start of the file when hiding the video preview.