### PR TITLE
mainwindow: Empty title bar on stop

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1976,6 +1976,8 @@ void MainWindow::setMediaTitle(const QString &title)
             newTitle.clear();
             break;
     }
+    if (title.isEmpty())
+        newTitle = QString();
     if (!newTitle.isEmpty())
         windowTitle = newTitle;
 


### PR DESCRIPTION
The file name isn't sent anymore from the PlaybackManager since dffbc6bb1223920ba8c03acd0d9011c57e3de8e5 so the title bar wouldn't reset in file name and full path mode.
Since mpv sends an empty title when no file is loaded, we can use that.
Note that when a file has no title, mpv sends the file name as title.

Fixes: dffbc6bb1223920ba8c03acd0d9011c57e3de8e5 ("Simplify the way the title bar is set")