### PR TITLE
Enable subtitles / unmute when user selects a subtitles / audio track

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2349,6 +2349,8 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
         int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index]() {
             emit subtitleTrackSelected(index, true);
+            if (index > 0)
+                setSubtitlesEnabled(true, false);
         });
         ui->menuPlaySubtitles->addAction(action);
     }
@@ -3374,11 +3376,13 @@ void MainWindow::on_actionPlaySubtitlesEnabled_triggered(bool checked)
 void MainWindow::on_actionPlaySubtitlesNext_triggered()
 {
     emit nextSubtitleSelected();
+    setSubtitlesEnabled(true, false);
 }
 
 void MainWindow::on_actionPlaySubtitlesPrevious_triggered()
 {
     emit previousSubtitleSelected();
+    setSubtitlesEnabled(true, false);
 }
 
 void MainWindow::on_actionPlaySubtitlesCopy_triggered()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2241,6 +2241,7 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
         int64_t index = track.id;
         connect(action, &QAction::triggered, this, [this,index] {
             emit audioTrackSelected(index, true);
+            setVolumeMuteState(false, false);
         });
         ui->menuPlayAudio->addAction(action);
     }
@@ -3361,11 +3362,13 @@ void MainWindow::on_actionVideoFiltersDeinterlaceNo_triggered()
 void MainWindow::on_actionPlayAudioTrackNext_triggered()
 {
     emit nextAudioTrackSelected();
+    setVolumeMuteState(false, false);
 }
 
 void MainWindow::on_actionPlayAudioTrackPrevious_triggered()
 {
     emit previousAudioTrackSelected();
+    setVolumeMuteState(false, false);
 }
 
 void MainWindow::on_actionPlaySubtitlesEnabled_triggered(bool checked)


### PR DESCRIPTION
* mainwindow: Enable subtitles when user selects a track
Enable subtitles when the user clicks on a subtitles track or uses a shortcut to select the next or previous track.
* mainwindow: Unmute when user selects an audio track
Unmute when the user clicks on an audio track or uses a shortcut to select the next or previous track.