### PR TITLE
ci: Update actions

### DIFF
--- a/.github/actions/commands/upload_screenshots/action.yml
+++ b/.github/actions/commands/upload_screenshots/action.yml
@@ -6,7 +6,7 @@ runs:
 
   steps:
   - name: Upload screenshots
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v7
     with:
       name: screenshots
       path: screenshot*.png

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -72,12 +72,12 @@ jobs:
       with:
         cache: true
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 1000
         fetch-tags: true
     - name: Checkout mpv repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         repository: "mpv-player/mpv-build"
         path: mpv-build
@@ -118,7 +118,7 @@ jobs:
     - name: Restore dependencies or cache them later
       id: cache-deps
       if: steps.check-cache-inputs.outputs.cacheable == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.4
       with:
         path: deb
         key: appimage-${{ env.RUNNEROS }}-${{ hashFiles(env.CACHE_KEY_FILES) }}
@@ -172,12 +172,12 @@ jobs:
           --custom-apprun ./packaging/appimage/AppRun \
           --plugin qt --output appimage
     - name: Upload AppImage
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-x86_64-AppImage"
         path: ./mpc-qt[-_]*.AppImage
     - name: Upload AppImage autoupdate zsync file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-x86_64-AppImage-zsync"
         path: ./mpc-qt[-_]*.AppImage.zsync

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -12,9 +12,9 @@ jobs:
       options: --privileged
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Check out Flathub repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           repository: 'flathub/io.github.mpc_qt.mpc-qt'
           path: flathub
@@ -54,7 +54,7 @@ jobs:
           manifest-path: flathub/io.github.mpc_qt.mpc-qt.yml
           upload-artifact: false
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mpc-qt-x86_64-Flatpak
           path: ${{github.workspace}}/mpc-qt[-_]*.flatpak

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
       uses: jurplel/install-qt-action@v4
       with:
         cache: true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 1000
         fetch-tags: true
@@ -49,12 +49,12 @@ jobs:
         objcopy --strip-debug mpc-qt
         objcopy --add-gnu-debuglink=mpc-qt.dbg mpc-qt
     - name: Upload executable
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-linux-x64-${{ env.VERSION }}"
         path: bin/mpc-qt
     - name: Upload symbols file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-linux-x64-debug_symbols-${{ env.VERSION }}"
         path: bin/mpc-qt.dbg

--- a/.github/workflows/linux_tests.yml
+++ b/.github/workflows/linux_tests.yml
@@ -10,9 +10,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
     - name: Download mpc-qt build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
       with:
         path: mpc-qt
         merge-multiple: true

--- a/.github/workflows/windows-msys2.yml
+++ b/.github/workflows/windows-msys2.yml
@@ -39,9 +39,9 @@ jobs:
     - name: Avoid line ending issues on Windows
       run: git config --global core.autocrlf input
     - name: Download mpc-qt source
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
     - name: Download yt-dlp
-      uses: robinraju/release-downloader@v1
+      uses: robinraju/release-downloader@v1.13
       with:
         repository: "yt-dlp/yt-dlp"
         latest: true
@@ -56,14 +56,14 @@ jobs:
         set +e
         bash scripts/make-release-msys2.sh
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-win-x64-${{ env.FORCE_VERSION }}"
         path: mpc-qt-*/
     - name: Rename installer
       run: mv build/mpc-qt-win-x64-installer.exe build/mpc-qt-win-x64-${{ env.FORCE_VERSION }}-installer.exe
     - name: Upload
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: "mpc-qt-win-installer"
         path: build/mpc-qt-win-x64-*-installer.exe

--- a/.github/workflows/windows_tests.yml
+++ b/.github/workflows/windows_tests.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
     - name: Download mpc-qt build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.1
     - name: Install packages
       uses: msys2/setup-msys2@v2
       with:
@@ -35,7 +35,7 @@ jobs:
 
     - name: Cache dep
       id: cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.4
       with:
         path: |
           ${{ env.EXEDIR }}x64\opengl32.dll


### PR DESCRIPTION
Fixes the warning in the workflows summaries: "Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026."