### PR TITLE
settings: add Replay Gain controls to Audio renderer page

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -164,6 +164,7 @@ QHash<QString, QStringList> SettingMap::indexedValueToText = {
     {"audioChannels", {"auto-safe", "auto", "stereo", "mono"}},
     {"audioRenderer", {"pulse", "alsa", "oss", "null"}},
     {"audioAutoloadMatch", { "exact", "fuzzy", "all" }},
+    {"replayGainMode", {"no", "track", "album"}},
     {"framedroppingMode", {"no", "vo", "decoder", "decoder+vo"}},
     {"framedroppingDecoderMode", {"none", "default", "nonref", "bidir",\
                                   "nonkey", "all"}},
@@ -991,6 +992,11 @@ void SettingsWindow::sendSignals()
     bool audioAutoload = WIDGET_LOOKUP(ui->audioAutoloadExternal).toBool();
     emit option("audio-file-auto", audioAutoload ? WIDGET_TO_TEXT(ui->audioAutoloadMatch) : "no");
     emit option("audio-file-paths", WIDGET_PLACEHOLD_LOOKUP(ui->audioAutoloadPath).split(';'));
+
+    emit option("replaygain", WIDGET_TO_TEXT(ui->replayGainMode));
+    emit option("replaygain-preamp", WIDGET_LOOKUP(ui->replayGainPreamp).toDouble());
+    emit option("replaygain-fallback", WIDGET_LOOKUP(ui->replayGainFallback).toDouble());
+    emit option("replaygain-clip", WIDGET_LOOKUP(ui->replayGainClip).toBool());
 
     emit option("sub-gray", WIDGET_LOOKUP(ui->subtitlesForceGrayscale).toBool());
     emit option("sub-font", WIDGET_LOOKUP(ui->fontComboBox).toString());

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -6179,7 +6179,7 @@ media file played</string>
              </layout>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="0" colspan="2">
             <widget class="QGroupBox" name="audioBalanceBox">
              <property name="title">
               <string>Audio balance</string>
@@ -6198,6 +6198,103 @@ media file played</string>
                 </property>
                 <property name="orientation">
                  <enum>Qt::Orientation::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QGroupBox" name="audioReplayGainBox">
+             <property name="title">
+              <string>Replay Gain</string>
+             </property>
+             <layout class="QGridLayout" name="audioReplayGainBoxLayout" columnstretch="0,1">
+              <item row="0" column="0">
+               <widget class="QLabel" name="replayGainModeLabel">
+                <property name="text">
+                 <string>Mode</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QComboBox" name="replayGainMode">
+                <item>
+                 <property name="text">
+                  <string>No</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Track</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Album</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="replayGainPreampLabel">
+                <property name="text">
+                 <string>Pre-amp</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="replayGainPreamp">
+                <property name="suffix">
+                 <string> dB</string>
+                </property>
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="minimum">
+                 <double>-15.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>15.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.500000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="replayGainFallbackLabel">
+                <property name="text">
+                 <string>Fallback</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <widget class="QDoubleSpinBox" name="replayGainFallback">
+                <property name="suffix">
+                 <string> dB</string>
+                </property>
+                <property name="decimals">
+                 <number>1</number>
+                </property>
+                <property name="minimum">
+                 <double>-15.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>15.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.500000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+               <widget class="QCheckBox" name="replayGainClip">
+                <property name="text">
+                 <string>Prevent clipping</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4387,6 +4387,34 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2788,7 +2788,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Caiguda</translation>
+        <translation>Caiguda</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4741,6 +4741,30 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2812,7 +2812,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Fallback</translation>
+        <translation>Fallback</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4770,6 +4770,30 @@ media file played</source>
     <message>
         <source>Use dark colors</source>
         <translation>Použít tmavé barvy</translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2794,7 +2794,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="obsolete">Ausweichlösung</translation>
+        <translation type="unfinished">Ausweichlösung</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4723,6 +4723,30 @@ media file played</source>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2820,7 +2820,7 @@ media file played</translation>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Fallback</translation>
+        <translation>Fallback</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4777,6 +4777,30 @@ media file played</translation>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2668,7 +2668,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Alternativa</translation>
+        <translation>Alternativa</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4573,6 +4573,30 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4381,6 +4381,34 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2742,7 +2742,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Fallback</translation>
+        <translation>Fallback</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4712,6 +4712,30 @@ fichier média lu</translation>
     <message>
         <source>VP8</source>
         <translation type="vanished">VP8</translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4525,6 +4525,34 @@ file media yang diputar</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4499,6 +4499,34 @@ ogni file multimediale riprodotto</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2810,7 +2810,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">フォールバック</translation>
+        <translation>フォールバック</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4780,6 +4780,30 @@ media file played</source>
     <message>
         <source>VP8</source>
         <translation type="vanished">VP8</translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2805,7 +2805,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Fallback</translation>
+        <translation>Fallback</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4762,6 +4762,30 @@ media file played</source>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4332,6 +4332,34 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4371,6 +4371,34 @@ media file played</source>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4659,6 +4659,34 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4427,6 +4427,34 @@ arquivo de mídia reproduzido</translation>
         <source>Use dark colors</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2768,7 +2768,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Резервная тема</translation>
+        <translation>Резервная тема</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4721,6 +4721,30 @@ media file played</source>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2790,7 +2790,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">தவறா</translation>
+        <translation>தவறா</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4751,6 +4751,30 @@ media file played</source>
     </message>
     <message>
         <source>Use dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2786,7 +2786,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">Yedek</translation>
+        <translation>Yedek</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4744,6 +4744,30 @@ yeni bir &amp;oynatıcı aç</translation>
     <message>
         <source>Use dark colors</source>
         <translation>Koyu renkleri kullan</translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4515,6 +4515,34 @@ media file played</source>
         <source>Show video preview (restart required)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Fallback</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2758,7 +2758,7 @@ media file played</source>
     </message>
     <message>
         <source>Fallback</source>
-        <translation type="vanished">备用方案</translation>
+        <translation>备用方案</translation>
     </message>
     <message>
         <source>Black (for white palette)</source>
@@ -4656,6 +4656,30 @@ media file played</source>
     <message>
         <source>VP8</source>
         <translation type="vanished">VP8</translation>
+    </message>
+    <message>
+        <source>Replay Gain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Album</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-amp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source> dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prevent clipping</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
mpv has Replay Gain support built in (replaygain={no,track,album}, replaygain-preamp, replaygain-clip, replaygain-fallback), but there was no UI to actually turn it on. People with Replay-Gain-tagged music libraries (foobar2000 / Picard / rsgain) had to edit input.conf or pass mpv options manually.

Adds a "Replay Gain" group on the audio settings page with four controls: Mode (No / Track / Album), Pre-amp (dB), Fallback (dB, applied when a file has no Replay Gain tag), and Prevent clipping. Wired through the existing audio-option pattern, the combo maps to mpv's enum strings via indexedValueToText, and sendSignals() emits the four option() signals that MpvObject already consumes.