### PR TITLE
settingswindow: Don't empty hwdec-codecs when disabling hardware decoding

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -960,7 +960,6 @@ void SettingsWindow::sendSignals()
         }
     } else {
         emit option("hwdec", "no");
-        emit option("hwdec-codecs", "");
         emit hwdecBackend("no");
     }
 


### PR DESCRIPTION
Hardware decoding wasn't being re-enabled until restart after being disabled then re-enabled by the user because hwdec-codecs was staying empty.

There doesn't seem to be a way to restore defaults for hwdec-codecs once we change it.

We could set it to the current default codecs of the latest version of mpv, but then we'd need to update it every time it changes.

The only case where it won't use the defaults until restart is if the user enables All or Custom codecs then changes back to Auto.

Fixes: 10f0a1089f147c5f479db46e949db0dcd80d69d8 ("settingswindow: Use mpv defaults for enabled hardware codecs; add AV1 and VP8")