### PR TITLE
drawnstatus: skip repaint when displayed time hasn't changed

### DIFF
--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -31,6 +31,7 @@ void StatusTime::setShortMode(bool shortened)
 {
     shortMode = shortened;
     lastTextLength = 0;
+    lastDrawnText.clear();
     updateTimeFormat();
     updateText();
 }
@@ -39,6 +40,7 @@ void StatusTime::setRemainingMode(bool isRemaining)
 {
     remainingMode = isRemaining;
     lastTextLength = 0;
+    lastDrawnText.clear();
     updateText();
 }
 
@@ -46,6 +48,7 @@ void StatusTime::setPercentMode(bool isPercent)
 {
     percentMode = isPercent;
     lastTextLength = 0;
+    lastDrawnText.clear();
     updateText();
 }
 
@@ -77,6 +80,9 @@ void StatusTime::updateText()
                                                                 'f',
                                                                 1)));
     }
+    if (drawnText == lastDrawnText)
+        return;
+    lastDrawnText = drawnText;
     int drawnTextLength = drawnText.length();
     if (drawnTextLength != lastTextLength) {
         setMinimumSize(minimumSizeHint());

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -30,6 +30,7 @@ private:
     double currentTime = 0;
     double currentDuration = 0;
     QString drawnText;
+    QString lastDrawnText;
     int lastTextLength = 0;
 };
 


### PR DESCRIPTION
StatusTime::setTime is called on every mpv time-pos update (frame rate), but the formatted text is second-precision. So most ticks rebuild the exact same "01:23 / 45:67" string and trigger a paint with identical pixels.

Caches the last built string and bails before update() when it matches. The format-toggle setters (short / remaining / percent) clear the cache so switching mode still repaints immediately.