### PR TITLE
Fix memory leaks in mainwindow

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2191,7 +2191,10 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
 {
     ui->menuPlayAudio->clear();
     ui->menuPlayAudio->setEnabled(false);
-    audioTracksGroup = nullptr;
+    if (audioTracksGroup) {
+        audioTracksGroup->deleteLater();
+        audioTracksGroup = nullptr;
+    }
     hasAudio = !tracks.isEmpty();
     ui->actionPlayAudioTrackPrevious->setEnabled(hasAudio);
     ui->actionPlayAudioTrackNext->setEnabled(hasAudio);
@@ -2200,10 +2203,11 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
     ui->menuPlayAudio->setEnabled(true);
     audioTracksGroup = new QActionGroup(this);
     for (const Track &track : tracks) {
-        QAction *action = new QAction(this);
+        QAction *action = new QAction(ui->menuPlayAudio);
         action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(audioTracksGroup);
+        action->setData(QVariant::fromValue(track.id));
         int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index] {
             emit audioTrackSelected(index, true);
@@ -2224,17 +2228,21 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
 {
     ui->menuPlayVideo->clear();
     ui->menuPlayVideo->setEnabled(false);
-    videoTracksGroup = nullptr;
+    if (videoTracksGroup) {
+        videoTracksGroup->deleteLater();
+        videoTracksGroup = nullptr;
+    }
     hasVideo = !tracks.isEmpty();
     if (!hasVideo)
         return;
     ui->menuPlayVideo->setEnabled(true);
     videoTracksGroup = new QActionGroup(this);
     for (const Track &track : tracks) {
-        QAction *action = new QAction(this);
+        QAction *action = new QAction(ui->menuPlayVideo);
         action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(videoTracksGroup);
+        action->setData(QVariant::fromValue(track.id));
         int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit videoTrackSelected(index, true);
@@ -2281,8 +2289,6 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
     ui->menuPlayVideoRotate->addAction(ui->actionRotateCounterclockwise);
     ui->menuPlayVideoRotate->addAction(ui->actionFlipHorizontal);
     ui->menuPlayVideoRotate->addAction(ui->actionResetRotate);
-
-
     videoTracksGroup->actions().constFirst()->setChecked(true);
     updateOnTop();
 }
@@ -2291,7 +2297,10 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
 {
     ui->menuPlaySubtitles->clear();
     ui->menuPlaySubtitles->setEnabled(false);
-    subtitleTracksGroup = nullptr;
+    if (subtitleTracksGroup) {
+        subtitleTracksGroup->deleteLater();
+        subtitleTracksGroup = nullptr;
+    }
     hasSubs = !tracks.isEmpty();
     ui->actionPlaySubtitlesEnabled->setEnabled(hasSubs);
     ui->subs->setEnabled(hasSubs);
@@ -2302,10 +2311,11 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
     ui->menuPlaySubtitles->setEnabled(true);
     subtitleTracksGroup = new QActionGroup(this);
     for (const Track &track : tracks) {
-        QAction *action = new QAction(this);
+        QAction *action = new QAction(ui->menuPlaySubtitles);
         action->setText(track.title);
         action->setCheckable(true);
         action->setActionGroup(subtitleTracksGroup);
+        action->setData(QVariant::fromValue(track.id));
         int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit subtitleTrackSelected(index, true);
@@ -2328,28 +2338,34 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
 
 void MainWindow::audioTrackSet(int64_t id)
 {
-    if (audioTracksGroup != nullptr && id <= audioTracksGroup->actions().length()) {
-        if (id <= 0)
-            id = 1;
-        audioTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
+    const auto actions = ui->menuPlayAudio->actions();
+    for (QAction *action : actions) {
+        if (action->data().toLongLong() == id) {
+            action->setChecked(true);
+            return;
+        }
     }
 }
 
 void MainWindow::videoTrackSet(int64_t id)
 {
-    if (videoTracksGroup != nullptr && id <= videoTracksGroup->actions().length()) {
-        if (id <= 0)
-            id = 1;
-        videoTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
+    const auto actions = ui->menuPlayVideo->actions();
+    for (QAction *action : actions) {
+        if (action->data().toLongLong() == id) {
+            action->setChecked(true);
+            return;
+        }
     }
 }
 
 void MainWindow::subtitleTrackSet(int64_t id)
 {
-    if (subtitleTracksGroup != nullptr && id <= subtitleTracksGroup->actions().length()) {
-        if (id <= 0)
-            id = 1;
-        subtitleTracksGroup->actions().constData()[static_cast <int> (id) -1]->setChecked(true);
+    const auto actions = ui->menuPlaySubtitles->actions();
+    for (QAction *action : actions) {
+        if (action->data().toLongLong() == id) {
+            action->setChecked(true);
+            return;
+        }
     }
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1793,10 +1793,11 @@ void MainWindow::setRecentDocuments(const QList<TrackInfo> &tracks)
     if (tracks.count() > 20) {
         LogStream(logModule) << "tracks.count(): " << tracks.count();
         Logger::log(logModule, "setRecentDocuments > 20");
-        QMenu *moreRecentsMenu = new QMenu(tr("More Files"));
-        addRecentDocumentsEntries(tracks, moreRecentsMenu, 20, 50);
+        moreRecentsMenu.clear();
+        moreRecentsMenu.setTitle(tr("More Files"));
+        addRecentDocumentsEntries(tracks, &moreRecentsMenu, 20, 50);
         ui->menuFileRecent->addSeparator();
-        ui->menuFileRecent->addMenu(moreRecentsMenu);
+        ui->menuFileRecent->addMenu(&moreRecentsMenu);
         Logger::log(logModule, "setRecentDocuments > 20 done");
     }
 
@@ -1815,7 +1816,7 @@ void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu
             displayString = track.title;
         displayString.truncate(100);
         QAction *a = new QAction(QString("%1").arg(displayString),
-                                 this);
+                                 menu);
         connect(a, &QAction::triggered, this, [this, track]() {
             emit recentOpened(track);
         });

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -507,6 +507,7 @@ private:
     Tooltip *tooltip = nullptr;
     StatusTime *statusTime = nullptr;
     PlaylistWindow *playlistWindow_ = nullptr;
+    QMenu moreRecentsMenu;
     QMenu *contextMenu = nullptr;
     QMenu *trayMenu = nullptr;
     QTimer hideTimer;


### PR DESCRIPTION
* mainwindow: Fix leak in setRecentDocuments

> Calls to setRecentDocuments() (triggered by
> Flow::manager_playLengthChanged) were allocating a new
> QMenu each time without deleting the previous instance.
> 
> Replace heap allocation with a persistent member QMenu and reuse it via
> clear() to avoid repeated allocations.
> 
> Parenting the submenu to menuFileRecent is not enough, as Qt only
> destroys child QObjects when the parent is destroyed, not when menus
> are cleared.
> 
> Livestreams length changes very frequently, so the recents menu gets
> recreated without need.
> 
> In the future, we may be able to remove Flow::updateRecentPosition from
> manager_playLengthChanged and rely on
> Flow::manager_aboutToStartPlayingFile.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/c3decc5e1da72f23c3bdb62736e7dabbc7f41b99 ("mainwindow: Add "More Files" entry in Recent Files to show up to 50 recents in total")

* mainwindow: Fix leaks and simplify track menu handling

> Fix memory leaks in set[Audio,Video,Subtitle]Tracks by properly
> destroying previously allocated QActionGroup instances.
> 
> Ensure QAction ownership is tied to their respective menus so they are
> correctly deleted by QMenu::clear().
> 
> Replace index-based track selection with ID-based lookup using
> QAction::data() to improve robustness.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/9183f2cdb463bf4ac1b66157c92ac9a5e24ce53e ("Reset the tracks menus actions groups on track change")