### PR TITLE
main: Always set mpv "start" position on file change

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1610,11 +1610,12 @@ void Flow::manager_aboutToStartPlayingFile()
 void Flow::manager_startedPlayingFile(QUrl url)
 {
     Logger::log(logModule, "manager_startedPlayingFile");
+    double position = 0;
     if (rememberFilePosition) {
         // Check if there's a position saved in recents for this file
         foreach (TrackInfo track, recentFiles) {
             if (track.url == url) {
-                playbackManager->navigateToTime(track.position);
+                position = track.position;
                 playbackManager->restoreVideoTrack(track.videoTrack);
                 playbackManager->restoreAudioTrack(track.audioTrack);
                 playbackManager->restoreSubtitleTrack(track.subtitleTrack);
@@ -1622,6 +1623,7 @@ void Flow::manager_startedPlayingFile(QUrl url)
             }
         }
     }
+    playbackManager->navigateToTime(position);
 }
 void Flow::manager_stoppedPlaying()
 {


### PR DESCRIPTION
mpv keeps the same start position even when loading a new file.
So set it to 0 if we don't restore a position.

Fixes: 9ded1d2bbe16aaf673a18d68043d21b9a0fe279a ("Use mpv "start" property to resume position")