### PR TITLE
main: Don't check GPU in Wayland mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -449,7 +449,7 @@ void Flow::earlyPlatformOverride()
             isWaylandMode = true;
     }
     // The Nvidia drivers don't work well with EGL
-    if (!Flow::isNvidiaGPU())
+    if (!isWaylandMode && !Flow::isNvidiaGPU())
         qputenv("QT_XCB_GL_INTEGRATION", "xcb_egl");
 }
 


### PR DESCRIPTION
The Nvidia bug only matters for X11 and XWayland, so there's no point in risking to slow down startup by running lspci in Wayland mode.