### PR TITLE
Speed up video transitions and prevent previous-frame flashing

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1113,6 +1113,8 @@ void PlaybackManager::mpvw_tracksChanged(QVariantList tracks)
     audioListData.clear();
     subtitleList.clear();
     subtitleListData.clear();
+    if (tracks.empty())
+        return;
     Track track;
 
     for (QVariant const &trackItem : tracks) {

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -364,6 +364,7 @@ void MpvObject::discFilesOpen(QString path) {
 void MpvObject::stopPlayback()
 {
     emit ctrlCommand("stop");
+    setDrawLogo(true);
 }
 
 void MpvObject::stepBackward()
@@ -985,8 +986,6 @@ MpvGlWidget::MpvGlWidget(MpvObject *object, QWidget *parent) :
             this, &MpvGlWidget::self_frameSwapped);
     connect(mpvObject, &MpvObject::playbackStarted,
             this, &MpvGlWidget::self_playbackStarted);
-    connect(mpvObject, &MpvObject::playbackFinished,
-            this, &MpvGlWidget::self_playbackFinished);
     setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
@@ -1088,7 +1087,7 @@ void MpvGlWidget::paintGL()
     if (mpvObject->clientDebuggingMessages())
         Logger::log(logModule, "paintGL");
     if (drawLogo || !render) {
-        if (logo)
+        if (logo && drawLogo)
             logo->paintGL(this);
         return;
     }
@@ -1214,12 +1213,6 @@ void MpvGlWidget::self_frameSwapped()
 void MpvGlWidget::self_playbackStarted()
 {
     drawLogo = false;
-}
-
-void MpvGlWidget::self_playbackFinished()
-{
-    drawLogo = true;
-    update();
 }
 
 

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -345,10 +345,12 @@ void MpvObject::urlOpen(QUrl url)
 void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist)
 {
     clearSubFiles();
+    setMpvPropertyVariant("vid", "no");
     if (replaceMpvPlaylist)
         emit ctrlCommand(QStringList({"loadfile", filename}));
     else
         emit ctrlCommand(QStringList({"loadfile", filename, "append-play"}));
+    setMpvPropertyVariant("vid", "auto");
     setMouseHideTime(hideTimer->interval());
 }
 

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -284,7 +284,6 @@ private slots:
     void maybeUpdate();
     void self_frameSwapped();
     void self_playbackStarted();
-    void self_playbackFinished();
 
 private:
     static constexpr char logModule[] = "glwidget";


### PR DESCRIPTION
* Only draw logo when no video file is loaded or loading

> We used to draw the logo every time a new file was being loaded (because mpv reports no tracks at all during the loading).
> But drawing the logo (or an empty image) is slow, and drawing it between videos slows down the loading.
> It also used to quickly show the previous video before beginning playing the new one.
> Instead, the previous video will be shown the whole time until the next one starts playing.
> Since https://github.com/mpc-qt/mpc-qt/commit/418f8085bf6e80f28c3589e29518cd4965fb67fd, we don't close the file at the end, so we don't need to wait for mpv to report that the playback is finished, we can show the logo as soon as the user manually stops the video.
> 
> Draw the logo as soon as we stop playing or when the file does contain tracks but no video track.

* mpvwidget: Force mpv to clear last frame of previous video file

> When loading a new video file, mpv keeps the last frame of the previous one until it actually begins playing the new one.
> Before https://github.com/mpc-qt/mpc-qt/commit/3eccf09b2e4ee621b733ec3653788314e555e99e, it led to blinking (last frame -> logo image -> last frame -> new frame).
> Since then, it led to a frozen last frame until the new frame.
> 
> By disabling the video track then re-enabling it, we force mpv to only output a black frame until it has decoded the first new frame.
> Combined with https://github.com/mpc-qt/mpc-qt/commit/3eccf09b2e4ee621b733ec3653788314e555e99e, this leads to a faster video transition without lingering last frame.