### PR TITLE
Show screen make and model in Fullscreen settings screen selector

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -727,7 +727,10 @@ QString Helpers::screenToVisualName(const QScreen *s)
         QString y = QString("%1%2").arg(r.top() >= 0 ? "+" : "-", QString::number(std::abs(r.top())));
         return QString("%1 %2x%3%4%5").arg(s->name(), w, h, x, y);
     }
-    return s->name();
+    QString makeAndModel;
+    if (!s->manufacturer().isEmpty() && !s->model().isEmpty())
+        makeAndModel = QString(" (%1 %2)").arg(s->manufacturer(), s->model());
+    return s->name() + makeAndModel;
 }
 
 

--- a/src/widgets/screencombo.cpp
+++ b/src/widgets/screencombo.cpp
@@ -1,3 +1,4 @@
+#include <QAbstractItemView>
 #include <QApplication>
 #include <QScreen>
 #include "platform/unify.h"
@@ -11,6 +12,7 @@ ScreenCombo::ScreenCombo(QWidget *parent) : QComboBox(parent)
     populateItems();
     connect(qApp, &QApplication::screenAdded, this, &ScreenCombo::qApp_screensChanged);
     connect(qApp, &QApplication::screenRemoved, this, &ScreenCombo::qApp_screensChanged);
+    setSizeAdjustPolicy(QComboBox::AdjustToMinimumContentsLengthWithIcon);
 }
 
 QString ScreenCombo::currentScreenName()
@@ -30,6 +32,18 @@ void ScreenCombo::setCurrentScreenName(QString name)
         }
     }
     setCurrentIndex(0);
+}
+
+void ScreenCombo::showPopup()
+{
+    int width = this->width();
+
+    QFontMetrics fm(font());
+    for (int i = 0; i < count(); ++i) {
+        width = std::max(width, fm.horizontalAdvance(itemText(i)) + 20);
+    }
+    view()->setFixedWidth(width);
+    QComboBox::showPopup();
 }
 
 void ScreenCombo::qApp_screensChanged()

--- a/src/widgets/screencombo.h
+++ b/src/widgets/screencombo.h
@@ -10,6 +10,7 @@ public:
     explicit ScreenCombo(QWidget *parent);
     QString currentScreenName();
     void setCurrentScreenName(QString name);
+    void showPopup() override;
 
 private slots:
     void qApp_screensChanged();


### PR DESCRIPTION
On Windows, the make and model were already shown as Windows doesn't expose the output name.

We override `ScreenCombo::showPopup` to be able to show the full screen description in the popup while keeping the `QComboBox` small when collapsed.