### PR TITLE
Improve StatusTime, split it more cleanly from MainWindow and hide hoverTooltip on context menu close

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1054,7 +1054,6 @@ void MainWindow::setOSDPage(int page)
 void MainWindow::setUiEnabledState(bool enabled)
 {
     positionSlider_->setEnabled(enabled);
-    ui->statusTime->setEnabled(enabled);
     if (!enabled) {
         positionSlider_->setLoopA(-1);
         positionSlider_->setLoopB(-1);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -196,9 +196,9 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionPlayVolumeMute) },
         { "volume", volumeSlider_->value() },
         { "shownStatsPage", mpvObject_->selectedStatsPage() },
-        { "timeShortMode", timeShortMode },
-        { "timeRemainingMode", timeRemainingMode },
-        { "timePercentageMode", timePercentageMode }
+        { "timeShortMode", statusTime->shortMode() },
+        { "timeRemainingMode", statusTime->remainingMode() },
+        { "timePercentageMode", statusTime->percentMode() }
     };
 #undef WRAP
 }
@@ -241,9 +241,9 @@ void MainWindow::setState(const QVariantMap &map)
     setVolumeMuteState(ui->actionPlayVolumeMute->isChecked(), true);
     setVolume(map.value("volume", 100).toInt(), true);
     setOSDPage(map.value("shownStatsPage",0).toInt());
-    setTimeShortMode(map.value("timeShortMode", true).toBool());
-    setTimeRemainingMode(map.value("timeRemainingMode", false).toBool());
-    setTimePercentageMode(map.value("timePercentageMode", false).toBool());
+    statusTime->setShortMode(map.value("timeShortMode", true).toBool());
+    statusTime->setRemainingMode(map.value("timeRemainingMode", false).toBool());
+    statusTime->setPercentMode(map.value("timePercentageMode", false).toBool());
     updateOnTop();
 
 #undef UNWRAP
@@ -879,7 +879,7 @@ void MainWindow::setupStatus()
     statusTime->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->statusbarLayout->insertWidget(2, statusTime);
     connect(statusTime, &StatusTime::customContextMenuRequested,
-            this, &MainWindow::statusTime_customContextMenuRequested);
+            statusTime, &StatusTime::showContextMenu);
     connect(statusTime, &StatusTime::doubleClicked,
             ui->actionNavigateGoto, &QAction::trigger);
 }
@@ -2420,24 +2420,6 @@ void MainWindow::setSubtitlesDelayStep(int subtitlesDelayStep)
     this->subtitlesDelayStep = subtitlesDelayStep;
 }
 
-void MainWindow::setTimeShortMode(bool shortened)
-{
-    statusTime->setShortMode(shortened);
-    timeShortMode = shortened;
-}
-
-void MainWindow::setTimeRemainingMode(bool isRemaining)
-{
-    statusTime->setRemainingMode(isRemaining);
-    timeRemainingMode = isRemaining;
-}
-
-void MainWindow::setTimePercentageMode(bool isPercentage)
-{
-    statusTime->setPercentMode(isPercentage);
-    timePercentageMode = isPercentage;
-}
-
 void MainWindow::resetPlayAfterOnce()
 {
     ui->actionPlayAfterOnceNothing->setChecked(true);
@@ -3621,48 +3603,6 @@ void MainWindow::mpvw_customContextMenuRequested(const QPoint &pos)
     if (mpvw == nullptr)
         return;
     contextMenu->popup(mpvw->mapToGlobal(pos));
-}
-
-void MainWindow::statusTime_customContextMenuRequested(const QPointF &p)
-{
-    QMenu *m = new QMenu(this);
-    QAction *a;
-
-    bool isTimeRemaingMode = timeRemainingMode;
-    a = new QAction(m);
-    a->setText(tr("Remaining time"));
-    a->setCheckable(true);
-    a->setChecked(timeRemainingMode);
-    connect(a, &QAction::triggered,
-            this, [this, isTimeRemaingMode]() {
-        setTimeRemainingMode(!isTimeRemaingMode);
-    });
-    m->addAction(a);
-    
-    bool isTimeShortMode = timeShortMode;
-    a = new QAction(m);
-    a->setText(tr("High precision"));
-    a->setCheckable(true);
-    a->setChecked(!timeShortMode);
-    connect(a, &QAction::triggered,
-            this, [this, isTimeShortMode]() {
-        setTimeShortMode(!isTimeShortMode);
-    });
-    m->addAction(a);
-
-    bool isTimePercentageMode = timePercentageMode;
-    a = new QAction(m);
-    a->setText(tr("Show percentage"));
-    a->setCheckable(true);
-    a->setChecked(timePercentageMode);
-    connect(a, &QAction::triggered,
-            this, [this, isTimePercentageMode]() {
-        setTimePercentageMode(!isTimePercentageMode);
-    });
-    m->addAction(a);
-
-    m->exec(statusTime->mapToGlobal(p).toPoint());
-    delete m;
 }
 
 void MainWindow::position_sliderMoved(int position)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -196,9 +196,9 @@ QVariantMap MainWindow::state()
         { WRAP(ui->actionPlayVolumeMute) },
         { "volume", volumeSlider_->value() },
         { "shownStatsPage", mpvObject_->selectedStatsPage() },
-        { "timeShortMode", statusTime->shortMode() },
-        { "timeRemainingMode", statusTime->remainingMode() },
-        { "timePercentageMode", statusTime->percentMode() }
+        { "timeShortMode", ui->statusTime->shortMode() },
+        { "timeRemainingMode", ui->statusTime->remainingMode() },
+        { "timePercentageMode", ui->statusTime->percentMode() }
     };
 #undef WRAP
 }
@@ -241,9 +241,9 @@ void MainWindow::setState(const QVariantMap &map)
     setVolumeMuteState(ui->actionPlayVolumeMute->isChecked(), true);
     setVolume(map.value("volume", 100).toInt(), true);
     setOSDPage(map.value("shownStatsPage",0).toInt());
-    statusTime->setShortMode(map.value("timeShortMode", true).toBool());
-    statusTime->setRemainingMode(map.value("timeRemainingMode", false).toBool());
-    statusTime->setPercentMode(map.value("timePercentageMode", false).toBool());
+    ui->statusTime->setShortMode(map.value("timeShortMode", true).toBool());
+    ui->statusTime->setRemainingMode(map.value("timeRemainingMode", false).toBool());
+    ui->statusTime->setPercentMode(map.value("timePercentageMode", false).toBool());
     updateOnTop();
 
 #undef UNWRAP
@@ -398,8 +398,7 @@ void MainWindow::changeEvent(QEvent *event)
             tooltip->updatePalette();
         if (videoPreview)
             videoPreview->updatePalette();
-        if (statusTime)
-            statusTime->updatePalette();
+        ui->statusTime->updatePalette();
     }
     else if (event->type() == QEvent::WindowStateChange && isMaximized())
         emit windowMaximized();
@@ -511,7 +510,7 @@ void MainWindow::mouseReleaseEvent(QMouseEvent *event)
 {
     QPoint pos = event->globalPosition().toPoint();
     bool ok = mpvw ? insideWidget(pos, mpvw) : false;
-    if (!(mousePressedInBottomArea && insideWidget(pos, statusTime))) {
+    if (!(mousePressedInBottomArea && insideWidget(pos, ui->statusTime))) {
         if (ok && mouseStateEvent(MouseState::fromMouseEvent(event, MouseState::MouseUp)))
             event->accept();
         else
@@ -626,7 +625,7 @@ void MainWindow::setFullscreenMode(bool fullscreenMode)
     QTimer::singleShot(50, this, [this]() {
         positionSlider_->update();
         volumeSlider_->update();
-        statusTime->update();
+        ui->statusTime->update();
     });
     emit fullscreenModeChanged(fullscreenMode_);
 }
@@ -874,13 +873,9 @@ void MainWindow::setupPlaylist()
 void MainWindow::setupStatus()
 {
     ui->tinyicon->setPixmap(renderPixmapFromSvg(tinyIconPath));
-    statusTime = new StatusTime();
-    statusTime->setCursor(Qt::PointingHandCursor);
-    statusTime->setContextMenuPolicy(Qt::CustomContextMenu);
-    ui->statusbarLayout->insertWidget(2, statusTime);
-    connect(statusTime, &StatusTime::customContextMenuRequested,
-            statusTime, &StatusTime::showContextMenu);
-    connect(statusTime, &StatusTime::doubleClicked,
+    connect(ui->statusTime, &StatusTime::customContextMenuRequested,
+            ui->statusTime, &StatusTime::showContextMenu);
+    connect(ui->statusTime, &StatusTime::doubleClicked,
             ui->actionNavigateGoto, &QAction::trigger);
 }
 
@@ -1059,7 +1054,7 @@ void MainWindow::setOSDPage(int page)
 void MainWindow::setUiEnabledState(bool enabled)
 {
     positionSlider_->setEnabled(enabled);
-    statusTime->setEnabled(enabled);
+    ui->statusTime->setEnabled(enabled);
     if (!enabled) {
         positionSlider_->setLoopA(-1);
         positionSlider_->setLoopB(-1);
@@ -1952,7 +1947,7 @@ void MainWindow::setTime(double time, double length)
 {
     positionSlider_->setMaximum(length);
     positionSlider_->setValue(time);
-    statusTime->setTime(time, length);
+    ui->statusTime->setTime(time, length);
 }
 
 void MainWindow::setMediaTitle(const QString &title)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -297,9 +297,6 @@ public slots:
     void setVolumeMax(int level);
     void setSubtitlesEnabled(bool enabled, bool onInit = false);
     void setSubtitlesDelayStep(int subtitlesDelayStep);
-    void setTimeShortMode(bool shortened);
-    void setTimeRemainingMode(bool isRemaining);
-    void setTimePercentageMode(bool isPercentage);
     void resetPlayAfterOnce();
     void setPlayAfterAlways(Helpers::AfterPlayback action);
     void setPlayAfterAlwaysDefault(Helpers::AfterPlayback action);
@@ -484,7 +481,6 @@ private slots:
     void on_actionPlaylistFinishSearching_triggered();
 
     void mpvw_customContextMenuRequested(const QPoint &pos);
-    void statusTime_customContextMenuRequested(const QPointF &p);
     void position_sliderMoved(int position);
     void position_hoverValue(double value, QString text, double mouseX);
     void position_hoverEnd();
@@ -542,9 +538,6 @@ private:
     bool timeTooltipShown = true;
     bool timeTooltipAbove = true;
     bool osdTimerOnSeek = false;
-    bool timeShortMode = true;
-    bool timeRemainingMode = false;
-    bool timePercentageMode = false;
     bool mousePressedInBottomArea = false;
     QPoint mousePressPosition;
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -8,7 +8,6 @@
 #include <QSystemTrayIcon>
 #include "helpers.h"
 #include "widgets/drawnslider.h"
-#include "widgets/drawnstatus.h"
 #include "widgets/tooltip.h"
 #include "widgets/videopreview.h"
 #include "manager.h"
@@ -509,7 +508,6 @@ private:
     VolumeSlider *volumeSlider_ = nullptr;
     VideoPreview *videoPreview = nullptr;
     Tooltip *tooltip = nullptr;
-    StatusTime *statusTime = nullptr;
     PlaylistWindow *playlistWindow_ = nullptr;
     QMenu moreRecentsMenu;
     QMenu *contextMenu = nullptr;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -763,7 +763,10 @@
           </item>
           <item>
            <widget class="QWidget" name="statusbar" native="true">
-            <layout class="QHBoxLayout" name="statusbarLayout" stretch="0,1">
+            <property name="contextMenuPolicy">
+             <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+            </property>
+            <layout class="QHBoxLayout" name="statusbarLayout" stretch="0,1,0">
              <property name="leftMargin">
               <number>6</number>
              </property>
@@ -783,6 +786,19 @@
               <widget class="QLabel" name="status">
                <property name="text">
                 <string>Stopped</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="StatusTime" name="statusTime">
+               <property name="cursor">
+                <cursorShape>PointingHandCursor</cursorShape>
+               </property>
+               <property name="contextMenuPolicy">
+                <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+               </property>
+               <property name="text">
+                <string notr="true">00:00:00 / 00:00:00</string>
                </property>
               </widget>
              </item>
@@ -2640,6 +2656,13 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>StatusTime</class>
+   <extends>QLabel</extends>
+   <header>widgets/drawnstatus.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -7,7 +7,7 @@
 
 static constexpr char logModule[] =  "drawnstatus";
 
-StatusTime::StatusTime(QWidget *parent) : QWidget(parent)
+StatusTime::StatusTime(QWidget *parent) : QLabel(parent)
 {
     setTime(0, 0);
     setMinimumSize(minimumSizeHint());

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -12,6 +12,7 @@ StatusTime::StatusTime(QWidget *parent) : QLabel(parent)
     setTime(0, 0);
     setMinimumSize(minimumSizeHint());
     setAttribute(Qt::WA_Hover);
+    setVisible(false);
 }
 
 QSize StatusTime::minimumSizeHint() const
@@ -23,6 +24,7 @@ QSize StatusTime::minimumSizeHint() const
 void StatusTime::setTime(double time, double duration)
 {
     if (currentDuration != duration) {
+        setVisible(duration != 0);
         currentDuration = duration;
         updateTimeFormat();
     } else if (currentTime == time)
@@ -209,12 +211,6 @@ void StatusTime::paintEvent(QPaintEvent *event)
     p.fillRect(rc, bgColor);
     p.setPen(txColor);
     p.drawText(rc, drawnText, QTextOption(Qt::AlignRight | Qt::AlignVCenter));
-}
-
-void StatusTime::changeEvent(QEvent *event)
-{
-    if (event->type() == QEvent::EnabledChange)
-        setVisible(isEnabled());
 }
 
 void StatusTime::mouseDoubleClickEvent(QMouseEvent *event)

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -1,5 +1,6 @@
-#include <QPainter>
+#include <QMenu>
 #include <QMouseEvent>
+#include <QPainter>
 #include "helpers.h"
 #include "tooltip.h"
 #include "drawnstatus.h"
@@ -32,7 +33,7 @@ void StatusTime::setTime(double time, double duration)
 
 void StatusTime::setShortMode(bool shortened)
 {
-    shortMode = shortened;
+    shortMode_ = shortened;
     lastTextLength = 0;
     lastDrawnText.clear();
     updateTimeFormat();
@@ -41,7 +42,7 @@ void StatusTime::setShortMode(bool shortened)
 
 void StatusTime::setRemainingMode(bool isRemaining)
 {
-    remainingMode = isRemaining;
+    remainingMode_ = isRemaining;
     lastTextLength = 0;
     lastDrawnText.clear();
     updateText();
@@ -49,7 +50,7 @@ void StatusTime::setRemainingMode(bool isRemaining)
 
 void StatusTime::setPercentMode(bool isPercent)
 {
-    percentMode = isPercent;
+    percentMode_ = isPercent;
     lastTextLength = 0;
     lastDrawnText.clear();
     updateText();
@@ -59,9 +60,9 @@ void StatusTime::updateTimeFormat()
 {
     Helpers::TimeFormat format;
     if (int(currentDuration*1000 + 0.5) >= 3600000)
-        format = shortMode ? Helpers::ShortFormat : Helpers::LongFormat;
+        format = shortMode_ ? Helpers::ShortFormat : Helpers::LongFormat;
     else
-        format = shortMode ? Helpers::ShortHourFormat : Helpers::LongHourFormat;
+        format = shortMode_ ? Helpers::ShortHourFormat : Helpers::LongHourFormat;
     if (timeFormat == format)
         return;
     timeFormat = format;
@@ -70,14 +71,14 @@ void StatusTime::updateTimeFormat()
 void StatusTime::updateText()
 {
     double time = currentTime;
-    if (remainingMode)
+    if (remainingMode_)
         time = currentTime - currentDuration;
 
     drawnText = Helpers::toDateFormatFixed(time, timeFormat);
     drawnText.append(" / ");
     drawnText.append(Helpers::toDateFormatFixed(currentDuration, timeFormat));
 
-    if (percentMode) {
+    if (percentMode_) {
         double durationNotNull = currentDuration == 0 ? 1 : currentDuration;
         drawnText.append(QString(tr(" (%1%)")).arg(QLocale().toString(currentTime / durationNotNull * 100,
                                                                 'f',
@@ -114,6 +115,50 @@ void StatusTime::updatePalette()
         hoverTooltip->updatePalette();
 }
 
+void StatusTime::showContextMenu(const QPointF &p)
+{
+    QMenu *m = new QMenu(window());
+    QAction *a;
+
+    bool isTimeRemaingMode = remainingMode_;
+    a = new QAction(m);
+    a->setText(tr("Remaining time"));
+    a->setCheckable(true);
+    a->setChecked(remainingMode_);
+    connect(a, &QAction::triggered,
+            this, [this, isTimeRemaingMode]() {
+        setRemainingMode(!isTimeRemaingMode);
+    });
+    m->addAction(a);
+
+    bool isTimeShortMode = shortMode_;
+    a = new QAction(m);
+    a->setText(tr("High precision"));
+    a->setCheckable(true);
+    a->setChecked(!shortMode_);
+    connect(a, &QAction::triggered,
+            this, [this, isTimeShortMode]() {
+        setShortMode(!isTimeShortMode);
+    });
+    m->addAction(a);
+
+    bool isTimePercentageMode = percentMode_;
+    a = new QAction(m);
+    a->setText(tr("Show percentage"));
+    a->setCheckable(true);
+    a->setChecked(percentMode_);
+    connect(a, &QAction::triggered,
+            this, [this, isTimePercentageMode]() {
+        setPercentMode(!isTimePercentageMode);
+    });
+    m->addAction(a);
+
+    m->exec(mapToGlobal(p).toPoint());
+    if (hoverTooltip)
+        hoverTooltip->hide();
+    delete m;
+}
+
 void StatusTime::updateHoverTooltip()
 {
     if (!hoverTooltip)
@@ -121,8 +166,8 @@ void StatusTime::updateHoverTooltip()
     QWidget *top = window();
     if (!top)
         return;
-    QString label = remainingMode ? tr("Played") : tr("Remaining");
-    double hoverTime = remainingMode ? currentTime : currentTime - currentDuration;
+    QString label = remainingMode_ ? tr("Played") : tr("Remaining");
+    double hoverTime = remainingMode_ ? currentTime : currentTime - currentDuration;
     QString text = QString("%1: %2").arg(label,
                                          Helpers::toDateFormatFixed(hoverTime, timeFormat));
     QString textTemplate = QString("%1: %2").arg(label,

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -31,7 +31,6 @@ protected:
     void updateTimeFormat();
     void updateText();
     void paintEvent(QPaintEvent *event) override;
-    void changeEvent(QEvent *event) override;
     void mouseDoubleClickEvent(QMouseEvent *event) override;
     bool event(QEvent *event) override;
 

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -1,12 +1,12 @@
 #ifndef QDRAWNSTATUS_H
 #define QDRAWNSTATUS_H
 
-#include <QWidget>
+#include <QLabel>
 #include "helpers.h"
 
 class Tooltip;
 
-class StatusTime : public QWidget
+class StatusTime : public QLabel
 {
     Q_OBJECT
 public:

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -18,6 +18,11 @@ public:
     void setRemainingMode(bool isRemaining);
     void setPercentMode(bool isPercent);
     void updatePalette();
+    void showContextMenu(const QPointF &p);
+
+    bool shortMode() const { return shortMode_; };
+    bool remainingMode() const { return remainingMode_; };
+    bool percentMode() const { return percentMode_; };
 
 signals:
     void doubleClicked();
@@ -34,9 +39,9 @@ private:
     void ensureHoverTooltip();
     void updateHoverTooltip();
 
-    bool shortMode = false;
-    bool remainingMode = false;
-    bool percentMode = false;
+    bool shortMode_ = false;
+    bool remainingMode_ = false;
+    bool percentMode_ = false;
     bool hovered = false;
     Helpers::TimeFormat timeFormat = Helpers::LongFormat;
     double currentTime = 0;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1286,18 +1286,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4464,6 +4452,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1406,18 +1406,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>Sense arxius preferits</translation>
     </message>
@@ -4824,6 +4812,18 @@ arxiu multimèdia reproduït</translation>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -1415,15 +1415,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>Zbývající čas</translation>
+        <translation type="vanished">Zbývající čas</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>Vysoká přesnost</translation>
+        <translation type="vanished">Vysoká přesnost</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>Ukázat procenta</translation>
+        <translation type="vanished">Ukázat procenta</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4849,6 +4849,18 @@ media file played</source>
     <message>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">Zbývající čas</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">Vysoká přesnost</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">Ukázat procenta</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1417,15 +1417,15 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>Verbleibende Zeit</translation>
+        <translation type="vanished">Verbleibende Zeit</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>Hohe Genauigkeit</translation>
+        <translation type="vanished">Hohe Genauigkeit</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>Prozentsatz anzeigen</translation>
+        <translation type="vanished">Prozentsatz anzeigen</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4807,6 +4807,18 @@ media file played</source>
     <message>
         <source> (%1%)</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">Verbleibende Zeit</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">Hohe Genauigkeit</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">Prozentsatz anzeigen</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1414,18 +1414,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>No files favorited</translation>
     </message>
@@ -4860,6 +4848,18 @@ media file played</translation>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1378,18 +1378,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>No hay archivos favoritos</translation>
     </message>
@@ -4656,6 +4644,18 @@ archivo multimedia reproducido</translation>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1318,18 +1318,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>Ei Suosikkitiedostoja</translation>
     </message>
@@ -4462,6 +4450,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1369,15 +1369,15 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>Temps restant</translation>
+        <translation type="vanished">Temps restant</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>Haute précision</translation>
+        <translation type="vanished">Haute précision</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>Afficher le pourcentage</translation>
+        <translation type="vanished">Afficher le pourcentage</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4795,6 +4795,18 @@ fichier média lu</translation>
     <message>
         <source> (%1%)</source>
         <translation> (%1 %)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">Temps restant</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">Haute précision</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">Afficher le pourcentage</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1401,15 +1401,15 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>Sisa waktu</translation>
+        <translation type="vanished">Sisa waktu</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>Presisi tinggi</translation>
+        <translation type="vanished">Presisi tinggi</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>Tampilkan persentase</translation>
+        <translation type="vanished">Tampilkan persentase</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4611,6 +4611,18 @@ file media yang diputar</translation>
     <message>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">Sisa waktu</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">Presisi tinggi</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">Tampilkan persentase</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1374,18 +1374,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4584,6 +4572,18 @@ ogni file multimediale riprodotto</translation>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1417,15 +1417,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>残り時間</translation>
+        <translation type="vanished">残り時間</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>高精度</translation>
+        <translation type="vanished">高精度</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>パーセンテージを表示</translation>
+        <translation type="vanished">パーセンテージを表示</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4863,6 +4863,18 @@ media file played</source>
     <message>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">残り時間</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">高精度</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">パーセンテージを表示</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -1411,18 +1411,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4837,6 +4825,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1290,18 +1290,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>Ingen filer favorittmerket</translation>
     </message>
@@ -4409,6 +4397,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1290,18 +1290,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4448,6 +4436,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -1450,18 +1450,6 @@ No action will be triggered.</source>
         <translation>Otwórz napisy</translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Development Build</source>
         <translation>Build deweloperski</translation>
     </message>
@@ -4740,6 +4728,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1310,18 +1310,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>Sem arquivos favoritos</translation>
     </message>
@@ -4508,6 +4496,18 @@ arquivo de mídia reproduzido</translation>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1406,18 +1406,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>No files favorited</source>
         <translation>Нет избранных файлов</translation>
     </message>
@@ -4804,6 +4792,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1409,15 +1409,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>மீதமுள்ள நேரம்</translation>
+        <translation type="vanished">மீதமுள்ள நேரம்</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>உயர் துல்லியம்</translation>
+        <translation type="vanished">உயர் துல்லியம்</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>சதவீதத்தைக் காட்டு</translation>
+        <translation type="vanished">சதவீதத்தைக் காட்டு</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4835,6 +4835,18 @@ media file played</source>
     <message>
         <source> (%1%)</source>
         <translation> (% 1%)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">மீதமுள்ள நேரம்</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">உயர் துல்லியம்</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">சதவீதத்தைக் காட்டு</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1409,15 +1409,15 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>Kalan süre</translation>
+        <translation type="vanished">Kalan süre</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>Yüksek kesinlik</translation>
+        <translation type="vanished">Yüksek kesinlik</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>Yüzdeyi göster</translation>
+        <translation type="vanished">Yüzdeyi göster</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4827,6 +4827,18 @@ yeni bir &amp;oynatıcı aç</translation>
     <message>
         <source> (%1%)</source>
         <translation> (%%1)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">Kalan süre</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">Yüksek kesinlik</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">Yüzdeyi göster</translation>
     </message>
     <message>
         <source>Played</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -1438,18 +1438,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining time</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>High precision</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show percentage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Development Build</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4592,6 +4580,18 @@ media file played</source>
     <name>StatusTime</name>
     <message>
         <source> (%1%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1417,15 +1417,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Remaining time</source>
-        <translation>剩余时间</translation>
+        <translation type="vanished">剩余时间</translation>
     </message>
     <message>
         <source>High precision</source>
-        <translation>高精度时间戳</translation>
+        <translation type="vanished">高精度时间戳</translation>
     </message>
     <message>
         <source>Show percentage</source>
-        <translation>显示百分比</translation>
+        <translation type="vanished">显示百分比</translation>
     </message>
     <message>
         <source>No files favorited</source>
@@ -4739,6 +4739,18 @@ media file played</source>
     <message>
         <source> (%1%)</source>
         <translation> (%1%)</translation>
+    </message>
+    <message>
+        <source>Remaining time</source>
+        <translation type="unfinished">剩余时间</translation>
+    </message>
+    <message>
+        <source>High precision</source>
+        <translation type="unfinished">高精度时间戳</translation>
+    </message>
+    <message>
+        <source>Show percentage</source>
+        <translation type="unfinished">显示百分比</translation>
     </message>
     <message>
         <source>Played</source>


### PR DESCRIPTION
* Move StatusTime context menu to StatusTime class, hide hoverTooltip on close

> Simplifies MainWindow and avoids duplication of state variables.
> 
> Manually hide the StatusTime hoverTooltip after closing the context menu to prevent it from lingering.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/336c722bb4b3ba527af510f401b65694e04eb220 ("widgets: add status time hover tooltip and double-click goto")
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/17f69913a025e292ced3f504a12f4ede5fb29b38 ("Support changing status time format by click and add remaining and percentage modes").

* Change StatusTime to QLabel, move its instantiation to MainWindow .ui

> Slightly simplifies MainWindow, reduces includes in mainwindow.h and makes the widget visible from Qt Widgets Designer.

* Don't show StatusTime when its duration is zero

> Only show StatusTime when it has meaningful information to show.
> Prevents briefly showing "00:00:00" or "00:00" when starting playback.
> 
> Reverts https://github.com/mpc-qt/mpc-qt/commit/6f22ff9fffa99dc545a823b940a1945898a8efc7 ("Don't show StatusTime when player is stopped");