### PR TITLE
Update geometry cache on window move to save position

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -937,6 +937,8 @@ void Flow::setupFlowConnections()
             this, &Flow::mainwindow_windowResized);
     connect(mainWindow, &MainWindow::windowMaximized,
             this, &Flow::mainwindow_windowMaximized);
+    connect(mainWindow, &MainWindow::windowMoved,
+            this, &Flow::mainwindow_windowMoved);
 
     // manager -> this
     connect(playbackManager, &PlaybackManager::playLengthChanged,
@@ -1424,6 +1426,11 @@ void Flow::mainwindow_windowResized()
 void Flow::mainwindow_windowMaximized()
 {
     windowManager.updateAppWindowGeometryCache(mainWindow, true);
+}
+
+void Flow::mainwindow_windowMoved()
+{
+    windowManager.updateAppWindowGeometryCache(mainWindow, false);
 }
 
 void Flow::mainwindow_recentOpened(const TrackInfo &track)

--- a/src/main.h
+++ b/src/main.h
@@ -76,6 +76,7 @@ private slots:
     void mainwindow_repeatAfter();
     void mainwindow_windowResized();
     void mainwindow_windowMaximized();
+    void mainwindow_windowMoved();
     void mainwindow_recentOpened(const TrackInfo &track);
     void mainwindow_recentClear();
     void mainwindow_takeImage(Helpers::ScreenshotRender render);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -399,6 +399,12 @@ void MainWindow::changeEvent(QEvent *event)
         emit windowMaximized();
 }
 
+void MainWindow::moveEvent(QMoveEvent *event)
+{
+    Q_UNUSED(event)
+    emit windowMoved();
+}
+
 bool MainWindow::eventFilter(QObject *object, QEvent *event)
 {
     bool insideMpv = mpvw ? object == mpvw : false;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -55,6 +55,7 @@ public:
 protected:
     void resizeEvent(QResizeEvent *event);
     void changeEvent(QEvent *event) override;
+    void moveEvent(QMoveEvent *event) override;
     bool eventFilter(QObject *object, QEvent *event);
     void closeEvent(QCloseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
@@ -177,6 +178,7 @@ signals:
     void fullscreenModeChanged(bool fullscreen);
     void windowResized();
     void windowMaximized();
+    void windowMoved();
     void zoomPresetChanged(int which);
     void playCurrentItemRequested();
     void favoriteCurrentTrack();


### PR DESCRIPTION
Since e384c907db5a756d832f38278d64aa361ecedc3b the window geometry (which includes its position) isn't checked directly on save.
Instead, its cache is used, so that cache has to be updated on each window move as well.

Tested with XWayland, with X11 (Flatpak version) and on Windows 10.

Fixes: e384c907db5a756d832f38278d64aa361ecedc3b ("Save last window size before it got maximized or made fullscreen")