### PR TITLE
main: Fix restoring original style after disabling Fusion one

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1684,7 +1684,7 @@ void Flow::settingswindow_stylesheetIsFusion(bool yes)
         originalApplicationStyle = QApplication::style()->name();
     }
 
-    bool wasFusion = QApplication::style()->name() == "Fusion";
+    bool wasFusion = QApplication::style()->name() == "fusion";
     if (!yes && wasFusion)
         QApplication::setStyle(originalApplicationStyle);
     if (yes && !wasFusion)


### PR DESCRIPTION
The style names are lowercase, so comparing the style name with "Fusion" never matched and thus never restored the original one.

Fixes: 9ddf1a0a1da091e419bc92c1fce37ac540482643 ("main,settingswindow: remember old stylesheet name")