### PR TITLE
Observe "idle-active" instead of deprecated MPV_EVENT_IDLE

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -990,8 +990,13 @@ void PlaybackManager::mpvw_pausedChanged(bool yes)
     emit stateChanged(playbackState_);
 }
 
-void PlaybackManager::mpvw_playbackIdling()
+void PlaybackManager::mpvw_playbackIdling(bool yes)
 {
+    // Received when the player has no more files to play and is in an idle state
+    if (!yes)
+        return;
+
+    Logger::log(logModule, "idling");
     if (nowPlayingItem.isNull()) {
         nowPlaying_.clear();
         playbackState_ = StoppedState;

--- a/src/manager.h
+++ b/src/manager.h
@@ -203,7 +203,7 @@ private slots:
     void mpvw_playbackLoading();
     void mpvw_playbackStarted();
     void mpvw_pausedChanged(bool yes);
-    void mpvw_playbackIdling();
+    void mpvw_playbackIdling(bool yes);
     void mpvw_playbackFinished();
     void mpvw_eofReachedChanged(QString eof);
     void mpvw_mediaTitleChanged(QString title);

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -45,6 +45,7 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("seekable", seekableChanged, toBool, false),
     HANDLE_PROP("pause", pausedChanged, toBool, true),
     HANDLE_PROP("eof-reached", eofReachedChanged, toString, QString()),
+    HANDLE_PROP("idle-active", playbackIdling, toBool, false),
     HANDLE_PROP("media-title", mediaTitleChanged, toString, QString()),
     HANDLE_PROP("chapter", self_chapterChanged, toDouble, 0.0),
     HANDLE_PROP("chapter-metadata/title", chapterTitleChanged, toString, QString()),
@@ -151,6 +152,7 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "time-pos", 0, MPV_FORMAT_DOUBLE },
         { "pause", 0, MPV_FORMAT_FLAG },
         { "eof-reached", 0, MPV_FORMAT_FLAG },
+        { "idle-active", 0, MPV_FORMAT_FLAG },
         { "video-params/aspect", 0, MPV_FORMAT_DOUBLE },
         { "video-params/aspect-name", 0, MPV_FORMAT_STRING },
         { "media-title", 0, MPV_FORMAT_STRING },
@@ -820,13 +822,6 @@ void MpvObject::ctrl_unhandledMpvEvent(int eventLevel)
         if (debugMessages)
             Logger::log(logModule, "end file");
         emit playbackFinished();
-        break;
-    }
-    // Received when the player has no more files to play and is in an idle state
-    case MPV_EVENT_IDLE: {
-        if (debugMessages)
-            Logger::log(logModule, "idling");
-        emit playbackIdling();
         break;
     }
     case MPV_EVENT_SHUTDOWN: {

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -134,7 +134,7 @@ signals:
     void pausedChanged(bool yes);
     void eofReachedChanged(QString eof);
     void playbackFinished();
-    void playbackIdling();
+    void playbackIdling(bool yes);
     void mediaTitleChanged(QString title);
     void metaDataChanged(QVariantMap metadata);
     void chapterTitleChanged(QString title);


### PR DESCRIPTION
MPV_EVENT_IDLE is deprecated since mpv 0.33 in 2020.

Link: https://github.com/mpv-player/mpv/commit/26ac6ead911bedf01b20d52e0696f70459ff0be2