### PR TITLE
main: Update main window playing state after translation update

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -473,6 +473,7 @@ void Flow::setTranslation(bool updateTranslations)
 
     if (updateTranslations) {
         mainWindow->updateLanguage();
+        mainWindow->setPlaybackState(playbackManager->playbackState(), 0);
         mainWindow->playlistWindow()->updateLanguage();
         settingsWindow->updateLanguage();
         propertiesWindow->updateLanguage();


### PR DESCRIPTION
retranslateUi re-applies the default text ("Stopped"), so we need to set it afterwards to the current one.

Fixes 11f9a573fb1237cd4c3bb5111a081707d77db19d ("Apply language change immediately")