### PR TITLE
Fix step forward button width and reduce buttons spacing 

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -122,7 +122,7 @@
           </item>
           <item>
            <widget class="QWidget" name="controlbar" native="true">
-            <layout class="QHBoxLayout" name="controlbarLayout" stretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0">
+            <layout class="QHBoxLayout" name="controlbarLayout">
              <property name="spacing">
               <number>2</number>
              </property>
@@ -433,12 +433,6 @@
               <widget class="QPushButton" name="stepForward">
                <property name="enabled">
                 <bool>false</bool>
-               </property>
-               <property name="maximumSize">
-                <size>
-                 <width>31</width>
-                 <height>40</height>
-                </size>
                </property>
                <property name="toolTip">
                 <string>Step Forward</string>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -124,7 +124,7 @@
            <widget class="QWidget" name="controlbar" native="true">
             <layout class="QHBoxLayout" name="controlbarLayout">
              <property name="spacing">
-              <number>2</number>
+              <number>0</number>
              </property>
              <property name="leftMargin">
               <number>6</number>

--- a/src/playlistwindow.ui
+++ b/src/playlistwindow.ui
@@ -118,6 +118,9 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="tabButtonLayout">
+      <property name="spacing">
+       <number>2</number>
+      </property>
       <item>
        <widget class="QPushButton" name="newTab">
         <property name="toolTip">


### PR DESCRIPTION
* mainwindow: Fix step forward button width

> Remove the custom stretch factor from controlbarLayout (it was making stepForward stretch) and the maximumSize used for stepForward as a workaround.
> Since https://github.com/mpc-qt/mpc-qt/commit/cca936c3e79db13a98921c5b142287a9c9bc7a51, that maximumSize was too wide.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/bf8181b1a346af03563997eea5d8a27076fc014f ("Add vertical dividers between control buttons").
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/cca936c3e79db13a98921c5b142287a9c9bc7a51 ("Reduce buttons size to 12px instead of default 16px")

* Reduce buttons spacing

> The buttons spacing in relation to their size is somewhat large since https://github.com/mpc-qt/mpc-qt/commit/cca936c3e79db13a98921c5b142287a9c9bc7a51.
> 
> Set the control bar buttons spacing to zero instead of 2.
> Set the playlist window buttons spacing to 2 instead of default 6.
> 
> There still an additional built-in 2-pixel spacing between the buttons.
> 
> Follow-up to cca936c3e79db13a98921c5b142287a9c9bc7a51 ("Reduce buttons size to 12px instead of default 16px").