### PR TITLE
Don't start window move until the mouse has moved enough

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -458,7 +458,9 @@ void MainWindow::mouseMoveEvent(QMouseEvent *event)
 {
     if (fullscreenMode_)
         checkBottomArea(event->globalPosition());
-    else if (mousePressedInBottomArea) {
+    else if (mousePressedInBottomArea &&
+             (event->globalPosition().toPoint() - mousePressPosition).manhattanLength()
+             > QApplication::startDragDistance()) {
         mousePressedInBottomArea = false;
         QWindow *parentWindow = this->window()->windowHandle();
         parentWindow->startSystemMove();
@@ -474,9 +476,10 @@ static bool insideWidget(QPoint p, QWidget const *widget) {
 
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
-    QPoint pos = event->globalPosition().toPoint();
-    bool isInMpvw = mpvw ? insideWidget(pos, mpvw) : false;
-    mousePressedInBottomArea = ui->bottomArea->isVisible() ? insideWidget(pos, ui->bottomArea) : false;
+    mousePressPosition = event->globalPosition().toPoint();
+    bool isInMpvw = mpvw ? insideWidget(mousePressPosition, mpvw) : false;
+    mousePressedInBottomArea = ui->bottomArea->isVisible() ?
+        insideWidget(mousePressPosition, ui->bottomArea) : false;
     if (isInMpvw && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseDown)))
         event->accept();
     else

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -533,6 +533,7 @@ private:
     bool timeRemainingMode = false;
     bool timePercentageMode = false;
     bool mousePressedInBottomArea = false;
+    QPoint mousePressPosition;
 
     QString previousOpenDir;
     QSize noVideoSize_ = QSize(500,270);

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -3,6 +3,7 @@
 
 #include <QLayout>
 #include <QMainWindow>
+#include <QApplication>
 #include <QGuiApplication>
 #include <QThread>
 #include <QTimer>
@@ -1128,8 +1129,10 @@ void MpvGlWidget::mouseMoveEvent(QMouseEvent *event)
 
         if (e == 0) {
             setCursor(Qt::ArrowCursor);
-            if (!windowDragging && event->buttons().testAnyFlag(Qt::LeftButton)
-                && event->position() != mousePressPosition) {
+            if (!windowDragging
+                && event->buttons().testAnyFlag(Qt::LeftButton)
+                && (event->position() - mousePressPosition).manhattanLength()
+                    > QApplication::startDragDistance()) {
                 QWindow *parentWindow = this->window()->windowHandle();
                 parentWindow->startSystemMove();
                 windowDragging = true;


### PR DESCRIPTION
Instead of triggering the move immediately, wait until the pointer has moved at least `QApplication::startDragDistance()` pixels (usually 25 pixels).
mpv uses 10 pixels and MPC-HC 30 pixels.

This avoids interfering with the play/pause action if the pointer isn't perfectly still during the click.

It also makes it less likely to unintentionally move the window when clicking quickly over the seekbar.

Fixes #758 ("Click to un/pause not always detected").