### PR TITLE
main: Default to Wayland mode on first start

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,7 +434,7 @@ void Flow::earlyPlatformOverride()
         isWayland = true;
         Storage s;
         QVariantMap settings = s.readVMap(fileSettings);
-        if (!settings.value("tweaksPreferWayland", QVariant(false)).toBool())
+        if (!settings.value("tweaksPreferWayland", QVariant(true)).toBool())
             qputenv("QT_QPA_PLATFORM", "xcb");
         else if (!qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY"))
             isWaylandMode = true;


### PR DESCRIPTION
Since 4cfd05c5978577d037c8a468f6f2a8b35a4873e8 we run in Wayland mode by default, except on the first start because the config value doesn't exist yet.

Fixes: 4cfd05c5978577d037c8a468f6f2a8b35a4873e8 ("settingswindow: Use Wayland mode by default on Wayland")