### PR TITLE
Fix for hiDPI pixel artifact on hardware decoding

### DIFF
--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -1109,8 +1109,8 @@ void MpvGlWidget::paintGL()
 void MpvGlWidget::resizeGL(int w, int h)
 {
     qreal r = devicePixelRatioF();
-    glWidth = int(w * r);
-    glHeight = int(h * r);
+    glWidth = qRound(w * r);
+    glHeight = qRound(h * r);
     logo->resizeGL(width(),height(), devicePixelRatioF());
 }
 

--- a/src/thumbnailerwindow.cpp
+++ b/src/thumbnailerwindow.cpp
@@ -482,8 +482,8 @@ void MpvThumbnailDrawer::paintGL()
 void MpvThumbnailDrawer::resizeGL(int w, int h)
 {
     qreal r = devicePixelRatioF();
-    glWidth = int(w * r);
-    glHeight = int(h * r);
+    glWidth = qRound(w * r);
+    glHeight = qRound(h * r);
 }
 
 void MpvThumbnailDrawer::alwaysUpdate()


### PR DESCRIPTION
When playing a video on HiDPI displays with hardware decoding enabled, there's a 1-pixel wide vertical line of incorrect color appears on the right side of the screen during fullscreen playback (see screenshot). 
<img width="97" height="131" alt="rightmost_part_artifact" src="https://github.com/user-attachments/assets/fe3208b3-e974-4ff0-99f0-74f62c4b28da" />

The cause comes from MpvGlWidget::resizeGL() (src/mpvwidget.cpp) where the framebuffer dimensions are calculated using integer truncation (int(w * r)).
On HiDPI displays, we get fractional value by default but this value gets rounded down, making the current buffer 1 pixel too small and exposing the underlying framebuffer.

Replaced int() truncation with qRound() when calculating the GL framebuffer dimensions from the widget size and device pixel ratio. Applied the fix to the thumbnailer too as it's the same code MpvThumbnailDrawer::resizeGL (src/thumbnailerwindow.cpp)

Tested on a HiDPI display (2560x1600 at 140% scaling) with hardware decoding enabled.

