### PR TITLE
Make "Previous" seek to beginning of current chapter if not beyond 5 seconds

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -328,9 +328,8 @@ void PlaybackManager::navigateToNextChapter()
 
 void PlaybackManager::navigateToPrevChapter()
 {
-    int64_t chapter = mpvObject_->chapter();
-    if (chapter > 0)
-        navigateToChapter(std::max(int64_t(0), chapter - 1));
+    if (mpvTime > 5)
+        changeChapter(-1);
     else
         playPrev(false);
 }
@@ -400,6 +399,11 @@ void PlaybackManager::repeatThisFile()
 void PlaybackManager::deltaExtraPlaytimes(int delta)
 {
     playlistWindow_->deltaExtraPlayTimes(nowPlayingList, nowPlayingItem, delta);
+}
+
+void PlaybackManager::changeChapter(int64_t diff)
+{
+    mpvObject_->changeChapter(diff);
 }
 
 void PlaybackManager::navigateToChapter(int64_t chapter)

--- a/src/manager.h
+++ b/src/manager.h
@@ -134,6 +134,7 @@ public slots:
     void closingPlaylist(QUuid playlist);
     void repeatThisFile();
     void deltaExtraPlaytimes(int delta);
+    void changeChapter(int64_t diff);
     void navigateToChapter(int64_t chapter);
     void navigateToTime(double time);
     void speedUp();

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -537,6 +537,11 @@ int64_t MpvObject::chapter()
     return chapter_;
 }
 
+void MpvObject::changeChapter(int diff)
+{
+    emit ctrlCommand(QStringList({"add", "chapter", QString::number(diff)}));
+}
+
 bool MpvObject::setChapter(int64_t chapter)
 {
     // As this requires knowledge of mpv's return value, it cannot be

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -86,6 +86,7 @@ public:
     void setVideoFlip(bool flip);
 
     int64_t chapter();
+    void changeChapter(int diff);
     bool setChapter(int64_t chapter);
     QString mediaTitle();
     void setMute(bool yes);


### PR DESCRIPTION
When using the "seek to previous chapter" command, both MPC-HC and mpv have the following behavior:
- if more than 5 seconds have passed since the chapter start, seek to the beginning of the current chapter
- otherwise, seek to the previous chapter.

Since our "Previous" command can also open the previous file, we can't just use the mpv command.

We could check the "chapter-seek-threshold" property instead of using the default mpv value. But it would make more sense to have an "advanced" option that, though MPC-HC doesn't seem to have one.

Fixes #855 ("In a MKV with chapters, Prev does not behave as in mpc-hc or desirably").