### PR TITLE
settingswindow: Use default mpv OSD font size

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -409,7 +409,7 @@
     "tweaksOpenNextFile": true,
     "tweaksOsdFont": "Segoe UI",
     "tweaksOsdFontChkBox": false,
-    "tweaksOsdSize": 55,
+    "tweaksOsdSize": 30,
     "tweaksOsdTimerOnSeek": false,
     "tweaksPreferWayland": false,
     "tweaksSeekFramedrop": false,

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1091,7 +1091,7 @@ void SettingsWindow::sendSignals()
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);
     emit osdTimerOnSeek(WIDGET_LOOKUP(ui->tweaksOsdTimerOnSeek).toBool());
     emit option("osd-font", WIDGET_LOOKUP(ui->tweaksOsdFontChkBox).toBool() ? WIDGET_LOOKUP(ui->tweaksOsdFont).toString() : "");
-    emit option("osd-font-size", WIDGET_LOOKUP(ui->tweaksOsdFontChkBox).toBool() ? WIDGET_LOOKUP(ui->tweaksOsdSize).toInt() : 55);
+    emit option("osd-font-size", WIDGET_LOOKUP(ui->tweaksOsdFontChkBox).toBool() ? WIDGET_LOOKUP(ui->tweaksOsdSize).toInt() : 30);
     emit option("brightness", WIDGET_LOOKUP(ui->miscBrightness).toInt());
     emit option("contrast", WIDGET_LOOKUP(ui->miscContrast).toInt());
     emit option("gamma", WIDGET_LOOKUP(ui->miscGamma).toInt());

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7858,7 +7858,7 @@ media file played</string>
                 <number>9000</number>
                </property>
                <property name="value">
-                <number>55</number>
+                <number>30</number>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
The default OSD font size of mpv is 30, so let's use that as well instead of 55.

Mentioned in #21.