### PR TITLE
Always use .log extension for log file and translate the file type

### DIFF
--- a/src/logwindow.cpp
+++ b/src/logwindow.cpp
@@ -69,7 +69,7 @@ void LogWindow::on_save_clicked()
 #endif
     QString textToSave = ui->messages->document()->toPlainText();
     static QString lastLog;
-    QString file = QFileDialog::getSaveFileName(this, tr("Save File"), lastLog, "Text files (*.txt)",
+    QString file = QFileDialog::getSaveFileName(this, tr("Save File"), lastLog, tr("Log files (*.log)"),
                                                 nullptr, options);
     if (file.isEmpty())
         return;

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1785,7 +1785,7 @@ void SettingsWindow::on_logFilePathBrowse_clicked()
 #endif
     QString file = ui->logFilePathValue->text().isEmpty() ? ui->logFilePathValue->placeholderText() :
                                                             ui->logFilePathValue->text();
-    file = QFileDialog::getSaveFileName(this, tr("Choose Log File"), file, "*.log *.txt", nullptr, options);
+    file = QFileDialog::getSaveFileName(this, tr("Choose Log File"), file, tr("Log files (*.log)"), nullptr, options);
     if (file.isEmpty())
         return;
     ui->logFilePathValue->setText(file);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4189,6 +4193,10 @@ media file played</source>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Desar arxiu</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4534,6 +4538,10 @@ arxiu multimèdia reproduït</translation>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>Arxius de perfil ICC (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -362,6 +362,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Uložit soubor</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4562,6 +4566,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>Soubory ICC profilů (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -363,6 +363,10 @@ Möchten Sie es stattdessen für „%3“ verwenden?</translation>
         <source>Save File</source>
         <translation>Datei speichern</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4516,6 +4520,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC Profildateien (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -362,6 +362,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Save File</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4566,6 +4570,10 @@ media file played</translation>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC profile files (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Guardar archivo</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4369,6 +4373,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -346,6 +346,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4175,6 +4179,10 @@ media file played</source>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -363,6 +363,10 @@ Voulez-vous l&apos;utiliser pour &quot;%3&quot; à la place&#x202f;?</translatio
         <source>Save File</source>
         <translation>Enregistrer le fichier</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4488,6 +4492,10 @@ fichier média lu</translation>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>Fichiers de profil ICC (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -355,6 +355,10 @@ Apakah Anda ingin menggunakannya untuk &quot;%3&quot;?</translation>
         <source>Save File</source>
         <translation>Simpan Berkas</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4316,6 +4320,10 @@ file media yang diputar</translation>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>File profil ICC (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -346,6 +346,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4301,6 +4305,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -363,6 +363,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>ファイルの保存</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4556,6 +4560,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC プロファイル (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -363,6 +363,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4558,6 +4562,10 @@ media file played</source>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Lagre fil</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4254,6 +4258,10 @@ media file played</source>
     </message>
     <message>
         <source>Choose Log File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Bestand Opslaan</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4165,6 +4169,10 @@ media file played</source>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -362,6 +362,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Zapisz plik</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4453,6 +4457,10 @@ media file played</source>
     </message>
     <message>
         <source>Choose Log File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -362,6 +362,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Salvar arquivo</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4221,6 +4225,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>Сохранить файл</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4506,6 +4510,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>Файлы профилей ICC (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -355,6 +355,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>கோப்பை சேமி</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4536,6 +4540,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ஐ.சி.சி சுயவிவரக் கோப்புகள் ( *.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -355,6 +355,10 @@ Bunun yerine “%3” için kullanmak ister misiniz?</translation>
         <source>Save File</source>
         <translation>Dosyayı Kaydet</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4524,6 +4528,10 @@ yeni bir &amp;oynatıcı aç</translation>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC profili dosyaları (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -354,6 +354,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4321,6 +4325,10 @@ media file played</source>
     </message>
     <message>
         <source>Choose Log File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -363,6 +363,10 @@ Do you want to use it for &quot;%3&quot; instead?</source>
         <source>Save File</source>
         <translation>保存文件</translation>
     </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Logger</name>
@@ -4432,6 +4436,10 @@ media file played</source>
     <message>
         <source>ICC profile files (*.icc *.icm)</source>
         <translation>ICC 配置文件 (*.icc *.icm)</translation>
+    </message>
+    <message>
+        <source>Log files (*.log)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allows dark theme support on Windows</source>


### PR DESCRIPTION
logwindow: Use .log as file extension, change type to "Log files" and translate it
settingswindow: Only use .log as log file extension and add "Log files" type