### PR TITLE
Use lambda expressions for QMetaObject::invokeMethod calls

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -49,8 +49,10 @@ void loggerCallback(QtMsgType type, const QMessageLogContext &context, const QSt
         break;
     case QtFatalMsg:
         Logger::log("qt", "fatal", msg);
-        QMetaObject::invokeMethod(Logger::singleton(), "fatalMessage",
-                                  Qt::BlockingQueuedConnection);
+        auto logger = Logger::singleton();
+        QMetaObject::invokeMethod(logger, [logger]() {
+            logger->fatalMessage();
+        }, Qt::BlockingQueuedConnection);
         std::abort();
     }
 }
@@ -104,9 +106,9 @@ void Logger::log(QString line)
     Logger *log = singleton();
     if (!log)
         return;
-    QMetaObject::invokeMethod(log, "makeLog",
-                              Qt::QueuedConnection,
-                              Q_ARG(QString, line));
+    QMetaObject::invokeMethod(log, [log, line]() {
+        log->makeLog(line);
+    }, Qt::QueuedConnection);
 }
 
 void Logger::log(QString prefix, QString message)
@@ -114,10 +116,9 @@ void Logger::log(QString prefix, QString message)
     Logger *log = singleton();
     if (!log)
         return;
-    QMetaObject::invokeMethod(log, "makeLogPrefixed",
-                              Qt::QueuedConnection,
-                              Q_ARG(QString, prefix),
-                              Q_ARG(QString, message));
+    QMetaObject::invokeMethod(log, [log, prefix, message]() {
+        log->makeLogPrefixed(prefix, message);
+    }, Qt::QueuedConnection);
 }
 
 void Logger::log(QString prefix, QString level, QString message, bool qtWarningMsg)
@@ -125,11 +126,9 @@ void Logger::log(QString prefix, QString level, QString message, bool qtWarningM
     Logger *log = singleton();
     if (!log)
         return;
-    QMetaObject::invokeMethod(log, "makeLogDescriptively",
-                              Qt::QueuedConnection,
-                              Q_ARG(QString, prefix),
-                              Q_ARG(QString, level),
-                              Q_ARG(QString, message));
+    QMetaObject::invokeMethod(log, [log, prefix, level, message]() {
+        log->makeLogDescriptively(prefix, level, message);
+    }, Qt::QueuedConnection);
 
     if (qtWarningMsg)
         checkAmbiguousShortcut(message);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,13 +116,18 @@ void signalHandler(int signal) {
         if (signal == SIGSEGV)
             Logger::log(logModule, "Segmentation fault!");
         Logger::log(logModule, "Please report this error.");
-        QMetaObject::invokeMethod(Logger::singleton(), "flushMessages", Qt::BlockingQueuedConnection);
+        auto logger = Logger::singleton();
+        QMetaObject::invokeMethod(logger, [logger]() {
+            logger->flushMessages();
+        }, Qt::BlockingQueuedConnection);
         if (signal == SIGSEGV) {
             std::signal(SIGSEGV, SIG_DFL);
             std::raise(SIGSEGV);
         }
     }
-    QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(qApp, []() {
+        QApplication::exit();
+    }, Qt::QueuedConnection);
 }
 
 //---------------------------------------------------------------------------
@@ -1807,7 +1812,9 @@ void Flow::updateRecents(QUrl url, QUuid listUuid, QUuid itemUuid, QString title
 void Flow::endProgram()
 {
     Logger::log(logModule, "endProgram");
-    QMetaObject::invokeMethod(qApp, "exit", Qt::QueuedConnection);
+    QMetaObject::invokeMethod(qApp, []() {
+        QApplication::exit();
+    }, Qt::QueuedConnection);
 }
 
 void Flow::importPlaylist(QString fname)

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -143,8 +143,9 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "scripts", scripts },
         { "clipboard-backends", "clr" }
     };
-    QMetaObject::invokeMethod(ctrl, "create", Qt::BlockingQueuedConnection,
-                              Q_ARG(MpvController::OptionList, earlyOptions));
+    QMetaObject::invokeMethod(ctrl, [this, earlyOptions]() {
+        this->ctrl->create(earlyOptions);
+    }, Qt::BlockingQueuedConnection);
 
     // clean up objects when the worker thread is deleted
     connect(worker, &QThread::finished, ctrl, &MpvController::deleteLater);
@@ -185,19 +186,17 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         "time-pos", "avsync", "estimated-vf-fps", "frame-drop-count",
         "decoder-frame-drop-count", "audio-bitrate", "video-bitrate"
     };
-    QMetaObject::invokeMethod(ctrl, "observeProperties",
-                              Qt::QueuedConnection,
-                              Q_ARG(MpvController::PropertyList, options),
-                              Q_ARG(QSet<QString>, throttled));
+    QMetaObject::invokeMethod(ctrl, [this, options, throttled]() {
+        this->ctrl->observeProperties(options, throttled);
+    }, Qt::QueuedConnection);
 
-    QMetaObject::invokeMethod(ctrl, "addHook",
-                              Qt::QueuedConnection,
-                              Q_ARG(QString, "on_unload"),
-                              Q_ARG(uint64_t, reinterpret_cast<uint64_t>(this)));
+    QMetaObject::invokeMethod(ctrl, [this]() {
+        this->ctrl->addHook("on_unload", reinterpret_cast<uint64_t>(this));
+    }, Qt::QueuedConnection);
 
-    QMetaObject::invokeMethod(ctrl, "setLogLevel",
-                              Qt::QueuedConnection,
-                              Q_ARG(QString, "info"));
+    QMetaObject::invokeMethod(ctrl, [this]() {
+        this->ctrl->setLogLevel("info");
+    }, Qt::QueuedConnection);
 }
 
 MpvObject::~MpvObject()
@@ -213,8 +212,9 @@ MpvObject::~MpvObject()
         // no explicit delete. deleteLater will be called at thread finish.
         // Instead tell mpv to stop sending wake notifications so the
         // can be reliably idle when we end it.
-        QMetaObject::invokeMethod(ctrl, "stop",
-                                  Qt::BlockingQueuedConnection);
+        QMetaObject::invokeMethod(ctrl, [this]() {
+            this->ctrl->stop();
+        }, Qt::BlockingQueuedConnection);
         ctrl = nullptr;
     }
     worker->quit();
@@ -550,11 +550,9 @@ bool MpvObject::setChapter(int64_t chapter)
     // MPV_ERROR_PROPERTY_FORMAT: past-the-end value requested
     // MPV_ERROR_SUCCESS: success
     int r;
-    QMetaObject::invokeMethod(ctrl, "setPropertyVariant",
-                              Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, r),
-                              Q_ARG(QString, "chapter"),
-                              Q_ARG(QVariant, QVariant(qlonglong(chapter))));
+    QMetaObject::invokeMethod(ctrl, [this, chapter, &r]() {
+        r = this->ctrl->setPropertyVariant("chapter", QVariant(qlonglong(chapter)));
+    }, Qt::BlockingQueuedConnection);
     return r == MPV_ERROR_SUCCESS;
 }
 
@@ -690,21 +688,18 @@ void MpvObject::setUncachedMpvOption(const QString &option, const QVariant &valu
 QVariant MpvObject::blockingMpvCommand(const QVariant &params)
 {
     QVariant v;
-    QMetaObject::invokeMethod(ctrl, "command",
-                              Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(QVariant, v),
-                              Q_ARG(QVariant, params));
+    QMetaObject::invokeMethod(ctrl, [this, params, &v]() {
+        v = this->ctrl->command(params);
+    }, Qt::BlockingQueuedConnection);
     return v;
 }
 
 QVariant MpvObject::blockingSetMpvPropertyVariant(QString name, const QVariant &value)
 {
     int v;
-    QMetaObject::invokeMethod(ctrl, "setPropertyVariant",
-                              Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, v),
-                              Q_ARG(QString, name),
-                              Q_ARG(QVariant, value));
+    QMetaObject::invokeMethod(ctrl, [this, name, value, &v]() {
+        v = this->ctrl->setPropertyVariant(name, value);
+    }, Qt::BlockingQueuedConnection);
     return v == MPV_ERROR_SUCCESS ? QVariant()
                                   : QVariant::fromValue(MpvErrorCode(v));
 }
@@ -712,11 +707,9 @@ QVariant MpvObject::blockingSetMpvPropertyVariant(QString name, const QVariant &
 QVariant MpvObject::blockingSetMpvOptionVariant(QString name, const QVariant &value)
 {
     int v;
-    QMetaObject::invokeMethod(ctrl, "setOptionVariant",
-                              Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(int, v),
-                              Q_ARG(QString, name),
-                              Q_ARG(QVariant, value));
+    QMetaObject::invokeMethod(ctrl, [this, name, value, &v]() {
+        v = this->ctrl->setOptionVariant(name, value);
+    }, Qt::BlockingQueuedConnection);
     return v == MPV_ERROR_SUCCESS ? QVariant()
                                   : QVariant::fromValue(MpvErrorCode(v));
 }
@@ -724,10 +717,9 @@ QVariant MpvObject::blockingSetMpvOptionVariant(QString name, const QVariant &va
 QVariant MpvObject::getMpvPropertyVariant(QString name)
 {
     QVariant v;
-    QMetaObject::invokeMethod(ctrl, "getPropertyVariant",
-                              Qt::BlockingQueuedConnection,
-                              Q_RETURN_ARG(QVariant, v),
-                              Q_ARG(QString, name));
+    QMetaObject::invokeMethod(ctrl, [this, name, &v]() {
+        v = this->ctrl->getPropertyVariant(name);
+    }, Qt::BlockingQueuedConnection);
     return v;
 }
 
@@ -1194,7 +1186,10 @@ void MpvGlWidget::keyReleaseEvent(QKeyEvent *event)
 
 void MpvGlWidget::render_update(void *ctx)
 {
-    QMetaObject::invokeMethod(static_cast<MpvGlWidget*>(ctx), "maybeUpdate");
+    auto widget = static_cast<MpvGlWidget*>(ctx);
+    QMetaObject::invokeMethod(widget, [widget]() {
+        widget->maybeUpdate();
+    });
 }
 
 void MpvGlWidget::maybeUpdate()
@@ -1525,9 +1520,10 @@ void MpvController::handleMpvEvent(mpv_event *event)
         QVariant v = propertyToVariant(static_cast<mpv_event_property*>(event->data));
         if (!event->reply_userdata)
             return;
-        QMetaObject::invokeMethod(reinterpret_cast<MpvCallback*>(event->reply_userdata),
-                                  "reply", Qt::QueuedConnection,
-                                  Q_ARG(QVariant, v));
+        auto callback = reinterpret_cast<MpvCallback*>(event->reply_userdata);
+        QMetaObject::invokeMethod(callback, [callback, v]() {
+            callback->reply(v);
+        }, Qt::QueuedConnection);
         break;
     }
     case MPV_EVENT_COMMAND_REPLY:
@@ -1535,9 +1531,10 @@ void MpvController::handleMpvEvent(mpv_event *event)
         QVariant v = QVariant::fromValue<MpvErrorCode>(MpvErrorCode(event->error));
         if (!event->reply_userdata)
             return;
-        QMetaObject::invokeMethod(reinterpret_cast<MpvCallback*>(event->reply_userdata),
-                                  "reply", Qt::QueuedConnection,
-                                  Q_ARG(QVariant, v));
+        auto callback = reinterpret_cast<MpvCallback*>(event->reply_userdata);
+        QMetaObject::invokeMethod(callback, [callback, v]() {
+            callback->reply(v);
+        }, Qt::QueuedConnection);
         break;
     }
     case MPV_EVENT_PROPERTY_CHANGE: {
@@ -1595,6 +1592,8 @@ void MpvController::handleMpvEvent(mpv_event *event)
 
 void MpvController::mpvWakeup(void *ctx)
 {
-    QMetaObject::invokeMethod(static_cast<MpvController*>(ctx), "parseMpvEvents",
-                              Qt::QueuedConnection);
+    auto controller = static_cast<MpvController*>(ctx);
+    QMetaObject::invokeMethod(controller, [controller]() {
+        controller->parseMpvEvents();
+    }, Qt::QueuedConnection);
 }

--- a/src/thumbnailerwindow.cpp
+++ b/src/thumbnailerwindow.cpp
@@ -497,7 +497,10 @@ void MpvThumbnailDrawer::alwaysUpdate()
 
 void MpvThumbnailDrawer::render_update(void *ctx)
 {
-    QMetaObject::invokeMethod(static_cast<MpvThumbnailDrawer*>(ctx), "alwaysUpdate");
+    auto drawer = static_cast<MpvThumbnailDrawer*>(ctx);
+    QMetaObject::invokeMethod(drawer, [drawer]() {
+        drawer->alwaysUpdate();
+    });
 }
 
 void MpvThumbnailDrawer::initMpv()


### PR DESCRIPTION
Avoids runtime method lookup and improves robustness and readability.