### PR TITLE
videopreview: Request yt-dlp formats meeting minimum preview height

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -23,6 +23,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
+    emit mpv->ctrlSetOptionVariant("ytdl-format", QString("bestvideo[height>=?%1]").arg(videoHeight));
     emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "format-sort=[+size,+br,+res,+fps]");
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 


### PR DESCRIPTION
Some video providers provide formats with lower resolution than the preview, resulting in poor preview quality.

Request formats with a height >= preview height when available. Use the "?" modifier so formats with unknown height are still considered as a fallback if no matching formats are found.