### PR TITLE
Use custom slider widget for audio balance and color controls settings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(SOURCES
     storage.cpp storage.h
     thumbnailerwindow.cpp thumbnailerwindow.h thumbnailerwindow.ui
     widgets/actioneditor.cpp widgets/actioneditor.h
+    widgets/plainslider.cpp widgets/plainslider.h
     widgets/drawncollection.cpp widgets/drawncollection.h
     widgets/drawnplaylist.cpp widgets/drawnplaylist.h
     widgets/drawnslider.cpp widgets/drawnslider.h
@@ -42,6 +43,10 @@ set(SOURCES
 )
 
 qt_add_executable(mpc-qt WIN32 MACOSX_BUNDLE ${SOURCES})
+
+target_include_directories(mpc-qt PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/widgets
+)
 
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.7.0)
     # Starting with Qt 6.7, this can be used to exclude some files from lupdate

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -6186,7 +6186,7 @@ media file played</string>
              </property>
              <layout class="QGridLayout" name="audioBalanceBoxLayout" columnstretch="1,1">
               <item row="0" column="0" colspan="2">
-               <widget class="QScrollBar" name="audioBalance">
+               <widget class="PlainSlider" name="audioBalance">
                 <property name="cursor">
                  <cursorShape>PointingHandCursor</cursorShape>
                 </property>
@@ -8258,7 +8258,10 @@ media file played</string>
                  </widget>
                 </item>
                 <item row="0" column="2">
-                 <widget class="QScrollBar" name="miscBrightness">
+                 <widget class="PlainSlider" name="miscBrightness">
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
                   <property name="minimum">
                    <number>-100</number>
                   </property>
@@ -8291,7 +8294,10 @@ media file played</string>
                  </widget>
                 </item>
                 <item row="1" column="2">
-                 <widget class="QScrollBar" name="miscContrast">
+                 <widget class="PlainSlider" name="miscContrast">
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
                   <property name="minimum">
                    <number>-100</number>
                   </property>
@@ -8324,7 +8330,10 @@ media file played</string>
                  </widget>
                 </item>
                 <item row="2" column="2">
-                 <widget class="QScrollBar" name="miscGamma">
+                 <widget class="PlainSlider" name="miscGamma">
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
                   <property name="minimum">
                    <number>-100</number>
                   </property>
@@ -8357,7 +8366,10 @@ media file played</string>
                  </widget>
                 </item>
                 <item row="3" column="2">
-                 <widget class="QScrollBar" name="miscHue">
+                 <widget class="PlainSlider" name="miscHue">
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
                   <property name="minimum">
                    <number>-100</number>
                   </property>
@@ -8393,7 +8405,10 @@ media file played</string>
                  </widget>
                 </item>
                 <item row="4" column="2">
-                 <widget class="QScrollBar" name="miscSaturation">
+                 <widget class="PlainSlider" name="miscSaturation">
+                  <property name="cursor">
+                   <cursorShape>PointingHandCursor</cursorShape>
+                  </property>
                   <property name="minimum">
                    <number>-100</number>
                   </property>
@@ -8494,6 +8509,13 @@ media file played</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PlainSlider</class>
+   <extends>QSlider</extends>
+   <header>widgets/plainslider.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/src/widgets/plainslider.cpp
+++ b/src/widgets/plainslider.cpp
@@ -1,0 +1,89 @@
+#include "plainslider.h"
+#include <QApplication>
+#include <QPainter>
+#include <QStyleOption>
+
+PlainSlider::PlainSlider(QWidget *parent) : QSlider(parent)
+{
+}
+
+void PlainSlider::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event)
+
+    QStyleOptionSlider opt;
+    initStyleOption(&opt);
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    checkPalette();
+    drawGroove(p, opt);
+    drawHandle(p, opt);
+}
+
+void PlainSlider::checkPalette()
+{
+    if (palette().color(QPalette::Normal, QPalette::Button).value() <
+            palette().color(QPalette::Normal, QPalette::Text).value()) {
+        darkPalette = true;
+    } else {
+        darkPalette = false;
+    }
+}
+
+void PlainSlider::drawGroove(QPainter& p, const QStyleOptionSlider& opt)
+{
+    QRect groove = style()->subControlRect(
+        QStyle::CC_Slider, &opt, QStyle::SC_SliderGroove, this);
+
+    if (darkPalette) {
+        grooveFill = palette().color(QPalette::Midlight);
+        grooveBorder = palette().color(QPalette::Light);
+        grooveBorder = grooveBorder.lighter(150);
+    } else {
+        grooveFill = palette().color(QPalette::Midlight);
+        grooveBorder = palette().color(QPalette::Mid);
+    }
+
+    p.setPen(grooveBorder);
+    p.setBrush(grooveFill);
+    QRectF grooveRect = QRectF(groove.adjusted(7, 1, -7, -1));
+    grooveRect = grooveRect.adjusted(0.5, 0.5, -0.5, -0.5);
+    p.drawRoundedRect(grooveRect, 1, 1);
+}
+void PlainSlider::drawHandle(QPainter& p, const QStyleOptionSlider& opt)
+{
+    QRect handle = style()->subControlRect(
+        QStyle::CC_Slider, &opt, QStyle::SC_SliderHandle, this);
+
+    if (QApplication::style()->name() != "fusion") {
+        QRect original = handle;
+        handle.setWidth(handle.height() / 2);
+        handle.moveCenter(original.center());
+    }
+
+    handleFill = palette().color(QPalette::Button);
+    if (darkPalette) {
+        handleBorder = palette().color(QPalette::Light);
+        handleBorder = handleBorder.lighter(150);
+    }
+    else {
+        handleBorder = palette().color(QPalette::Mid);
+    }
+
+    if (opt.state & QStyle::State_MouseOver)
+        handleBorder = palette().color(QPalette::Highlight);
+    if (opt.state & QStyle::State_Sunken) {
+        if (darkPalette)
+            handleFill = handleFill.lighter(150);
+        else
+            handleFill = handleFill.darker(150);
+    }
+
+    p.setPen(handleBorder);
+    p.setBrush(handleFill);
+    QRectF handleRect = QRectF(handle.adjusted(1, 1, -1, -1));
+    handleRect = handleRect.adjusted(0.5, 0.5, -0.5, -0.5);
+    p.drawRoundedRect(handleRect, 2, 2);
+}
+
+

--- a/src/widgets/plainslider.h
+++ b/src/widgets/plainslider.h
@@ -1,0 +1,27 @@
+#ifndef CLEANSLIDER_H
+#define CLEANSLIDER_H
+
+#include <QSlider>
+
+class PlainSlider : public QSlider
+{
+public:
+    explicit PlainSlider(QWidget *parent = nullptr);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    void checkPalette();
+    void drawGroove(QPainter& p, const QStyleOptionSlider& opt);
+    void drawHandle(QPainter& p, const QStyleOptionSlider& opt);
+
+    QColor grooveFill;
+    QColor grooveBorder;
+    QColor handleFill;
+    QColor handleBorder;
+
+    bool darkPalette = true;
+};
+
+#endif // CLEANSLIDER_H


### PR DESCRIPTION
Replace scrollbars with a new custom slider widget based on QSlider.

QSlider has a highlight in its groove between the minimum position and the current one, so it cannot be used when the neutral position is at the center.
Unlike QSlider, this custom widget can be styled in the settings even when not using the Fusion style. It's also more visible with dark themes than QSlider.

Tested with various themes including Fusion (both dark and light).