### PR TITLE
widgets: jump to next chapter on middle-click in progress bar

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -792,6 +792,8 @@ void MainWindow::setupPositionSlider()
             this, &MainWindow::position_hoverValue);
     connect(positionSlider_, &MediaSlider::hoverEnd,
             this, &MainWindow::position_hoverEnd);
+    connect(positionSlider_, &MediaSlider::middleClicked,
+            this, [this](double t) { emit timeSelected(t); });
 }
 
 void MainWindow::setupVolumeSlider()

--- a/src/widgets/drawnslider.cpp
+++ b/src/widgets/drawnslider.cpp
@@ -432,6 +432,18 @@ void MediaSlider::handleHover(double x)
     emit hoverValue(valueOfX, valueToTickText(valueOfX), x);
 }
 
+void MediaSlider::mousePressEvent(QMouseEvent *ev)
+{
+    if (ev->button() == Qt::MiddleButton && !ticks.isEmpty()) {
+        double clickTime = xToValue(ev->position().x());
+        auto it = ticks.upperBound(clickTime);
+        if (it != ticks.constEnd())
+            emit middleClicked(it.key());
+        return;
+    }
+    DrawnSlider::mousePressEvent(ev);
+}
+
 void MediaSlider::updateLoopArea()
 {
     double left = valueToX(vLoopA);

--- a/src/widgets/drawnslider.h
+++ b/src/widgets/drawnslider.h
@@ -44,6 +44,9 @@ protected:
 
     void paintEvent(QPaintEvent *event) override;
     void resizeEvent(QResizeEvent *event) override;
+    void mousePressEvent(QMouseEvent *ev) override;
+    void mouseReleaseEvent(QMouseEvent *ev) override;
+    void mouseMoveEvent(QMouseEvent *ev) override;
 
     bool highContrast = false;
     bool redrawHandle = true;
@@ -59,9 +62,6 @@ protected:
     int handleWidth, handleHeight, marginX, marginY, paddingHeight;
 
 private:
-    void mousePressEvent(QMouseEvent *ev) override;
-    void mouseReleaseEvent(QMouseEvent *ev) override;
-    void mouseMoveEvent(QMouseEvent *ev) override;
 
     bool isDragging = false;
     double xPosition = 0.0;
@@ -87,6 +87,7 @@ signals:
     void hoverBegin();
     void hoverEnd();
     void hoverValue(double position, QString chapterInfo, double x);
+    void middleClicked(double chapterTime);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -94,6 +95,7 @@ protected:
     void makeHandle() override;
     void enterEvent(QEnterEvent *event) override;
     void leaveEvent(QEvent *event) override;
+    void mousePressEvent(QMouseEvent *ev) override;
     void handleHover(double x) override;
 
     void updateLoopArea();


### PR DESCRIPTION
Middle-clicking the position slider seeks to the first chapter whose start time is after the click position. 
No-op when the file has no chapters or the click is past the last one.

Mirrors Haruna's `HProgressBar.qml` behavior (one of my favorite linux video player).