### PR TITLE
widgets: add status time hover tooltip and double-click goto

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -398,6 +398,8 @@ void MainWindow::changeEvent(QEvent *event)
             tooltip->updatePalette();
         if (videoPreview)
             videoPreview->updatePalette();
+        if (statusTime)
+            statusTime->updatePalette();
     }
     else if (event->type() == QEvent::WindowStateChange && isMaximized())
         emit windowMaximized();
@@ -509,11 +511,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QPoint pos = event->globalPosition().toPoint();
     bool ok = mpvw ? insideWidget(pos, mpvw) : false;
-    if (mousePressedInBottomArea && insideWidget(pos, statusTime)) {
-        if (event->button() == Qt::MouseButton::LeftButton)
-            setTimeRemainingMode(!timeRemainingMode);
-    }
-    else {
+    if (!(mousePressedInBottomArea && insideWidget(pos, statusTime))) {
         if (ok && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseUp)))
             event->accept();
         else
@@ -882,6 +880,8 @@ void MainWindow::setupStatus()
     ui->statusbarLayout->insertWidget(2, statusTime);
     connect(statusTime, &StatusTime::customContextMenuRequested,
             this, &MainWindow::statusTime_customContextMenuRequested);
+    connect(statusTime, &StatusTime::doubleClicked,
+            ui->actionNavigateGoto, &QAction::trigger);
 }
 
 void MainWindow::setupSizing()

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -1,5 +1,7 @@
 #include <QPainter>
+#include <QMouseEvent>
 #include "helpers.h"
+#include "tooltip.h"
 #include "drawnstatus.h"
 
 static constexpr char logModule[] =  "drawnstatus";
@@ -8,6 +10,7 @@ StatusTime::StatusTime(QWidget *parent) : QWidget(parent)
 {
     setTime(0, 0);
     setMinimumSize(minimumSizeHint());
+    setAttribute(Qt::WA_Hover);
 }
 
 QSize StatusTime::minimumSizeHint() const
@@ -80,6 +83,10 @@ void StatusTime::updateText()
                                                                 'f',
                                                                 1)));
     }
+
+    if (hovered)
+        updateHoverTooltip();
+
     if (drawnText == lastDrawnText)
         return;
     lastDrawnText = drawnText;
@@ -89,6 +96,62 @@ void StatusTime::updateText()
         lastTextLength = drawnTextLength;
     }
     update();
+}
+
+void StatusTime::ensureHoverTooltip()
+{
+    if (hoverTooltip)
+        return;
+    QWidget *top = window();
+    if (!top || top == this)
+        return;
+    hoverTooltip = new Tooltip(top);
+}
+
+void StatusTime::updatePalette()
+{
+    if (hoverTooltip)
+        hoverTooltip->updatePalette();
+}
+
+void StatusTime::updateHoverTooltip()
+{
+    if (!hoverTooltip)
+        return;
+    QWidget *top = window();
+    if (!top)
+        return;
+    QString label = remainingMode ? tr("Played") : tr("Remaining");
+    double hoverTime = remainingMode ? currentTime : currentTime - currentDuration;
+    QString text = QString("%1: %2").arg(label,
+                                         Helpers::toDateFormatFixed(hoverTime, timeFormat));
+    QString textTemplate = QString("%1: %2").arg(label,
+                                                 Helpers::toDateFormatFixed(currentDuration, timeFormat));
+    QPoint topLeft = mapTo(top, QPoint(0, 0));
+    QPoint where(topLeft.x() + width() / 2, topLeft.y() - 2);
+    hoverTooltip->show(text, where, top->width(), textTemplate);
+}
+
+bool StatusTime::event(QEvent *event)
+{
+    switch (event->type()) {
+    case QEvent::HoverEnter:
+        hovered = true;
+        ensureHoverTooltip();
+        updateHoverTooltip();
+        break;
+    case QEvent::HoverLeave:
+        hovered = false;
+        if (hoverTooltip)
+            hoverTooltip->hide();
+        break;
+    case QEvent::ToolTip:
+        event->accept();
+        return true;
+    default:
+        break;
+    }
+    return QWidget::event(event);
 }
 
 void StatusTime::paintEvent(QPaintEvent *event)
@@ -107,4 +170,11 @@ void StatusTime::changeEvent(QEvent *event)
 {
     if (event->type() == QEvent::EnabledChange)
         setVisible(isEnabled());
+}
+
+void StatusTime::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    if (event->button() == Qt::LeftButton)
+        emit doubleClicked();
+    QWidget::mouseDoubleClickEvent(event);
 }

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -4,6 +4,8 @@
 #include <QWidget>
 #include "helpers.h"
 
+class Tooltip;
+
 class StatusTime : public QWidget
 {
     Q_OBJECT
@@ -15,23 +17,34 @@ public:
     void setShortMode(bool shortened);
     void setRemainingMode(bool isRemaining);
     void setPercentMode(bool isPercent);
+    void updatePalette();
+
+signals:
+    void doubleClicked();
 
 protected:
     void updateTimeFormat();
     void updateText();
     void paintEvent(QPaintEvent *event) override;
     void changeEvent(QEvent *event) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
+    bool event(QEvent *event) override;
 
 private:
+    void ensureHoverTooltip();
+    void updateHoverTooltip();
+
     bool shortMode = false;
     bool remainingMode = false;
     bool percentMode = false;
+    bool hovered = false;
     Helpers::TimeFormat timeFormat = Helpers::LongFormat;
     double currentTime = 0;
     double currentDuration = 0;
     QString drawnText;
     QString lastDrawnText;
     int lastTextLength = 0;
+    Tooltip *hoverTooltip = nullptr;
 };
 
 #endif // QDRAWNSTATUS_H

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4422,6 +4422,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4774,6 +4774,14 @@ arxiu multimèdia reproduït</translation>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4802,6 +4802,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4756,6 +4756,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4810,6 +4810,14 @@ media file played</translation>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4606,6 +4606,14 @@ archivo multimedia reproducido</translation>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4416,6 +4416,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4744,6 +4744,14 @@ fichier média lu</translation>
         <source> (%1%)</source>
         <translation> (%1 %)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation>Lu</translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation>Restant</translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4560,6 +4560,14 @@ file media yang diputar</translation>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4534,6 +4534,14 @@ ogni file multimediale riprodotto</translation>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4812,6 +4812,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4795,6 +4795,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4367,6 +4367,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4406,6 +4406,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4694,6 +4694,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4462,6 +4462,14 @@ arquivo de mídia reproduzido</translation>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4754,6 +4754,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4784,6 +4784,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation> (% 1%)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4776,6 +4776,14 @@ yeni bir &amp;oynatıcı aç</translation>
         <source> (%1%)</source>
         <translation> (%%1)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4550,6 +4550,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4688,6 +4688,14 @@ media file played</source>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
     </message>
+    <message>
+        <source>Played</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ThumbnailerWindow</name>


### PR DESCRIPTION
Last PR of the day, wrapping up a few small things I felt were missing compared to other players I've been using.

Three additions on the time display:

  - A "Show milliseconds in time display" checkbox under Tweaks, so it can be set from settings instead of right-clicking the time.
  - Double-click on the time in the status bar opens the Go To Time dialog.
  - When remaining-time mode is on, the display shows -remaining / played instead of -remaining / total. Normal mode is unchanged (played / total).

Also wanted to say really awesome project. I've already switched from Haruna to mpc-qt as my main player on CachyOS.

I hope you enjoyed my small PR so far and would be happy to help in the future if I see something relevant to fix or implement.