### PR TITLE
Fix visual glitches and animation when exiting from fullscreen in Wayland mode

### DIFF
--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -161,7 +161,9 @@ FullscreenMemory WindowManager::makeFullscreen(QWidget *who, QString preferredSc
 void WindowManager::restoreFullscreen(QWidget *who, const FullscreenMemory &fm)
 {
     who->showNormal();
-    who->setGeometry(fm.normalGeometry);
+    QMetaObject::invokeMethod(who, [who, fm]() {
+        who->setGeometry(fm.normalGeometry);
+    }, Qt::SingleShotConnection);
 
     QScreen *target = Helpers::findScreenByName(fm.originalScreen);
     if (target) {


### PR DESCRIPTION
Fixes two problems when exiting fullscreen in Wayland mode:
- visual glitches
- with the KDE Plasma fullscreen "stretch" effect, the window was shown gliding from the top left corner to its original position.

Tested on Windows 10, Mint Cinnamon and Fedora GNOME with no side effects.