### PR TITLE
playlistwindow: Remove Close Tab button at the bottom

### DIFF
--- a/res/CMakeLists.txt
+++ b/res/CMakeLists.txt
@@ -22,7 +22,6 @@ set(res_resource_files
     images/theme/black/media-skip-forward.svg
     images/theme/black/player-volume-muted.svg
     images/theme/black/player-volume.svg
-    images/theme/black/tab-close.svg
     images/theme/black/tab-duplicate.svg
     images/theme/black/tab-new.svg
     images/theme/black/view-media-queue.svg
@@ -44,7 +43,6 @@ set(res_resource_files
     images/theme/white/media-skip-forward.svg
     images/theme/white/player-volume-muted.svg
     images/theme/white/player-volume.svg
-    images/theme/white/tab-close.svg
     images/theme/white/tab-duplicate.svg
     images/theme/white/tab-new.svg
     images/theme/white/video-x-generic-16.svg

--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -347,7 +347,6 @@ void PlaylistWindow::setupIconThemer()
 {
     QVector<IconThemer::IconData> data {
         { ui->newTab, "tab-new", {} },
-        { ui->closeTab, "tab-close", {} },
         { ui->duplicateTab, "tab-duplicate", {} },
         { ui->importList, "document-import", {} },
         { ui->exportList, "document-export", {} },
@@ -369,8 +368,6 @@ void PlaylistWindow::connectSignalsToSlots()
 
     connect(ui->newTab, &QPushButton::clicked,
             this, &PlaylistWindow::newTab);
-    connect(ui->closeTab, &QPushButton::clicked,
-            this, &PlaylistWindow::closeTab);
     connect(ui->duplicateTab, &QPushButton::clicked,
             this, &PlaylistWindow::duplicateTab);
     connect(ui->importList, &QPushButton::clicked,

--- a/src/playlistwindow.ui
+++ b/src/playlistwindow.ui
@@ -140,24 +140,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="closeTab">
-        <property name="toolTip">
-         <string>Close Tab</string>
-        </property>
-        <property name="icon">
-         <iconset>
-          <normalon>:/images/theme/black/tab-close.svg</normalon>
-         </iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>12</width>
-          <height>12</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QPushButton" name="duplicateTab">
         <property name="toolTip">
          <string>Duplicate Tab</string>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1967,10 +1967,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Close Tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Duplicate Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2144,7 +2144,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Tancar pestanya</translation>
+        <translation type="vanished">Tancar pestanya</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2172,7 +2172,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Zavřít záložku</translation>
+        <translation type="vanished">Zavřít záložku</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2162,7 +2162,7 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Tab schließen</translation>
+        <translation type="vanished">Tab schließen</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2176,7 +2176,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Close Tab</translation>
+        <translation type="vanished">Close Tab</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2032,7 +2032,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Cerrar la pestaña</translation>
+        <translation type="vanished">Cerrar la pestaña</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2004,7 +2004,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Sulje Välilehti</translation>
+        <translation type="vanished">Sulje Välilehti</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2102,7 +2102,7 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Fermer l’onglet</translation>
+        <translation type="vanished">Fermer l’onglet</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2094,7 +2094,7 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Tutup Tab</translation>
+        <translation type="vanished">Tutup Tab</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2028,7 +2028,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Chiudi scheda</translation>
+        <translation type="vanished">Chiudi scheda</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2166,7 +2166,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>タブを閉じる</translation>
+        <translation type="vanished">タブを閉じる</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2164,10 +2164,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Close Tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Duplicate Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1943,10 +1943,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Close Tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Duplicate Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1971,10 +1971,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Close Tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Duplicate Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2156,7 +2156,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Zamknij zakładkę</translation>
+        <translation type="vanished">Zamknij zakładkę</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1988,7 +1988,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Fechar Aba</translation>
+        <translation type="vanished">Fechar Aba</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2124,7 +2124,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Закрыть вкладку</translation>
+        <translation type="vanished">Закрыть вкладку</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2146,7 +2146,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>தாவலை மூடு</translation>
+        <translation type="vanished">தாவலை மூடு</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2146,7 +2146,7 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>Sekmeyi Kapat</translation>
+        <translation type="vanished">Sekmeyi Kapat</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2083,10 +2083,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Close Tab</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Duplicate Tab</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2122,7 +2122,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation>关闭标签页</translation>
+        <translation type="vanished">关闭标签页</translation>
     </message>
     <message>
         <source>Duplicate Tab</source>


### PR DESCRIPTION
The tabs already have a close button, so it's redundant.
It can also confuse users who may think it will remove the current item and end up closing the current tab.