### PR TITLE
tooltip: Reduce sides margin and use lighter border for dark palettes, paletteeditor: Restore visibility of Light, Midlight and Mid

### DIFF
--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -111,8 +111,7 @@ PaletteEditor::PaletteEditor(QWidget *parent) : QWidget(parent)
         col = 0;
         QLabel* roleTitle = new QLabel(colorRoleTitle);
         layout->addWidget(roleTitle, row, col++);
-        QList lightTitles = {QPalette::Light, QPalette::Midlight, QPalette::Dark,
-                             QPalette::Mid, QPalette::BrightText, QPalette::LinkVisited,
+        QList lightTitles = {QPalette::Dark, QPalette::BrightText, QPalette::LinkVisited,
                              QPalette::AlternateBase, QPalette::NoRole};
         if (lightTitles.contains(colorRole))
             roleTitle->setStyleSheet("font-weight: 100;");

--- a/src/widgets/tooltip.cpp
+++ b/src/widgets/tooltip.cpp
@@ -2,7 +2,7 @@
 #include "tooltip.h"
 
 static constexpr char logModule[] =  "tooltip";
-static constexpr int windowSidesMargin = 20;
+static constexpr int windowSidesMargin = 5;
 static constexpr int insidePadding = 10;
 
 Tooltip::Tooltip(QWidget *parent) : QWidget(parent)
@@ -25,7 +25,10 @@ Tooltip::~Tooltip()
 
 void Tooltip::updatePalette()
 {
-    QPalette palette = QApplication::palette();
+    const QPalette palette = QApplication::palette();
+    const auto text = palette.color(QPalette::WindowText);
+    const auto window = palette.color(QPalette::Window);
+    const bool darkPalette = text.lightness() > window.lightness();
     QString css = QString(
         "background-color: %1;"
         "color: %2;"
@@ -34,7 +37,7 @@ void Tooltip::updatePalette()
     )
     .arg(palette.color(QPalette::ToolTipBase).name(),
         palette.color(QPalette::ToolTipText).name(),
-        palette.color(QPalette::Mid).name());
+        palette.color(darkPalette ? QPalette::Light : QPalette::Mid).name());
 
     textLabel->setStyleSheet(css);
 }


### PR DESCRIPTION
* tooltip: Reduce sides margin and use lighter border for dark palettes
Reduce the sides margin since it interferes with the status time tooltip of https://github.com/mpc-qt/mpc-qt/commit/336c722bb4b3ba527af510f401b65694e04eb220.
Use a lighter border color for dark palettes
* paletteeditor: Restore visibility of Light, Midlight and Mid
Since https://github.com/mpc-qt/mpc-qt/commit/ab7ce73c1b380b8d392d7a6b644d4569d59893fd, the Mid color is used for the tooltip border (now only for light palettes).
Since https://github.com/mpc-qt/mpc-qt/commit/e9a7293ecaa3262474c281e15696c400c195c982, the Light, Mid and Midlight colors are used for the colors and audio balance sliders in the settings.
Since https://github.com/mpc-qt/mpc-qt/commit/fe6ec389571d5f634d977452e86d6f690c3ffa1a, the Light color is used for the tooltip border with dark palettes.