### PR TITLE
Show hardware decoding state in a main window playback status tooltip

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -647,6 +647,8 @@ void Flow::setupMainWindowConnections()
             mainWindow, &MainWindow::setAudioBitrate);
     connect(playbackManager, &PlaybackManager::videoBitrateChanged,
             mainWindow, &MainWindow::setVideoBitrate);
+    connect(playbackManager, &PlaybackManager::hwdecCurrentChanged,
+            mainWindow, &MainWindow::setHwdecTooltip);
     connect(playbackManager, &PlaybackManager::afterPlaybackReset,
             mainWindow, &MainWindow::resetPlayAfterOnce);
     connect(playbackManager, &PlaybackManager::nowPlayingChanged,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2116,6 +2116,23 @@ void MainWindow::setTimeTooltip(bool shown, bool above)
     timeTooltipAbove = above;
 }
 
+void MainWindow::setHwdecTooltip(const QString &hwdecCurrent, bool fastHardwareDecoding)
+{
+    if (hwdecCurrent.isEmpty()) {
+        ui->status->setToolTip(QString());
+        return;
+    }
+    QString tooltipText;
+    if (hwdecCurrent == "no")
+        tooltipText = tr("Software Decoding");
+    else if (fastHardwareDecoding)
+        tooltipText = tr("Hardware Decoding: %1").arg(hwdecCurrent);
+    else
+        tooltipText = tr("Hardware Decoding: %1 (slow)").arg(hwdecCurrent);
+
+    ui->status->setToolTip(tooltipText);
+}
+
 void MainWindow::setOsdTimerOnSeek(bool enabled)
 {
     osdTimerOnSeek = enabled;

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -287,6 +287,7 @@ public slots:
     void setAudioTracks(QList<Track> tracks);
     void setVideoTracks(QList<Track> tracks);
     void setSubtitleTracks(QList<Track> tracks);
+    void setHwdecTooltip(const QString &tooltip, bool fastHardwareDecoding);
     void audioTrackSet(int64_t id);
     void videoTrackSet(int64_t id);
     void subtitleTrackSet(int64_t id);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1206,6 +1206,7 @@ void PlaybackManager::mpvw_hwdecCurrentChanged(QString newHwdecCurrent)
     fastHardwareDecoding = !(newHwdecCurrent.isEmpty() ||
                              newHwdecCurrent == "no" ||
                              newHwdecCurrent.contains("copy"));
+    emit hwdecCurrentChanged(newHwdecCurrent, fastHardwareDecoding);
 }
 
 void PlaybackManager::mpvw_interlacedChanged(bool interlaced)

--- a/src/manager.h
+++ b/src/manager.h
@@ -104,6 +104,7 @@ signals:
     void decoderFramedropsChanged(int64_t count);
     void audioBitrateChanged(double bitrate);
     void videoBitrateChanged(double bitrate);
+    void hwdecCurrentChanged(QString hwdecCurrent, bool fastHardwareDecoding);
 
 public slots:
     // load functions

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1254,6 +1254,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1378,6 +1378,18 @@ No action will be triggered.</source>
         <translation>Obertura ràpida</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -1386,6 +1386,18 @@ No action will be triggered.</source>
         <translation>Rychle otevřít</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>Zbývající čas</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1388,6 +1388,18 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation>Schnelles Öffnen</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>Verbleibende Zeit</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1386,6 +1386,18 @@ No action will be triggered.</source>
         <translation>Quick Open</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1346,6 +1346,18 @@ No action will be triggered.</source>
         <translation>Apertura rápida</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1290,6 +1290,18 @@ No action will be triggered.</source>
         <translation>Pika Avaus</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1340,6 +1340,18 @@ Aucune action ne sera déclenchée.</translation>
         <translation>Ouverture rapide</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>Temps restant</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1372,6 +1372,18 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <translation>Buka Cepat</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>Sisa waktu</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1342,6 +1342,18 @@ No action will be triggered.</source>
         <translation>Apri rapidamente</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1388,6 +1388,18 @@ No action will be triggered.</source>
         <translation>クイック再生</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>残り時間</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -1383,6 +1383,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1258,6 +1258,18 @@ No action will be triggered.</source>
         <translation>Hurtigåpning</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1258,6 +1258,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -1390,6 +1390,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1278,6 +1278,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1378,6 +1378,18 @@ No action will be triggered.</source>
         <translation>Быстро открыть</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1380,6 +1380,18 @@ No action will be triggered.</source>
         <translation>விரைவாக திறந்திருக்கும்</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>மீதமுள்ள நேரம்</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1380,6 +1380,18 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Tez Aç</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>Kalan süre</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -1378,6 +1378,18 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1388,6 +1388,18 @@ No action will be triggered.</source>
         <translation>快速打开</translation>
     </message>
     <message>
+        <source>Software Decoding</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hardware Decoding: %1 (slow)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Remaining time</source>
         <translation>剩余时间</translation>
     </message>


### PR DESCRIPTION
Show a status tooltip over the main window bottom status text with current hardware decoding state in the format: "Software Decoding / Hardware Decoding: backend [(slow)]".