### PR TITLE
Don't play first frame when resuming position

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -107,8 +107,6 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_playTimeChanged);
         connect(mpvObject, &MpvObject::playLengthChanged,
                 this, &PlaybackManager::mpvw_playLengthChanged);
-        connect(mpvObject, &MpvObject::seekableChanged,
-                this, &PlaybackManager::mpvw_seekableChanged);
         connect(mpvObject, &MpvObject::playbackLoading,
                 this, &PlaybackManager::mpvw_playbackLoading);
         connect(mpvObject, &MpvObject::pausedForCacheChanged,
@@ -227,7 +225,6 @@ void PlaybackManager::playDiscFiles(QUrl where)
         emit stateChanged(playbackState_);
         mpvObject_->stopPlayback();
     }
-    mpvStartTime = -1.0;
     mpvObject_->discFilesOpen(where.toLocalFile());
     mpvObject_->setPaused(false);
     playbackStartState = PlayingState;
@@ -434,7 +431,7 @@ void PlaybackManager::navigateToChapter(int64_t chapter)
 void PlaybackManager::navigateToTime(double time)
 {
     if (playbackState_ == WaitingState || playbackState_ == StoppedState)
-        mpvStartTime = time;
+        mpvObject_->setStartTime(time);
     else
         mpvObject_->setTime(time);
 }
@@ -705,8 +702,6 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
     if (playbackState_ == WaitingState || what.isEmpty())
         return;
     emit stateChanged(playbackState_ = WaitingState);
-
-    mpvStartTime = -1.0;
 
     if (!isRepeating)
         emit aboutToStartPlayingFile(what);
@@ -1010,14 +1005,6 @@ void PlaybackManager::mpvw_playLengthChanged(double length)
 {
     mpvLength = length;
     emit playLengthChanged();
-}
-
-void PlaybackManager::mpvw_seekableChanged(bool yes)
-{
-    if (yes && mpvStartTime > 0) {
-        mpvObject_->setTimeSync(mpvStartTime);
-        mpvStartTime = -1;
-    }
 }
 
 void PlaybackManager::mpvw_playbackLoading()

--- a/src/manager.h
+++ b/src/manager.h
@@ -207,7 +207,6 @@ private:
 private slots:
     void mpvw_playTimeChanged(double time);
     void mpvw_playLengthChanged(double length);
-    void mpvw_seekableChanged(bool yes);
     void mpvw_playbackLoading();
     void mpvw_pausedForCache(QString paused);
     void mpvw_bufferFillStateChanged(int64_t percentage);
@@ -241,7 +240,6 @@ private:
     QString nowPlayingTitle_;
     int64_t currentMpvPlaylistItemId = 0;
 
-    double mpvStartTime = -1.0;
     double mpvTime = 0.0;
     double mpvLength = 0.0;
     double mpvSpeed = 1.0;

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -43,7 +43,6 @@
 MpvObject::PropertyDispatchMap MpvObject::propertyDispatch = {
     HANDLE_PROP("time-pos", self_playTimeChanged, toDouble, 0.0),
     HANDLE_PROP("duration", self_playLengthChanged, toDouble, 0.0),
-    HANDLE_PROP("seekable", seekableChanged, toBool, false),
     HANDLE_PROP("pause", pausedChanged, toBool, true),
     HANDLE_PROP("eof-reached", eofReachedChanged, toString, QString()),
     HANDLE_PROP("idle-active", playbackIdling, toBool, false),
@@ -181,7 +180,6 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
         { "file-format", 0, MPV_FORMAT_STRING },
         { "file-size", 0, MPV_FORMAT_STRING },
         { "path", 0, MPV_FORMAT_STRING },
-        { "seekable", 0, MPV_FORMAT_FLAG },
         { "sub-text", 0, MPV_FORMAT_STRING },
         { "hwdec-current", 0, MPV_FORMAT_STRING }
     };
@@ -347,7 +345,6 @@ void MpvObject::urlOpen(QUrl url)
 void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist)
 {
     clearSubFiles();
-    //setStartTime(0.0);
     if (replaceMpvPlaylist)
         emit ctrlCommand(QStringList({"loadfile", filename}));
     else
@@ -579,14 +576,14 @@ void MpvObject::setSpeed(double speed)
     setMpvPropertyVariant("speed", speed);
 }
 
+void MpvObject::setStartTime(double position)
+{
+    setMpvPropertyVariant("start", QString::number(position));
+}
+
 void MpvObject::setTime(double position)
 {
     setMpvPropertyVariant("time-pos", position);
-}
-
-void MpvObject::setTimeSync(double position)
-{
-    ctrl->command(QVariantList() << "seek" << position << "absolute");
 }
 
 void MpvObject::setLoopPoints(double first, double end)

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -92,8 +92,8 @@ public:
     void setMute(bool yes);
     void setPaused(bool yes);
     void setSpeed(double speed);
+    void setStartTime(double position);
     void setTime(double position);
-    void setTimeSync(double position);
     void setLoopPoints(double first, double end);
     void setAudioTrack(int64_t id);
     void setSubtitleTrack(int64_t id);
@@ -129,7 +129,6 @@ signals:
 
     void playTimeChanged(double time);
     void playLengthChanged(double length);
-    void seekableChanged(bool yes);
     void playbackLoading();
     void playbackStarted();
     void pausedChanged(bool yes);


### PR DESCRIPTION
It's faster than watching the seekable property, which avoids playing the first frame.

Tested with streams and yt-dlp.

Follow-up to f02b1a4d33629ad1a44290689b2913115a550a2c ("helpers,main,manager,mpvwidget: implement start times").