### PR TITLE
Migrate video horizontal flip to filterlist and make it a toggle

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3223,18 +3223,16 @@ void MainWindow::on_actionRotateCounterclockwise_triggered()
     mpvObject_->setVideoRotate(currentAngle);
 }
 
-void MainWindow::on_actionFlipHorizontal_triggered()
+void MainWindow::on_actionFlipHorizontal_toggled(bool checked)
 {
-    flipped = !flipped;
-    mpvObject_->setVideoFlip(flipped);
+    emit videoFilter("hflip", "", checked);
 }
 
 void MainWindow::on_actionResetRotate_triggered()
 {
     currentAngle = 0;
-    flipped = false;
     mpvObject_->setVideoRotate(0);
-    mpvObject_->setVideoFlip(false);
+    ui->actionFlipHorizontal->setChecked(false);
 }
 
 void MainWindow::on_actionViewOntopAlways_toggled(bool checked)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -403,7 +403,7 @@ private slots:
     void on_actionResetMove_triggered();
     void on_actionRotateClockwise_triggered();
     void on_actionRotateCounterclockwise_triggered();
-    void on_actionFlipHorizontal_triggered();
+    void on_actionFlipHorizontal_toggled(bool checked);
     void on_actionResetRotate_triggered();
 
     void on_actionViewOntopDefault_toggled(bool checked);
@@ -576,7 +576,6 @@ private:
     double videoPanX = 0;
     double videoPanY = 0;
     int currentAngle = 0;
-    bool flipped = false;
     QUrl currentFile;
     QString currentFileTitle;
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -2523,6 +2523,9 @@
    </property>
   </action>
   <action name="actionFlipHorizontal">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
     <string>&amp;Horizontal Flip</string>
    </property>

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -526,15 +526,6 @@ void MpvObject::setVideoRotate(int angle)
     setMpvPropertyVariant("video-rotate", angle);
 }
 
-void MpvObject::setVideoFlip(bool flip)
-{
-    if (flip) {
-        setMpvOptionVariant("vf", "hflip");
-    } else {
-        setMpvOptionVariant("vf", "");
-    }
-}
-
 int64_t MpvObject::chapter()
 {
     return chapter_;

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -83,7 +83,6 @@ public:
     void setVideoPanX(double value);
     void setVideoPanY(double value);
     void setVideoRotate(int angle);
-    void setVideoFlip(bool flip);
 
     int64_t chapter();
     void changeChapter(int diff);


### PR DESCRIPTION
Allows its use combined with other video filters and shows the current state in the menu.

Follow-up to a5e2d129e56f306ba2cfe98d5dd741d8c36511c5 ("Add Rotate and horizontal flip feature").