### PR TITLE
Bring window to front when opening a video for immediate playback

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -647,6 +647,8 @@ void Flow::setupMainWindowConnections()
             mainWindow, &MainWindow::setVideoPreviewItem);
     connect(playbackManager, &PlaybackManager::isVideo,
             mainWindow, &MainWindow::setIsVideo);
+    connect(playbackManager, &PlaybackManager::windowShouldBeRaised,
+            mainWindow, &MainWindow::setWindowShouldBeRaised);
 
     // manager -> playlistwindow
     connect(playbackManager, &PlaybackManager::removePlaylistItemRequested,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1817,6 +1817,15 @@ void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu
     }
 }
 
+void MainWindow::raiseWindow()
+{
+    if (freestanding_)
+        return;
+    activateWindow();
+    raise();
+    this->window()->windowHandle()->requestActivate(); // Enough on Wayland
+}
+
 void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration,
                                          bool setControlsInFullscreen = true)
 {
@@ -2440,6 +2449,8 @@ void MainWindow::setIsVideo(bool isVideo)
     isVideo_ = isVideo;
     if (isPlaying)
         showStepAndSubsButtons(isVideo);
+    if (isVideo && windowShouldBeRaised)
+        raiseWindow();
 }
 
 void MainWindow::setVideoPreviewItem(QUrl itemUrl)
@@ -2448,6 +2459,11 @@ void MainWindow::setVideoPreviewItem(QUrl itemUrl)
     isVideo_ = false;
     if (videoPreview)
         videoPreview->openFile(itemUrl);
+}
+
+void MainWindow::setWindowShouldBeRaised(bool yes)
+{
+    windowShouldBeRaised = yes;
 }
 
 void MainWindow::logWindowClosed()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -305,6 +305,7 @@ public slots:
     void setVideoBitrate(double bitrate);
     void setIsVideo(bool isVideo);
     void setVideoPreviewItem(QUrl itemUrl);
+    void setWindowShouldBeRaised(bool yes);
     void logWindowClosed();
     void libraryWindowClosed();
     void mpvObject_mouseReleased();
@@ -482,6 +483,7 @@ private slots:
     void playlistWindow_playlistAddItem(const QUuid &playlistUuid);
     void hideTimer_timeout();
     void addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end);
+    void raiseWindow();
 
     void on_actionFileLoadSubtitle_triggered();
 
@@ -553,6 +555,7 @@ private:
     bool zoomCenter = true;
     OnTopMode onTopMode = OnTopDefault;
     bool showOnTop = false;
+    bool windowShouldBeRaised = false;
     int mouseHideTimeWindowed = 1000;
     int mouseHideTimeFullscreen = 1000;
     int64_t displayDrops = 0;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -200,6 +200,7 @@ void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
     if (playAfterAdd && !playlistItem.item.isNull()) {
         QUrl urlToPlay = playlistWindow_->getUrlOf(playlistItem.list, playlistItem.item);
         startPlayWithUuid(urlToPlay, playlistItem.list, playlistItem.item, false);
+        emit windowShouldBeRaised(true);
     }
 }
 
@@ -692,6 +693,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
                                         bool replaceMpvPlaylist)
 {
     Logger::log(logModule, "startPlayWithUuid");
+    emit windowShouldBeRaised(false);
     if (playbackState_ == WaitingState || what.isEmpty())
         return;
     emit stateChanged(playbackState_ = WaitingState);

--- a/src/manager.h
+++ b/src/manager.h
@@ -92,6 +92,7 @@ signals:
     void systemShouldHibernate();
     void currentTrackInfo(TrackInfo track);
     void openingNewFile();
+    void windowShouldBeRaised(bool yes);
     void aboutToStartPlayingFile(QUrl url);
     void startedPlayingFile(QUrl url);
     void removePlaylistItemRequested(QUuid itemUuid);


### PR DESCRIPTION
If the application is already running:
- Bring the window to the foreground when opening a video that starts playing immediately.
- Do not change focus when opening audio files or when adding media to the playlist.

Works on Wayland, XWayland and X11, but not on Windows.

#846 ("[Bug] Player window does not come to the front when opening a file")