### PR TITLE
windowmanager: Don't set geometry when exiting fullscreen in wayland mode

### DIFF
--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -161,9 +161,8 @@ FullscreenMemory WindowManager::makeFullscreen(QWidget *who, QString preferredSc
 void WindowManager::restoreFullscreen(QWidget *who, const FullscreenMemory &fm)
 {
     who->showNormal();
-    QMetaObject::invokeMethod(who, [who, fm]() {
+    if (QGuiApplication::platformName() != "wayland")
         who->setGeometry(fm.normalGeometry);
-    }, Qt::SingleShotConnection);
 
     QScreen *target = Helpers::findScreenByName(fm.originalScreen);
     if (target) {


### PR DESCRIPTION
Qt::SingleShotConnection isn't enough for QMetaObject::invokeMethod, so the code wasn't run anymore.
Since it did fix it in Wayland mode, just disable it in that case.

Link: https://doc.qt.io/qt-6/qt.html#ConnectionType-enum

Fixes: 0223400f8c6e2b4e2a47600066066af01c4aa9e2 ("windowmanager: Delay setting geometry when exiting fullscreen")