### PR TITLE
mainwindow: arm AB loop when B is set at current playback position

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3420,16 +3420,14 @@ void MainWindow::on_actionPlayLoopStart_triggered()
 {
     positionSlider_->setLoopA(mpvObject_->playTime());
     if (ui->actionPlayLoopUse->isChecked())
-        mpvObject_->setLoopPoints(positionSlider_->loopA(),
-                                  positionSlider_->loopB());
+        armAbLoop();
 }
 
 void MainWindow::on_actionPlayLoopEnd_triggered()
 {
     positionSlider_->setLoopB(mpvObject_->playTime());
     if (ui->actionPlayLoopUse->isChecked())
-        mpvObject_->setLoopPoints(positionSlider_->loopA(),
-                                  positionSlider_->loopB());
+        armAbLoop();
 }
 
 void MainWindow::on_actionPlayLoopUse_toggled(bool checked)
@@ -3441,11 +3439,22 @@ void MainWindow::on_actionPlayLoopUse_toggled(bool checked)
         if (positionSlider_->loopB() < 0 )
             positionSlider_->setLoopB(mpvObject_->playLength());
 
-        mpvObject_->setLoopPoints(positionSlider_->loopA(),
-                                  positionSlider_->loopB());
+        armAbLoop();
     }
     else
         mpvObject_->setLoopPoints(-1, -1);
+}
+
+void MainWindow::armAbLoop()
+{
+    double a = positionSlider_->loopA();
+    double b = positionSlider_->loopB();
+    mpvObject_->setLoopPoints(a, b);
+    if (a < 0 || b < 0)
+        return;
+    double loopEnd = std::max(a, b);
+    if (mpvObject_->playTime() > loopEnd)
+        mpvObject_->setTime(std::min(a, b));
 }
 
 void MainWindow::on_actionPlayLoopClear_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -125,6 +125,7 @@ private:
     void raiseWindow();
     void createAlwaysOnTopWindow();
     void showAlwaysOnTopWindow(bool show);
+    void armAbLoop();
 
     QIcon createIconFromSvg(const QString &svgPath, int maxSize) const;
     QPixmap renderPixmapFromSvg(const QString &path) const;


### PR DESCRIPTION
When you press "Set Loop End" while playing, B gets set to the current playback time, so the playhead is sitting right on B at the moment the loop is armed. mpv only triggers ab-loop when the playhead crosses B from inside the range, so playback just keeps going past B until you seek back into [A, B] yourself.

Fix is to seek back to A with setTime() right after setLoopPoints when the loop is enabled, the range is valid, and the playhead is at or past B. Applied to all three handlers that arm the loop (Set Start, Set End, and Use toggled), so the same situation is also handled when re-enabling the loop after playback drifted past B while it was off.

Resolves #949