### PR TITLE
Fix stacktrace outputing to log file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_subdirectory(src)
 target_include_directories(mpc-qt PRIVATE ${CMAKE_BINARY_DIR})
 if (Boost_FOUND)
     target_include_directories(mpc-qt PRIVATE ${Boost_INCLUDE_DIRS})
+    target_compile_definitions(mpc-qt PRIVATE HAVE_BOOST)
 endif()
 
 file(GLOB TS_FILES "${PROJECT_SOURCE_DIR}/translations/*.ts")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 }
 
 void signalHandler(int signal) {
-    if (signal == SIGSEGV || SIGABRT) {
+    if (signal == SIGSEGV || signal == SIGTERM || signal == SIGABRT) {
         std::ostringstream stacktrace;
 #ifdef HAVE_BOOST
         stacktrace << boost::stacktrace::stacktrace();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 #include <QStyleFactory>
 #include <QLockFile>
 #include <QThread>
-#ifdef Boost_FOUND
+#ifdef HAVE_BOOST
 #include <boost/stacktrace.hpp>
 #endif
 #include "logger.h"
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 void signalHandler(int signal) {
     if (signal == SIGSEGV || SIGABRT) {
         std::ostringstream stacktrace;
-#ifdef Boost_FOUND
+#ifdef HAVE_BOOST
         stacktrace << boost::stacktrace::stacktrace();
         Logger::log(logModule, "Stack trace:");
         Logger::log(logModule, QString::fromStdString(stacktrace.str()));


### PR DESCRIPTION
* Add preprocessor macro for Boost

> Boost_FOUND is a CMake variable, not a preprocessor macro, so Boost was never used to get a stacktrace since https://github.com/mpc-qt/mpc-qt/commit/dc7aea2b4ee7fce0a33d84e346ee08bb4a467629.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/dc7aea2b4ee7fce0a33d84e346ee08bb4a467629 ("Make Boost optional to build")

* main: Fix signal checking and output stacktrace with SIGTERM

> Because of a syntax error, all handled signals were leading to a stacktrace.
> So SIGTERM now needs to actually be checked to output a stacktrace for it too.
> 
> While https://github.com/mpc-qt/mpc-qt/commit/b2e2f9d5f1782250f21ddfe6002e3876788c3b13 mentioned "Killing the app", that meant with killall which sends a SIGTERM signal by default.
> The SIGKILL signal can't be intercepted by an application.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/commit/b2e2f9d5f1782250f21ddfe6002e3876788c3b13 ("Output stacktrace in log and handle SIGABRT")