### PR TITLE
manager: Make "Previous" seek to start for files without chapters

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -333,8 +333,12 @@ void PlaybackManager::navigateToNextChapter()
 
 void PlaybackManager::navigateToPrevChapter()
 {
-    if (mpvTime > 5)
-        changeChapter(-1);
+    if (mpvTime > 5) {
+        if (mpvObject_->chapter() > 0)
+            changeChapter(-1);
+        else
+            navigateToTime(0);
+    }
     else
         playPrev(false);
 }


### PR DESCRIPTION
When on the first chapter and past 5 seconds, "Previous" now seeks to the beginning of the file instead of attempting a chapter change.
This aligns the behavior between files with and without chapters, and restores correct "previous track/file" handling when past 5 seconds in files that lack chapter metadata.

The mpv chapter command is a no-op when no chapters are present, which previously caused the action to fail.

Fixes: 5dc40a204790cae93de36c2f32b867b0ea445f32 ('Make 'Previous' seek to beginning of current chapter if not beyond 5 seconds')
Fixes #924 ('Previous file" function with mouse button breaks after you jump on the seekbar').