### PR TITLE
Add "Use dark colors" option

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -389,7 +389,7 @@ void MainWindow::changeEvent(QEvent *event)
         volumeSlider_->applicationPaletteChanged();
         themer.updateIcons();
         playlistWindow_->updateIcons();
-        ui->menubar->setStyle(ui->menubar->style());
+        updatePalette();
         if (tooltip)
             tooltip->updatePalette();
         if (videoPreview)
@@ -1014,6 +1014,13 @@ void MainWindow::setUiDecorationState(DecorationState state)
     }
 
     updateWindowFlags();
+}
+
+void MainWindow::updatePalette()
+{
+    QPalette palette = QApplication::palette();
+    palette.setColor(ui->menubar->backgroundRole(), palette.Window);
+    ui->menubar->setPalette(palette);
 }
 
 void MainWindow::setOSDPage(int page)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -99,6 +99,7 @@ private:
     void connectPlaylistWindowToActions() const;
     void globalizeAllActions();
     void setUiDecorationState(DecorationState state);
+    void updatePalette();
     void setOSDPage(int page);
     void setUiEnabledState(bool enabled);
     void setVolumeMuteState(bool checked, bool onInit);

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -731,8 +731,13 @@ void SettingsWindow::sendSignals()
                    WIDGET_LOOKUP(ui->interfaceIconsCustomFolder).toString());
     emit highContrastWidgets(WIDGET_LOOKUP(ui->interfaceWidgetHighContast).toBool());
     bool useCustomColors = WIDGET_LOOKUP(ui->interfaceWidgetCustom).toBool();
-    emit applicationPalette(useCustomColors ? paletteEditor->variantToPalette(WIDGET_LOOKUP(paletteEditor))
-                                         : paletteEditor->systemPalette());
+    bool useDarkColors = WIDGET_LOOKUP(ui->interfaceWidgetDark).toBool();
+    if (useDarkColors)
+        emit applicationPalette(paletteEditor->darkPalette());
+    else if (useCustomColors)
+        emit applicationPalette(paletteEditor->variantToPalette(WIDGET_LOOKUP(paletteEditor)));
+    else
+        emit applicationPalette(paletteEditor->systemPalette());
     emit videoColor(useCustomColors ? QString("#%1").arg(WIDGET_LOOKUP(ui->windowVideoValue).toString())
                                     : "000000");
     emit option("background-color", useCustomColors
@@ -743,7 +748,7 @@ void SettingsWindow::sendSignals()
     emit infoStatsColors(useCustomColors ? infoForegroundColor : "FFFFFF",
                          useCustomColors ? infoBackgroundColor : "000000");
 
-    emit stylesheetIsFusion(WIDGET_LOOKUP(ui->stylesheetFusion).toBool());
+    emit stylesheetIsFusion(WIDGET_LOOKUP(ui->stylesheetFusion).toBool() || useDarkColors);
     emit stylesheetText(WIDGET_LOOKUP(ui->stylesheetText).toString());
 
     emit webserverListening(WIDGET_LOOKUP(ui->webEnableServer).toBool());

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -687,6 +687,13 @@ media file played</string>
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="interfaceWidgetDark">
+                <property name="text">
+                 <string>Use dark colors</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="interfaceWidgetCustom">
                 <property name="text">
                  <string>Use custom colors</string>

--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -158,6 +158,71 @@ QPalette PaletteEditor::systemPalette()
     return system;
 }
 
+QPalette PaletteEditor::darkPalette()
+{
+    QPalette dark;
+
+    const QVector<QVector<QColor>> table {
+        { QColor("#fffcfcfc"), QColor("#ff686a6c"), QColor("#fffcfcfc") }, // WindowText
+        { QColor("#ff292c30"), QColor("#ff272a2e"), QColor("#ff292c30") }, // Button
+        { QColor("#ff40464c"), QColor("#ff3f454b"), QColor("#ff40464c") }, // Light
+        { QColor("#ff33383c"), QColor("#ff32363b"), QColor("#ff33383c") }, // Midlight
+        { QColor("#ff101112"), QColor("#ff0f1012"), QColor("#ff101112") }, // Dark
+        { QColor("#ff1c1e21"), QColor("#ff1a1d1f"), QColor("#ff1c1e21") }, // Mid
+        { QColor("#fffcfcfc"), QColor("#ff606263"), QColor("#fffcfcfc") }, // Text
+        { QColor("#ffffffff"), QColor("#ffffffff"), QColor("#ffffffff") }, // BrightText
+        { QColor("#fffcfcfc"), QColor("#ff6d6f72"), QColor("#fffcfcfc") }, // ButtonText
+        { QColor("#ff141618"), QColor("#ff131517"), QColor("#ff141618") }, // Base
+        { QColor("#ff202326"), QColor("#ff1f2124"), QColor("#ff202326") }, // Window
+        { QColor("#ff0b0c0d"), QColor("#ff0b0c0d"), QColor("#ff0b0c0d") }, // Shadow
+        { QColor("#ff1c84b6"), QColor("#ff1f2124"), QColor("#ff11394d") }, // Highlight
+        { QColor("#ff000000"), QColor("#ff686a6c"), QColor("#fffcfcfc") }, // HighlightedText
+        { QColor("#ff20b4fb"), QColor("#ff174a63"), QColor("#ff20b4fb") }, // Link
+        { QColor("#ff9b59b6"), QColor("#ff402b4c"), QColor("#ff9b59b6") }, // LinkVisited
+        { QColor("#ff1d1f22"), QColor("#ff1c1e20"), QColor("#ff1d1f22") }, // AlternateBase
+        { QColor("#ff000000"), QColor("#ff000000"), QColor("#ff000000") }, // NoRole
+        { QColor("#ff292c30"), QColor("#ff292c30"), QColor("#ff292c30") }, // ToolTipBase
+        { QColor("#fffcfcfc"), QColor("#fffcfcfc"), QColor("#fffcfcfc") }  // ToolTipText
+    };
+
+    const QVector<QPalette::ColorRole> roles {
+        QPalette::WindowText,
+        QPalette::Button,
+        QPalette::Light,
+        QPalette::Midlight,
+        QPalette::Dark,
+        QPalette::Mid,
+        QPalette::Text,
+        QPalette::BrightText,
+        QPalette::ButtonText,
+        QPalette::Base,
+        QPalette::Window,
+        QPalette::Shadow,
+        QPalette::Highlight,
+        QPalette::HighlightedText,
+        QPalette::Link,
+        QPalette::LinkVisited,
+        QPalette::AlternateBase,
+        QPalette::NoRole,
+        QPalette::ToolTipBase,
+        QPalette::ToolTipText
+    };
+
+    const QVector<QPalette::ColorGroup> groups {
+        QPalette::Active,
+        QPalette::Disabled,
+        QPalette::Inactive
+    };
+
+    for (int r = 0; r < roles.size(); ++r) {
+        for (int g = 0; g < groups.size(); ++g) {
+            dark.setColor(groups[g], roles[r], table[r][g]);
+        }
+    }
+
+    return dark;
+}
+
 QVariant PaletteEditor::variant()
 {
     QVariant v = paletteToVariant(selected);

--- a/src/widgets/paletteeditor.h
+++ b/src/widgets/paletteeditor.h
@@ -43,6 +43,7 @@ public:
     explicit PaletteEditor(QWidget *parent = nullptr);
     QPalette palette();
     QPalette systemPalette();
+    QPalette darkPalette();
 
     // custom variant et al routines are needed for json serialisation
     QVariant variant();

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4351,6 +4351,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4695,6 +4695,10 @@ arxiu multimèdia reproduït</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4677,6 +4677,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4731,6 +4731,10 @@ media file played</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4535,6 +4535,10 @@ archivo multimedia reproducido</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4337,6 +4337,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4657,6 +4657,10 @@ fichier média lu</translation>
         <source>Remember last window size and position</source>
         <translation>Se souvenir de la taille et de la position de la fenêtre</translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4477,6 +4477,10 @@ file media yang diputar</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4463,6 +4463,10 @@ ogni file multimediale riprodotto</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4725,6 +4725,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation>最後のウィンドウのサイズと位置を記憶する</translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4292,6 +4292,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4331,6 +4331,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4387,6 +4387,10 @@ arquivo de mídia reproduzido</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4675,6 +4675,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4705,6 +4705,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation>கடைசி சாளர அளவு மற்றும் நிலையை நினைவில் கொள்ளுங்கள்</translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4695,6 +4695,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Remember last window size and position</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4601,6 +4601,10 @@ media file played</source>
         <source>Remember last window size and position</source>
         <translation>记住上次窗口的大小和位置</translation>
     </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>


### PR DESCRIPTION
Based on "Breeze Dark" theme colors.

The Fusion style is required to apply the colors to the main menu bar on KDE, so it's automatically applied.
On GNOME and Windows, the Fusion style is already used or enabled by default.

Fixes #821 ("[Feature Request] Dark mode option").