### PR TITLE
settingswindow: add searchable settings input

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -6,6 +6,7 @@
 #include <QColorDialog>
 #include <QStyleHints>
 #include <QToolTip>
+#include <QToolButton>
 #include "logger.h"
 #include "platform/unify.h"
 #include "settingswindow.h"
@@ -353,6 +354,13 @@ SettingsWindow::SettingsWindow(QWidget *parent) :
     setupColorPickers();
     setupUnimplementedWidgets();
     ui->pageStack->installEventFilter(this);
+
+    buildPageSearchIndex();
+
+    int headerHeight = std::max(ui->pageLabel->sizeHint().height(),
+                                ui->optionsSearchField->sizeHint().height());
+    ui->pageLabel->setFixedHeight(headerHeight);
+    ui->optionsSearchField->setFixedHeight(headerHeight);
 }
 
 SettingsWindow::~SettingsWindow()
@@ -386,6 +394,7 @@ void SettingsWindow::updateLanguage()
     ui->retranslateUi(this);
     ui->videoPresetApplied->clear();
     takeKeyMap(acceptedKeyMap);
+    buildPageSearchIndex();
 }
 
 void SettingsWindow::setupPageTree()
@@ -615,6 +624,7 @@ void SettingsWindow::takeActions(const QList<QAction *> actions)
     }
     actionEditor->setCommands(commandList);
     defaultKeyMap = actionEditor->toVMap();
+    buildPageSearchIndex();
 }
 
 void SettingsWindow::takeSettings(QVariantMap payload)
@@ -632,6 +642,7 @@ void SettingsWindow::takeKeyMap(const QVariantMap &payload)
     actionEditor->fromVMap(payload);
     actionEditor->updateActions();
     acceptedKeyMap = actionEditor->toVMap();
+    buildPageSearchIndex();
 }
 
 void SettingsWindow::setMouseMapDefaults(const QVariantMap &payload)
@@ -1253,18 +1264,92 @@ QList<MpvOption> SettingsWindow::parseMpvOptions(const QString &optionsInline) c
     return mpvOptions;
 }
 
+int SettingsWindow::pageIndexForTreeItem(const QModelIndex &index) const
+{
+    static const int parentIndex[] = { 0, 6, 13, 14, 16, 18, 19, 20 };
+    if (!index.isValid())
+        return -1;
+    if (!index.parent().isValid())
+        return parentIndex[index.row()];
+    return parentIndex[index.parent().row()] + index.row() + 1;
+}
+
+void SettingsWindow::buildPageSearchIndex()
+{
+    pageSearchTerms.clear();
+    for (int i = 0; i < ui->pageStack->count(); ++i) {
+        QWidget *page = ui->pageStack->widget(i);
+        if (!page)
+            continue;
+        QStringList terms;
+        for (auto *w : page->findChildren<QLabel*>())       terms << w->text();
+        for (auto *w : page->findChildren<QCheckBox*>())    terms << w->text();
+        for (auto *w : page->findChildren<QRadioButton*>()) terms << w->text();
+        for (auto *w : page->findChildren<QGroupBox*>())    terms << w->title();
+        for (auto *w : page->findChildren<QPushButton*>())  terms << w->text();
+        for (auto *w : page->findChildren<QToolButton*>())  terms << w->text();
+        for (auto *tabs : page->findChildren<QTabWidget*>())
+            for (int t = 0; t < tabs->count(); ++t)
+                terms << tabs->tabText(t);
+        for (auto *combo : page->findChildren<QComboBox*>())
+            for (int k = 0; k < combo->count(); ++k)
+                terms << combo->itemText(k);
+        for (auto *list : page->findChildren<QListWidget*>())
+            for (int k = 0; k < list->count(); ++k)
+                terms << list->item(k)->text();
+        if (page == ui->keysPage && actionEditor)
+            terms << actionEditor->searchableText();
+        pageSearchTerms[i] = terms.join(QChar(' '));
+    }
+}
+
+void SettingsWindow::on_optionsSearchField_textChanged(const QString &text)
+{
+    const QString needle = text.trimmed();
+    QTreeWidget *tree = ui->pageTree;
+
+    if (needle.isEmpty()) {
+        for (int i = 0; i < tree->topLevelItemCount(); ++i) {
+            QTreeWidgetItem *top = tree->topLevelItem(i);
+            top->setHidden(false);
+            for (int j = 0; j < top->childCount(); ++j)
+                top->child(j)->setHidden(false);
+        }
+        return;
+    }
+
+    for (int i = 0; i < tree->topLevelItemCount(); ++i) {
+        QTreeWidgetItem *top = tree->topLevelItem(i);
+        bool anyChildVisible = false;
+
+        for (int j = 0; j < top->childCount(); ++j) {
+            QTreeWidgetItem *child = top->child(j);
+            QModelIndex childIndex = tree->indexFromItem(child);
+            int pageIdx = pageIndexForTreeItem(childIndex);
+            bool match = child->text(0).contains(needle, Qt::CaseInsensitive)
+                      || pageSearchTerms.value(pageIdx).contains(needle, Qt::CaseInsensitive);
+            child->setHidden(!match);
+            anyChildVisible |= match;
+        }
+
+        QModelIndex topIndex = tree->indexFromItem(top);
+        int parentPageIdx = pageIndexForTreeItem(topIndex);
+        bool parentMatch = top->text(0).contains(needle, Qt::CaseInsensitive)
+                        || pageSearchTerms.value(parentPageIdx).contains(needle, Qt::CaseInsensitive);
+
+        top->setHidden(!(parentMatch || anyChildVisible));
+        if (anyChildVisible)
+            top->setExpanded(true);
+    }
+}
+
 void SettingsWindow::on_pageTree_itemSelectionChanged()
 {
     QModelIndex modelIndex = ui->pageTree->currentIndex();
     if (!modelIndex.isValid())
         return;
 
-    static int parentIndex[] = { 0, 6, 13, 14, 16, 18, 19, 20 };
-    int index = 0;
-    if (!modelIndex.parent().isValid())
-        index = parentIndex[modelIndex.row()];
-    else
-        index = parentIndex[modelIndex.parent().row()] + modelIndex.row() + 1;
+    int index = pageIndexForTreeItem(modelIndex);
     ui->pageStack->setCurrentIndex(index);
     ui->pageLabel->setText(QString("<big><b>%1</b></big>").
                            arg(modelIndex.data().toString()));
@@ -1296,6 +1381,7 @@ void SettingsWindow::closeEvent(QCloseEvent *event)
     Q_UNUSED(event)
     sendSignals();
     ui->keysSearchField->clear();
+    ui->optionsSearchField->clear();
     ui->videoPreset->setCurrentIndex(0);
 }
 

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -77,6 +77,8 @@ private:
     void updateLogoWidget();
     QString selectedLogo() const;
     QString channelSwitcher();
+    void buildPageSearchIndex();
+    int pageIndexForTreeItem(const QModelIndex &index) const;
 
 signals:
     void settingsData(const QVariantMap &s);
@@ -367,6 +369,8 @@ private slots:
 
     void on_logFilePathBrowse_clicked();
 
+    void on_optionsSearchField_textChanged(const QString &text);
+
 private:
     Ui::SettingsWindow *ui = nullptr;
     ActionEditor *actionEditor = nullptr;
@@ -381,6 +385,7 @@ private:
     QList<AudioDevice> audioDevices;
     QList<QPair<QString, QString>> audioFiltersList;
     QList<QPair<QString, QString>> videoFiltersList;
+    QMap<int, QString> pageSearchTerms;
 };
 
 #endif // SETTINGSWINDOW_H

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -28,21 +28,49 @@
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>
      </property>
-     <widget class="QTreeWidget" name="pageTree">
-      <property name="verticalScrollBarPolicy">
-       <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="horizontalScrollBarPolicy">
-       <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
-      </property>
-      <property name="headerHidden">
-       <bool>true</bool>
-      </property>
-      <column>
-       <property name="text">
-        <string>1</string>
+     <property name="handleWidth">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="leftPaneContainer" native="true">
+      <layout class="QVBoxLayout" name="leftPaneLayout" stretch="0,1">
+       <property name="leftMargin">
+        <number>0</number>
        </property>
-      </column>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>8</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLineEdit" name="optionsSearchField">
+         <property name="placeholderText">
+          <string>Search settings…</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTreeWidget" name="pageTree">
+         <property name="verticalScrollBarPolicy">
+          <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="headerHidden">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string>1</string>
+          </property>
+         </column>
       <item>
        <property name="text">
         <string>Player</string>
@@ -148,6 +176,9 @@
         <string>Miscellaneous</string>
        </property>
       </item>
+        </widget>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="stackHost" native="true">
       <property name="sizePolicy">
@@ -157,10 +188,24 @@
        </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="stackHostLayout" stretch="0,0">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QLabel" name="pageLabel">
+         <property name="styleSheet">
+          <string notr="true">QLabel#pageLabel {
+    background-color: palette(midlight);
+    border-bottom: 1px solid palette(mid);
+    padding-left: 12px;
+    padding-right: 12px;
+}</string>
+         </property>
          <property name="text">
           <string>&lt;big&gt;&lt;b&gt;Player</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>

--- a/src/widgets/actioneditor.cpp
+++ b/src/widgets/actioneditor.cpp
@@ -26,6 +26,19 @@ ActionEditor::ActionEditor(QWidget *parent) :
     setEditTriggers(QAbstractItemView::AllEditTriggers);
 }
 
+QString ActionEditor::searchableText() const
+{
+    QStringList parts;
+    for (int i = 0; i < model.rowCount(); ++i) {
+        for (int j = 0; j < model.columnCount(); ++j) {
+            QStandardItem *cell = model.item(i, j);
+            if (cell)
+                parts << cell->text();
+        }
+    }
+    return parts.join(QChar(' '));
+}
+
 void ActionEditor::filterActions(const QString &text)
 {
     if (text.isEmpty()) {

--- a/src/widgets/actioneditor.h
+++ b/src/widgets/actioneditor.h
@@ -30,6 +30,8 @@ public:
     QVariantMap toVMap() const;
     void fromVMap(const QVariantMap &map);
 
+    QString searchableText() const;
+
 private:
     QString getDescriptiveName(const QAction *action);
 

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4415,6 +4415,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4767,6 +4767,10 @@ arxiu multimèdia reproduït</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4795,6 +4795,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4749,6 +4749,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4803,6 +4803,10 @@ media file played</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4599,6 +4599,10 @@ archivo multimedia reproducido</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4409,6 +4409,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4737,6 +4737,10 @@ fichier média lu</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation>Rechercher dans les paramètres…</translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4553,6 +4553,10 @@ file media yang diputar</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4527,6 +4527,10 @@ ogni file multimediale riprodotto</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4805,6 +4805,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4788,6 +4788,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4360,6 +4360,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4399,6 +4399,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4687,6 +4687,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4455,6 +4455,10 @@ arquivo de mídia reproduzido</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4747,6 +4747,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4777,6 +4777,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4769,6 +4769,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4543,6 +4543,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4681,6 +4681,10 @@ media file played</source>
         <source>Prevent clipping</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>


### PR DESCRIPTION
There's so many options in the settings that I couldn't always find what I was looking for, so I added a small search bar at the top of the Options window.
It just filters the left tree as you type, matches against category names, setting labels, combo box entries, and even keyboard shortcuts (both action names and the keys themselves, so typing "space" or "play" both work).
While I was at it I also gave the right pane title a small header bar so it's a bit more obvious where you are, and made it follow the theme.

Translated the new placeholder to French. Other languages will show the English string until someone translates it.

Resolves #751 

Sorry this is the last one for today but I think would make life easier for many people

[Enregistrement d'écran_20260512_193818.webm](https://github.com/user-attachments/assets/34af77f2-1c82-4be4-82ba-a65772939eb4)
