### PR TITLE
cmakelists: Add missing enqueue .desktop file to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ if(UNIX)
     install(TARGETS mpc-qt DESTINATION bin)
     install(FILES DOCS/ipc.md DESTINATION share/doc/mpc-qt)
     install(FILES data/io.github.mpc_qt.mpc-qt.desktop DESTINATION share/applications)
+    install(FILES data/io.github.mpc_qt.mpc-qt_enqueue.desktop DESTINATION share/applications)
     install(FILES data/io.github.mpc_qt.mpc-qt.metainfo.xml DESTINATION share/metainfo)
     install(FILES res/images/icon/mpc-qt.svg DESTINATION share/icons/hicolor/scalable/apps)
 


### PR DESCRIPTION
Fixes: c5b21752c261786fb729b63d7b1db70149abed9e ("data: Add .desktop file to enqueue files to playlist")