### PR TITLE
manager: Restart tracks auto selection unless user-selected

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -764,8 +764,8 @@ void PlaybackManager::selectDesiredTracks()
                     if (isSubs && it.value().isForced)
                         lastGoodTrack = it.key();
                     else{
-                        Logger::log(logModule,
-                                    "lang track auto selected: " + QString::number(it.key()));
+                        Logger::log(logModule, QString(isSubs ? "subs" : "audio") +
+                                    " lang track auto selected: " + QString::number(it.key()));
                         return it.key();
                     }
                 }
@@ -774,9 +774,13 @@ void PlaybackManager::selectDesiredTracks()
                     "lastGoodTrack track auto selected: " + QString::number(lastGoodTrack));
         return lastGoodTrack;
     };
-    int64_t videoId = videoTrackSelected;
-    int64_t audioId = audioTrackSelected;
-    int64_t subsId = subtitleTrackSelected;
+    int64_t videoId = videoTrackIsUserSelected ? videoTrackSelected : -1;
+    int64_t audioId = audioTrackIsUserSelected ? audioTrackSelected : -1;
+    int64_t subsId = subtitleTrackIsUserSelected ? subtitleTrackSelected : -1;
+
+    Logger::log(logModule, "videoId: " + QString::number(videoId));
+    Logger::log(logModule, "audioId: " + QString::number(audioId));
+    Logger::log(logModule, "subsId: " + QString::number(subsId));
 
     if (audioId < 0)
         audioId = findTrackByLangPreference(audioLangPref, audioListData, false);


### PR DESCRIPTION
When auto selecting tracks, we must not reuse previously auto selected tracks.
We have to restart the auto selection based on all the available tracks at the moment unless the tracks have been selected by the user.

This is important because selectDesiredTracks is called more than once even for the same kind of tracks (e.g. subtitles).

Fixes: 8d90b2edaf27f6edd0dd8933bf677c9222070797 ("manager: Don't store current tracks selection if auto selected")

Fixes #869 ("Incorrect default audio & subtitle track selection").