### PR TITLE
helpers: Don't sort items by URL when filtering them

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -608,14 +608,6 @@ QList<QUrl> Helpers::filterUrls(const QList<QUrl> &urls) {
                 filtered.append(QUrl::fromLocalFile(info.filePath()));
         }
     }
-
-    QCollator collator;
-    collator.setCaseSensitivity(Qt::CaseInsensitive);
-    collator.setNumericMode(true);
-
-    using namespace std::placeholders;
-    std::sort(filtered.begin(), filtered.end(), std::bind(&Helpers::compareUrls, _1, _2, collator));
-
     return filtered;
 }
 


### PR DESCRIPTION
a3032227e9cb1da9f2a8956630a1440215be6f06 added auto sorting (by URL) of filtered items.
This means that items added by the user wouldn't keep their original order.
The rest of the list wouldn't get sorted though so it only made sense when creating a list and adding the list items all at once.

A better way to achieve the intended behavior would be to convert the playlists sort commands to toggles (in a submenu) and add a global setting for new playlists to choose the default sorting order.

Partially reverts: a3032227e9cb1da9f2a8956630a1440215be6f06 ("Better processing and sorting of [new] playlist items")

Fixes #860 ("Files opened externally (drag & drop, file association, Nautilus selection) are sorted alphabetically, ignoring playlist order").