### PR TITLE
drawnslider: Fix background image height calculation

### DIFF
--- a/src/widgets/drawnslider.cpp
+++ b/src/widgets/drawnslider.cpp
@@ -341,7 +341,7 @@ void MediaSlider::makeBackground()
     Logger::log(logModule, "MediaSlider::makeBackground");
     qreal pr = devicePixelRatioF();
     int pw = width() * pr;
-    int ph = width() * pr;
+    int ph = height() * pr;
     backgroundPic = QImage(pw, ph, QImage::Format_RGBA8888);
     backgroundPic.fill(Qt::transparent);
     QPainter p(&backgroundPic);


### PR DESCRIPTION
The background image was allocated using width() for both dimensions, resulting in a square buffer (width × width) instead of (width × height).

Estimated impact on RAM usage in maximized or fullscreen mode:

With a 1920×1080 layout and a 1905x35 slider:
- Before: 14.8 MB (1905×1905×4)
- After: 0.3 MB (1905×35×4)

With a 4K screen:
- Before: 55.6 MB (3818×3818×4)
- After: 0.7 MB (3818×49×4)

Measured impact at 1920×1080:
- ~50% reduction in seekbar CPU usage when comparing with vs without seekbar

Fixes: 0fff34c37d1b18d571fab3be713b4870814e7c8e ("slider: use bitmaps to display sliders")

This may also help with #891 ("Seekbar causes video to stutter slightly").