### PR TITLE
Simplify the way the title bar is set and rename "Don't prefix anything" title bar setting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -605,7 +605,7 @@ void Flow::setupMainWindowConnections()
 
     // propertieswindow -> mainwindow
     connect(propertiesWindow, &PropertiesWindow::artistAndTitleChanged,
-            mainWindow, &MainWindow::setMediaTitleWithFilename);
+            mainWindow, &MainWindow::setMediaTitle);
 
     // mainwindow -> playlistwindow
     connect(mainWindow, &MainWindow::playCurrentItemRequested,
@@ -618,8 +618,8 @@ void Flow::setupMainWindowConnections()
     // manager -> mainwindow
     connect(playbackManager, &PlaybackManager::timeChanged,
             mainWindow, &MainWindow::setTime);
-    connect(playbackManager, &PlaybackManager::titleChangedWithFilename,
-            mainWindow, &MainWindow::setMediaTitleWithFilename);
+    connect(playbackManager, &PlaybackManager::titleChanged,
+            mainWindow, &MainWindow::setMediaTitle);
     connect(playbackManager, &PlaybackManager::videoSizeChanged,
             mainWindow, &MainWindow::setVideoSize);
     connect(playbackManager, &PlaybackManager::stateChanged,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1788,7 +1788,7 @@ void MainWindow::httpAfterPlaybackLock()
 void MainWindow::setFreestanding(bool freestanding)
 {
     freestanding_ = freestanding;
-    setMediaTitleWithFilename(QString(), QString());
+    setMediaTitle(QString());
 }
 
 void MainWindow::setNoVideoSize(const QSize &size)
@@ -1808,7 +1808,7 @@ void MainWindow::setTrayIcon(bool enabled)
 void MainWindow::setTitleBarFormat(Helpers::TitlePrefix titlebarFormat)
 {
     titlebarFormat_ = titlebarFormat;
-    setMediaTitleWithFilename(currentFileTitle, currentFileName);
+    setMediaTitle(currentFileTitle);
 }
 
 void MainWindow::setWindowedMouseMap(const MouseStateMap &map)
@@ -1955,20 +1955,20 @@ void MainWindow::setTime(double time, double length)
     statusTime->setTime(time, length);
 }
 
-void MainWindow::setMediaTitleWithFilename(const QString& title, const QString& filename)
+void MainWindow::setMediaTitle(const QString &title)
 {
     currentFileTitle = title;
-    currentFileName = filename;
     QString newTitle = title;
     QString windowTitle(textWindowTitle);
 
     switch(titlebarFormat_) {
         case PrefixFullPath:
-            newTitle = currentFile.toString();
+            if (currentFile.isLocalFile())
+                newTitle = currentFile.path();
             break;
         case PrefixFileName:
-            if (!filename.isEmpty())
-                newTitle = filename;
+            if (currentFile.isLocalFile())
+                newTitle = currentFile.fileName();
             break;
         case PrefixFileTitle:
             break;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -259,7 +259,7 @@ public slots:
     void setHighContrastWidgets(bool yes);
     void setInfoColors(const QColor &foreground, const QColor &background);
     void setTime(double time, double length);
-    void setMediaTitleWithFilename(const QString& title, const QString& filename);
+    void setMediaTitle(const QString &title);
     void setChapterTitle(QString title);
     void setAspectName(QString aspectName);
     void setVideoSize(QSize size);
@@ -578,7 +578,6 @@ private:
     int currentAngle = 0;
     bool flipped = false;
     QUrl currentFile;
-    QString currentFileName;
     QString currentFileTitle;
 
     IconThemer themer;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1096,8 +1096,6 @@ void PlaybackManager::mpvw_mediaTitleChanged(QString title)
 {
     nowPlayingTitle_ = title;
     emit titleChanged(title);
-    emit titleChangedWithFilename(title,
-                                  nowPlaying().isLocalFile() ? nowPlaying().fileName() : QString());
 }
 
 void PlaybackManager::mpvw_chaptersChanged(QVariantList chapters)

--- a/src/manager.h
+++ b/src/manager.h
@@ -63,7 +63,6 @@ signals:
     void timeChanged(double time, double length);
     void playLengthChanged();
     void titleChanged(QString title);
-    void titleChangedWithFilename(QString title, QString filename);
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
     void stateChanged(PlaybackManager::PlaybackState state, int bufferFillState = 0);

--- a/src/propertieswindow.cpp
+++ b/src/propertieswindow.cpp
@@ -195,8 +195,7 @@ void PropertiesWindow::setMetaData(QVariantMap data)
 
     generalData.insert(data);
     if (data.contains("artist") && data.contains("title"))
-        emit artistAndTitleChanged(data["artist"].toString() + " - " + data["title"].toString(),
-                                   this->filename);
+        emit artistAndTitleChanged(data["artist"].toString() + " - " + data["title"].toString());
     updateLastTab();
 }
 

--- a/src/propertieswindow.h
+++ b/src/propertieswindow.h
@@ -20,7 +20,7 @@ public:
     void updateLanguage();
 
 signals:
-    void artistAndTitleChanged(QString artistAndTitle, QString filename);
+    void artistAndTitleChanged(QString artistAndTitle);
 
 public slots:
     void setFileName(const QString &filename);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -367,7 +367,7 @@
               <item>
                <widget class="QRadioButton" name="playerTitleDontPrefix">
                 <property name="text">
-                 <string>Don't prefi&amp;x anything</string>
+                 <string>A&amp;pplication name only</string>
                 </property>
                </widget>
               </item>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2459,10 +2459,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4417,6 +4413,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2668,7 +2668,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>No afegir prefi&amp;xos a res</translation>
+        <translation type="vanished">No afegir prefi&amp;xos a res</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4769,6 +4769,10 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2691,10 +2691,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Replace file name with title</source>
         <translation type="vanished">Replace file name with title</translation>
     </message>
@@ -4797,6 +4793,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2678,7 +2678,7 @@ media file played</source>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Nichts voran&amp;stellen</translation>
+        <translation type="vanished">Nichts voran&amp;stellen</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4751,6 +4751,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2700,7 +2700,7 @@ media file played</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Don&apos;t prefi&amp;x anything</translation>
+        <translation type="vanished">Don&apos;t prefi&amp;x anything</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4805,6 +4805,10 @@ media file played</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2556,7 +2556,7 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>No añadir prefijos a nada</translation>
+        <translation type="vanished">No añadir prefijos a nada</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4601,6 +4601,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2517,10 +2517,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4411,6 +4407,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2622,7 +2622,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Ne rien préfi&amp;xer</translation>
+        <translation type="vanished">Ne rien préfi&amp;xer</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4740,6 +4740,10 @@ fichier média lu</translation>
     <message>
         <source>Search settings…</source>
         <translation>Rechercher dans les paramètres…</translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2594,7 +2594,7 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Jangan tambahkan awalan apa pun</translation>
+        <translation type="vanished">Jangan tambahkan awalan apa pun</translation>
     </message>
     <message>
         <source>History</source>
@@ -4555,6 +4555,10 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2544,7 +2544,7 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Non usare alcun prefi&amp;sso</translation>
+        <translation type="vanished">Non usare alcun prefi&amp;sso</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4529,6 +4529,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2690,7 +2690,7 @@ media file played</source>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>接頭辞を付けない(&amp;X)</translation>
+        <translation type="vanished">接頭辞を付けない(&amp;X)</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4808,6 +4808,10 @@ media file played</source>
     <message>
         <source>Search settings…</source>
         <translation>検索設定…</translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2684,10 +2684,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Replace file name with title</source>
         <translation type="vanished">Replace file name with title</translation>
     </message>
@@ -4790,6 +4786,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2448,10 +2448,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4362,6 +4358,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2463,10 +2463,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4401,6 +4397,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2675,10 +2675,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Replace file name with title</source>
         <translation type="vanished">Zamień nazwę pliku tytułem</translation>
     </message>
@@ -4689,6 +4685,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2499,10 +2499,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4457,6 +4453,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2648,7 +2648,7 @@ media file played</source>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Ничего не д&amp;елать</translation>
+        <translation type="vanished">Ничего не д&amp;елать</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4749,6 +4749,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2670,7 +2670,7 @@ media file played</source>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>ப்ரீஃபி &amp; ஃச் எதையும் வேண்டாம்</translation>
+        <translation type="vanished">ப்ரீஃபி &amp; ஃச் எதையும் வேண்டாம்</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4779,6 +4779,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2670,7 +2670,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>Hiçbir şeye ö&amp;nek koyma</translation>
+        <translation type="vanished">Hiçbir şeye ö&amp;nek koyma</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4771,6 +4771,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2579,10 +2579,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Don&apos;t prefi&amp;x anything</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>History</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4545,6 +4541,10 @@ media file played</source>
     </message>
     <message>
         <source>Search settings…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2646,7 +2646,7 @@ media file played</source>
     </message>
     <message>
         <source>Don&apos;t prefi&amp;x anything</source>
-        <translation>不要添加任何前缀(&amp;X)</translation>
+        <translation type="vanished">不要添加任何前缀(&amp;X)</translation>
     </message>
     <message>
         <source>Replace file name with title</source>
@@ -4684,6 +4684,10 @@ media file played</source>
     <message>
         <source>Search settings…</source>
         <translation>搜索设置…</translation>
+    </message>
+    <message>
+        <source>A&amp;pplication name only</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
* Simplify the way the title bar is set

> There were two sources of the same data, with only one of them being
> actually used. So change it to:
> PropertiesWindow sends the title in "artist - title" format for audio
> files.
> PlaybackManager sends the title when it changes. Reuse the file name
> already set for the video preview.
> File name and full path are formatted in MainWindow::setMediaTitle.
> 
> Fixes special characters being URL encoded for full path mode.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/952 ("URL encoding used in title bar if unusual character in path
> or filename").

* settingswindow: Rename "Don't prefix anything" title bar setting

> Since https://github.com/mpc-qt/mpc-qt/commit/85d255a4a39a691d8a2bff86ba9fdb85f9c1a60f we don't append the app
> name to the window title when a file is loaded.
> So rename the "Don't prefix anything" setting by "Application name
> only".