### PR TITLE
data: Remove StartupWMClass from enqueue .desktop file

### DIFF
--- a/data/io.github.mpc_qt.mpc-qt_enqueue.desktop
+++ b/data/io.github.mpc_qt.mpc-qt_enqueue.desktop
@@ -8,7 +8,6 @@ Exec=mpc-qt --add-to-playlist %U
 TryExec=mpc-qt
 Icon=mpc-qt
 StartupNotify=false
-StartupWMClass=io.github.mpc_qt.mpc-qt
 NoDisplay=true
 Terminal=false
 Categories=Qt;AudioVideo;Audio;Video;Player;TV;


### PR DESCRIPTION
It confuses KWin - probably because it's a duplicate of the main .desktop file - and causes the window to not being correctly associated to the main launcher when it is used.
The visible effect is the launch notifications not being correctly replaced by the window.

Since the enqueue launcher is hidden (and thus less likely to get pinned to the taskbar), StartupWMClass is less useful for it.
Ideally, we would be able to use both StartupWMClass and StartupNotify=true for the enqueue .desktop file.

Fixes: c5b21752c261786fb729b63d7b1db70149abed9e ("data: Add .desktop file to enqueue files to playlist")