### PR TITLE
settingswindow: Use dark colors if a dark colors system theme is detected

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -4,6 +4,7 @@
 #include <QFileInfo>
 #include <QFileDialog>
 #include <QColorDialog>
+#include <QStyleHints>
 #include <QToolTip>
 #include "logger.h"
 #include "platform/unify.h"
@@ -733,10 +734,11 @@ void SettingsWindow::sendSignals()
     emit highContrastWidgets(WIDGET_LOOKUP(ui->interfaceWidgetHighContast).toBool());
     bool useCustomColors = WIDGET_LOOKUP(ui->interfaceWidgetCustom).toBool();
     bool useDarkColors = WIDGET_LOOKUP(ui->interfaceWidgetDark).toBool();
-    if (useDarkColors)
-        emit applicationPalette(paletteEditor->darkPalette());
-    else if (useCustomColors)
+    if (useCustomColors)
         emit applicationPalette(paletteEditor->variantToPalette(WIDGET_LOOKUP(paletteEditor)));
+    // REMOVEME: Apply a dark palette manually because Qt doesn't propagate it
+    else if (useDarkColors || QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)
+        emit applicationPalette(paletteEditor->darkPalette());
     else
         emit applicationPalette(paletteEditor->systemPalette());
     emit videoColor(useCustomColors ? QString("#%1").arg(WIDGET_LOOKUP(ui->windowVideoValue).toString())


### PR DESCRIPTION
Even though Qt doesn't automatically apply a dark color scheme on GNOME-based desktops (maybe QTBUG-130385), it's still possible to detect it. We can then apply our own dark colors.

Both the Qt 6.8.3-based AppImage and the Qt 6.10.2-based Flatpak version detect the dark theme on Fedora GNOME.

The AppImage still can't detect the dark theme on Mint Cinnamon, but the dark theme can be enabled manually and the checkboxes are correctly rendered with it. The Flatpak version does detect it.

Follow-up to 83267497fb25ff8e8e7f95515050305f06c8ffe6 ("Add "Use dark colors" option");
Fixes #850 ("Tickboxes are barely visible (Linux)").