### PR TITLE
Display buffering state and progress in status bar on buffer underrun

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2094,7 +2094,7 @@ void MainWindow::setFullscreenHidePanels(bool hidden)
     }
 }
 
-void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state)
+void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState)
 {
     // Update the fullscreen state
     if (state == PlaybackManager::StoppedState) {
@@ -2108,11 +2108,26 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state)
     }
 
     // Update the UI
-    ui->status->setText(state==PlaybackManager::StoppedState ? tr("Stopped") :
-                        state==PlaybackManager::PausedState ? tr("Paused") :
-                        state==PlaybackManager::PlayingState ? tr("Playing") :
-                        state==PlaybackManager::BufferingState ? tr("Buffering") :
-                                                                 tr("Unknown"));
+    switch (state) {
+    case PlaybackManager::StoppedState:
+        ui->status->setText(tr("Stopped"));
+        break;
+    case PlaybackManager::PausedState:
+        ui->status->setText(tr("Paused"));
+        break;
+    case PlaybackManager::PlayingState:
+        ui->status->setText(tr("Playing"));
+        break;
+    case PlaybackManager::LoadingState:
+        ui->status->setText(tr("Loading"));
+        break;
+    case PlaybackManager::BufferingState:
+        ui->status->setText(tr("Buffering (%1%)").arg(bufferFillState));
+        break;
+    case PlaybackManager::WaitingState:
+        ui->status->setText(tr("Unknown"));
+        break;
+    }
     isPlaying = state != PlaybackManager::StoppedState;
     isPaused = state == PlaybackManager::PausedState;
     setUiEnabledState(state != PlaybackManager::StoppedState);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -273,7 +273,7 @@ public slots:
     void setTimeTooltip(bool show, bool above);
     void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
-    void setPlaybackState(PlaybackManager::PlaybackState state);
+    void setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState);
     void setPlaybackType(PlaybackManager::PlaybackType type);
     void disableChaptersMenus();
     void setChapters(QList<Chapter> chapters);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -111,6 +111,10 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_seekableChanged);
         connect(mpvObject, &MpvObject::playbackLoading,
                 this, &PlaybackManager::mpvw_playbackLoading);
+        connect(mpvObject, &MpvObject::pausedForCacheChanged,
+                this, &PlaybackManager::mpvw_pausedForCache);
+        connect(mpvObject, &MpvObject::bufferStateChanged,
+                this, &PlaybackManager::mpvw_bufferFillStateChanged);
         connect(mpvObject, &MpvObject::playbackStarted,
                 this, &PlaybackManager::mpvw_playbackStarted);
         connect(mpvObject, &MpvObject::pausedChanged,
@@ -1014,8 +1018,24 @@ void PlaybackManager::mpvw_seekableChanged(bool yes)
 
 void PlaybackManager::mpvw_playbackLoading()
 {
-    playbackState_ = BufferingState;
+    playbackState_ = LoadingState;
     emit stateChanged(playbackState_);
+}
+
+void PlaybackManager::mpvw_pausedForCache(QString paused)
+{
+    if (paused == strTrue)
+        playbackState_ = BufferingState;
+    else if (paused == strFalse)
+        playbackState_ = PlayingState;
+    else
+        playbackState_ = StoppedState;
+    emit stateChanged(playbackState_);
+}
+
+void PlaybackManager::mpvw_bufferFillStateChanged(int64_t percentage)
+{
+    emit stateChanged(playbackState_, percentage);
 }
 
 void PlaybackManager::mpvw_playbackStarted()
@@ -1049,7 +1069,7 @@ void PlaybackManager::mpvw_playbackIdling(bool yes)
 }
 
 void PlaybackManager::mpvw_playbackFinished() {
-    if (playbackState_ == BufferingState) {
+    if (playbackState_ == LoadingState) {
         playbackState_ = StoppedState;
         emit stateChanged(playbackState_);
         mpvw_eofReachedChanged(strTrue);

--- a/src/manager.h
+++ b/src/manager.h
@@ -48,7 +48,7 @@ class PlaybackManager : public QObject
     Q_OBJECT
 public:
     enum PlaybackState { StoppedState, PausedState, PlayingState,
-                         BufferingState, WaitingState };
+                         LoadingState, BufferingState, WaitingState };
     enum PlaybackType { None, File, Disc, Stream, Device };
     enum class Deinterlace { Yes, Auto, No };
 
@@ -66,7 +66,7 @@ signals:
     void titleChangedWithFilename(QString title, QString filename);
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
-    void stateChanged(PlaybackManager::PlaybackState state);
+    void stateChanged(PlaybackManager::PlaybackState state, int bufferFillState = 0);
     void fileClosed();
     void typeChanged(PlaybackManager::PlaybackType type);
     // Transmit a map of chapter index to time,description pairs
@@ -209,6 +209,8 @@ private slots:
     void mpvw_playLengthChanged(double length);
     void mpvw_seekableChanged(bool yes);
     void mpvw_playbackLoading();
+    void mpvw_pausedForCache(QString paused);
+    void mpvw_bufferFillStateChanged(int64_t percentage);
     void mpvw_playbackStarted();
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling(bool yes);

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -68,7 +68,9 @@ MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("file-size", fileSizeChanged, toLongLong, 0ll),
     HANDLE_PROP("path", filePathChanged, toString, QString()),
     HANDLE_PROP("sub-text", subTextChanged, toString, QString()),
-    HANDLE_PROP("hwdec-current", hwdecCurrentChanged, toString, QString())
+    HANDLE_PROP("hwdec-current", hwdecCurrentChanged, toString, QString()),
+    HANDLE_PROP("paused-for-cache", pausedForCacheChanged, toString, QString()),
+    HANDLE_PROP("cache-buffering-state", bufferStateChanged, toLongLong, 0ll)
 };
 
 MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
@@ -171,6 +173,7 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "audio-bitrate", 0, MPV_FORMAT_DOUBLE },
         { "video-bitrate", 0, MPV_FORMAT_DOUBLE },
         { "paused-for-cache", 0, MPV_FORMAT_FLAG },
+        { "cache-buffering-state", 0, MPV_FORMAT_INT64 },
         { "metadata", 0, MPV_FORMAT_NODE },
         { "audio-device-list", 0, MPV_FORMAT_NODE },
         { "filename", 0, MPV_FORMAT_STRING },

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -157,6 +157,8 @@ signals:
     void filePathChanged(QString path);
     void subTextChanged(QString subText);
     void hwdecCurrentChanged(QString hwdecCurrent);
+    void pausedForCacheChanged(QString paused);
+    void bufferStateChanged(int64_t percentage);
     void playlistChanged(QVariantList playlist);
 
     void audioTrackSet(int64_t id);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1246,6 +1246,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,6 +1271,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1331,10 +1339,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1390,6 +1390,14 @@ No action will be triggered.</source>
         <translation> ·[Independent]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Addició &amp;ràpida a llista de reproducció</translation>
     </message>
@@ -1455,7 +1463,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Memòria intermèdia</translation>
+        <translation type="vanished">Memòria intermèdia</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1400,6 +1400,14 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation> [Freistehend]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Schnelles &amp;Hinzufügen zur Wiedergabeliste</translation>
     </message>
@@ -1465,7 +1473,7 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Puffern</translation>
+        <translation type="vanished">Puffern</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1398,6 +1398,14 @@ No action will be triggered.</source>
         <translation> [Freestanding]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Quick Add To Playlist</translation>
     </message>
@@ -1463,7 +1471,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Buffering</translation>
+        <translation type="vanished">Buffering</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1334,6 +1334,10 @@ No action will be triggered.</source>
         <translation>Apertura rápida</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1355,6 +1359,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1415,10 +1423,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1306,6 +1306,14 @@ No action will be triggered.</source>
         <translation> [Vapaa paikka]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Lisää Nopeasti Soittolistaan</translation>
     </message>
@@ -1367,7 +1375,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Puskuroi</translation>
+        <translation type="vanished">Puskuroi</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1352,6 +1352,14 @@ Aucune action ne sera déclenchée.</translation>
         <translation> [Indépendant]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Ajout &amp;rapide à la playlist</translation>
     </message>
@@ -1413,7 +1421,7 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Préchargement</translation>
+        <translation type="vanished">Préchargement</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1384,6 +1384,14 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <translation> ·[Berdiri sendiri]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Tambah Cepat ke Daftar Putar</translation>
     </message>
@@ -1449,7 +1457,7 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Penyangga</translation>
+        <translation type="vanished">Penyangga</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1334,6 +1334,10 @@ No action will be triggered.</source>
         <translation>Apri rapidamente</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1355,6 +1359,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1415,10 +1423,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1400,6 +1400,14 @@ No action will be triggered.</source>
         <translation> [Freestanding]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>再生リストへクイック追加(&amp;Q)</translation>
     </message>
@@ -1465,7 +1473,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>バッファリング</translation>
+        <translation type="vanished">バッファリング</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -1399,6 +1399,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1460,10 +1468,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1246,6 +1246,10 @@ No action will be triggered.</source>
         <translation>Hurtigåpning</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,6 +1271,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1327,10 +1335,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1246,6 +1246,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,6 +1271,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1331,10 +1339,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -1378,6 +1378,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1455,7 +1463,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Buforowanie</translation>
+        <translation type="vanished">Buforowanie</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1266,6 +1266,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1287,6 +1291,10 @@ No action will be triggered.</source>
     </message>
     <message>
         <source> [Freestanding]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1351,10 +1359,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1390,6 +1390,14 @@ No action will be triggered.</source>
         <translation> [Свободное положение]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Добавить в список воспроизведения</translation>
     </message>
@@ -1455,7 +1463,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Буферизация</translation>
+        <translation type="vanished">Буферизация</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1392,6 +1392,14 @@ No action will be triggered.</source>
         <translation> [ஃப்ரீச்டாண்டிங்]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp; பிளேலிச்ட்டில் விரைவாக சேர்க்கவும்</translation>
     </message>
@@ -1457,7 +1465,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>இடையக</translation>
+        <translation type="vanished">இடையக</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1392,6 +1392,14 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation> [Bekleyen]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Tez Oynatma Listesine Ekle</translation>
     </message>
@@ -1457,7 +1465,7 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>Arabelleğe alınıyor</translation>
+        <translation type="vanished">Arabelleğe alınıyor</translation>
     </message>
     <message>
         <source>Unknown</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -1370,6 +1370,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1443,10 +1451,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Buffering</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1400,6 +1400,14 @@ No action will be triggered.</source>
         <translation> [独立]</translation>
     </message>
     <message>
+        <source>Loading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Buffering (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>快速添加到播放列表(&amp;Q)</translation>
     </message>
@@ -1461,7 +1469,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Buffering</source>
-        <translation>正在缓冲</translation>
+        <translation type="vanished">正在缓冲</translation>
     </message>
     <message>
         <source>Unknown</source>


### PR DESCRIPTION
Shows "Buffering (X%)" instead of "Playing" when the buffer needs to be refilled.

The previous "Buffering" state which was shown when starting a file is replaced by a new "Loading" state. The initial buffering state isn't advertised by mpv.