### PR TITLE
manager: Show track language script when non standard

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -58,11 +58,10 @@ QString TrackData::formatted(const QString &nowPlayingTitle)
     QString output;
     output.append(QString("%1: ").arg(trackId));
     if (!lang.isEmpty()) {
-#if QT_VERSION < QT_VERSION_CHECK(6,3,0)
-        QString langName = QLocale::languageToString(QLocale(lang).language());
-#else
-        QString langName = QLocale::languageToString(QLocale::codeToLanguage(lang, QLocale::AnyLanguageCode));
-#endif
+        QLocale locale = QLocale(lang);
+        QString langName = QLocale::languageToString(locale.language());
+        if (locale.script() != QLocale(locale.language()).script())
+            langName.append(QString(" (%1)").arg(QLocale::scriptToString(locale.script())));
         output.append(QString("%1 ").arg(langName));
         output.append(QString("[%1] ").arg(lang));
     }


### PR DESCRIPTION
Shows the language script of the tracks when it's not the default one for the language.

For instance for [en], "English" will be shown.
However, for [sr-Latn], "Serbian (Latin)" will be shown. Though for [sr-Cyrl], "Serbian" will be shown.
Likewise, for [zh-Hant] and [zh-TW], "Chinese (Traditional Han)" will be shown. Though for [zh] and [zh-CN] and even [zh-Hans], "Chinese" will be shown.

`QLocale::codeToLanguage` doesn't work for language codes with script.

Fixes #873 ("Support for BCP 47 language tags").