### PR TITLE
Work around black screen bug during fullscreen transitions on Windows

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1383,6 +1383,15 @@ void MainWindow::showStepAndSubsButtons(bool show)
     ui->subs->setVisible(show);
 }
 
+void MainWindow::raiseWindow()
+{
+    if (freestanding_)
+        return;
+    activateWindow();
+    raise();
+    this->window()->windowHandle()->requestActivate(); // Enough on Wayland
+}
+
 QIcon MainWindow::createIconFromSvg(const QString &svgPath, int maxSize) const
 {
     QIcon icon;
@@ -1822,15 +1831,6 @@ void MainWindow::addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu
         });
         menu->addAction(a);
     }
-}
-
-void MainWindow::raiseWindow()
-{
-    if (freestanding_)
-        return;
-    activateWindow();
-    raise();
-    this->window()->windowHandle()->requestActivate(); // Enough on Wayland
 }
 
 void MainWindow::setControlsInFullscreen(bool hide, int showWhen, int showWhenDuration,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -82,6 +82,10 @@ MainWindow::~MainWindow()
 {
     Logger::log(logModule, "~MainWindow");
     mpvObject_->setWidgetType(Helpers::NullWidget);
+    if (alwaysOnTopWindow) {
+        delete alwaysOnTopWindow;
+        alwaysOnTopWindow = nullptr;
+    }
     delete ui;
     ui = nullptr;
 }
@@ -604,10 +608,13 @@ void MainWindow::setFullscreenMode(bool fullscreenMode)
         return;
     fullscreenMode_ = fullscreenMode;
 
-    if (fullscreenMode)
+    if (fullscreenMode) {
+        showAlwaysOnTopWindow(true);
         fullscreenMemory = WindowManager::makeFullscreen(this, fullscreenName);
+    }
     else {
         WindowManager::restoreFullscreen(this, fullscreenMemory);
+        showAlwaysOnTopWindow(false);
         if (videoPreview)
             videoPreview->hide();
         if (tooltip)
@@ -1390,6 +1397,29 @@ void MainWindow::raiseWindow()
     activateWindow();
     raise();
     this->window()->windowHandle()->requestActivate(); // Enough on Wayland
+}
+
+void MainWindow::createAlwaysOnTopWindow()
+{
+    alwaysOnTopWindow = new QWidget();
+    alwaysOnTopWindow->setGeometry(0, 0, 1, 1);
+    alwaysOnTopWindow->setWindowFlag(Qt::WindowStaysOnTopHint);
+    alwaysOnTopWindow->setWindowFlag(Qt::Tool);
+    alwaysOnTopWindow->setWindowFlag(Qt::WindowDoesNotAcceptFocus);
+    alwaysOnTopWindow->setWindowFlag(Qt::FramelessWindowHint);
+    alwaysOnTopWindow->setAttribute(Qt::WA_TranslucentBackground);
+    alwaysOnTopWindow->setAttribute(Qt::WA_QuitOnClose, false);
+}
+
+// Work around black screen during fullscreen transitions bug on Windows
+void MainWindow::showAlwaysOnTopWindow(bool show)
+{
+    if (!Platform::isWindows)
+        return;
+    if (!alwaysOnTopWindow)
+        createAlwaysOnTopWindow();
+    if (alwaysOnTopWindow)
+        alwaysOnTopWindow->setVisible(show);
 }
 
 QIcon MainWindow::createIconFromSvg(const QString &svgPath, int maxSize) const

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -123,6 +123,8 @@ private:
     void showStepAndSubsButtons(bool show);
     void addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end);
     void raiseWindow();
+    void createAlwaysOnTopWindow();
+    void showAlwaysOnTopWindow(bool show);
 
     QIcon createIconFromSvg(const QString &svgPath, int maxSize) const;
     QPixmap renderPixmapFromSvg(const QString &path) const;
@@ -500,6 +502,7 @@ private:
     QMainWindow *mpvHost_ = nullptr;
     MpvObject *mpvObject_ = nullptr;
     QWidget *mpvw = nullptr;
+    QWidget *alwaysOnTopWindow = nullptr;
     //MpvGlCbWidget *mpvw = nullptr;
     MediaSlider *positionSlider_ = nullptr;
     VolumeSlider *volumeSlider_ = nullptr;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -121,6 +121,8 @@ private:
     void resizePlaylistToFit();
     QList<QUrl> doQuickOpenFileDialog();
     void showStepAndSubsButtons(bool show);
+    void addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end);
+    void raiseWindow();
 
     QIcon createIconFromSvg(const QString &svgPath, int maxSize) const;
     QPixmap renderPixmapFromSvg(const QString &path) const;
@@ -484,8 +486,6 @@ private slots:
     void playlistWindow_windowDocked();
     void playlistWindow_playlistAddItem(const QUuid &playlistUuid);
     void hideTimer_timeout();
-    void addRecentDocumentsEntries(const QList<TrackInfo> &tracks, QMenu *menu, int start, int end);
-    void raiseWindow();
 
     void on_actionFileLoadSubtitle_triggered();
 


### PR DESCRIPTION
* mainwindow: Move functions to their correct place

> But keep addRecentDocumentsEntries after caller setRecentDocuments.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/c3decc5e1da72f23c3bdb62736e7dabbc7f41b99 ("mainwindow: Add "More Files" entry in Recent Files to show up to 50 recents in total")
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/3369ff1fb24bdcdca0f1a7dcba8cb65d52312685 ("Bring window to front when opening a video for immediate playback")

* mainwindow: Work around black screen bug during fullscreen transitions on Windows

> Create an always on top window/overlay and "show" it (hidden) on Windows before
> transitioning to fullscreen until transitioning back to windowed mode.
> Workaround found by @Mingo-coder.
> 
> Works around https://github.com/mpc-qt/mpc-qt/issues/572 ("Blackscreen in fullscreen").