### PR TITLE
settingswindow: Mark AV1 and VP8 names as not translatable

### DIFF
--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -5480,7 +5480,7 @@ media file played</string>
                   <item>
                    <widget class="QCheckBox" name="hwdecVp8">
                     <property name="text">
-                     <string>VP8</string>
+                     <string notr="true">VP8</string>
                     </property>
                     <property name="checked">
                      <bool>true</bool>
@@ -5500,7 +5500,7 @@ media file played</string>
                   <item>
                    <widget class="QCheckBox" name="hwdecAv1">
                     <property name="text">
-                     <string>AV1</string>
+                     <string notr="true">AV1</string>
                     </property>
                     <property name="checked">
                      <bool>true</bool>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4375,14 +4375,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4719,14 +4719,6 @@ arxiu multimèdia reproduït</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4701,14 +4701,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4755,14 +4755,6 @@ media file played</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4559,14 +4559,6 @@ archivo multimedia reproducido</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4361,14 +4361,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4683,11 +4683,11 @@ fichier média lu</translation>
     </message>
     <message>
         <source>AV1</source>
-        <translation>AV1</translation>
+        <translation type="vanished">AV1</translation>
     </message>
     <message>
         <source>VP8</source>
-        <translation>VP8</translation>
+        <translation type="vanished">VP8</translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4501,14 +4501,6 @@ file media yang diputar</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4487,14 +4487,6 @@ ogni file multimediale riprodotto</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4751,11 +4751,11 @@ media file played</source>
     </message>
     <message>
         <source>AV1</source>
-        <translation>AV1</translation>
+        <translation type="vanished">AV1</translation>
     </message>
     <message>
         <source>VP8</source>
-        <translation>VP8</translation>
+        <translation type="vanished">VP8</translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4752,14 +4752,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4316,14 +4316,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4355,14 +4355,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4639,14 +4639,6 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4411,14 +4411,6 @@ arquivo de mídia reproduzido</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4699,14 +4699,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4729,14 +4729,6 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4721,14 +4721,6 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4503,14 +4503,6 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>VP8</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>AV1</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4627,11 +4627,11 @@ media file played</source>
     </message>
     <message>
         <source>AV1</source>
-        <translation>AV1</translation>
+        <translation type="vanished">AV1</translation>
     </message>
     <message>
         <source>VP8</source>
-        <translation>VP8</translation>
+        <translation type="vanished">VP8</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixes: 10f0a1089f147c5f479db46e949db0dcd80d69d8 ("settingswindow: Use mpv defaults for enabled hardware codecs; add AV1 and VP8")