### PR TITLE
drawnstatus: Fix hover tooltip padding and formatting

### DIFF
--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -168,10 +168,9 @@ void StatusTime::updateHoverTooltip()
     QWidget *top = window();
     if (!top)
         return;
-    QString label = remainingMode_ ? tr("Played") : tr("Remaining");
+    QString text = remainingMode_ ? tr("Played: %1") : tr("Remaining: %1");
     double hoverTime = remainingMode_ ? currentTime : currentTime - currentDuration;
-    QString text = QString("%1: %2").arg(label,
-                                         Helpers::toDateFormatFixed(hoverTime, timeFormat));
+    text = text.arg(Helpers::toDateFormatFixed(hoverTime, timeFormat));
     QPoint topLeft = mapTo(top, QPoint(0, 0));
     QPoint where(topLeft.x() + width() / 2, topLeft.y() - 2);
     hoverTooltip->show(text, where, top->width(), text);

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -172,11 +172,9 @@ void StatusTime::updateHoverTooltip()
     double hoverTime = remainingMode_ ? currentTime : currentTime - currentDuration;
     QString text = QString("%1: %2").arg(label,
                                          Helpers::toDateFormatFixed(hoverTime, timeFormat));
-    QString textTemplate = QString("%1: %2").arg(label,
-                                                 Helpers::toDateFormatFixed(currentDuration, timeFormat));
     QPoint topLeft = mapTo(top, QPoint(0, 0));
     QPoint where(topLeft.x() + width() / 2, topLeft.y() - 2);
-    hoverTooltip->show(text, where, top->width(), textTemplate);
+    hoverTooltip->show(text, where, top->width(), text);
 }
 
 bool StatusTime::event(QEvent *event)

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4467,11 +4467,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4827,11 +4827,11 @@ arxiu multimèdia reproduït</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4863,11 +4863,11 @@ media file played</source>
         <translation type="unfinished">Ukázat procenta</translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4821,11 +4821,11 @@ media file played</source>
         <translation type="unfinished">Prozentsatz anzeigen</translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4863,11 +4863,11 @@ media file played</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4659,11 +4659,11 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4465,11 +4465,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4809,12 +4809,20 @@ fichier média lu</translation>
         <translation type="unfinished">Afficher le pourcentage</translation>
     </message>
     <message>
+        <source>Played: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played</source>
-        <translation>Lu</translation>
+        <translation type="vanished">Lu</translation>
     </message>
     <message>
         <source>Remaining</source>
-        <translation>Restant</translation>
+        <translation type="vanished">Restant</translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4625,12 +4625,20 @@ file media yang diputar</translation>
         <translation type="unfinished">Tampilkan persentase</translation>
     </message>
     <message>
+        <source>Played: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played</source>
-        <translation>Diputar</translation>
+        <translation type="vanished">Diputar</translation>
     </message>
     <message>
         <source>Remaining</source>
-        <translation>Tersisa</translation>
+        <translation type="vanished">Tersisa</translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4587,11 +4587,11 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4877,12 +4877,20 @@ media file played</source>
         <translation>パーセンテージを表示</translation>
     </message>
     <message>
+        <source>Played: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played</source>
-        <translation>再生</translation>
+        <translation type="vanished">再生</translation>
     </message>
     <message>
         <source>Remaining</source>
-        <translation>残り時間</translation>
+        <translation type="vanished">残り時間</translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4840,11 +4840,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4412,11 +4412,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4451,11 +4451,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4743,11 +4743,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4511,11 +4511,11 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4807,11 +4807,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4849,11 +4849,11 @@ media file played</source>
         <translation type="unfinished">சதவீதத்தைக் காட்டு</translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4841,11 +4841,11 @@ yeni bir &amp;oynatıcı aç</translation>
         <translation type="unfinished">Yüzdeyi göster</translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4595,11 +4595,11 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Played</source>
+        <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remaining</source>
+        <source>Remaining: %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4753,12 +4753,20 @@ media file played</source>
         <translation>显示百分比</translation>
     </message>
     <message>
+        <source>Played: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remaining: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played</source>
-        <translation>已播放</translation>
+        <translation type="vanished">已播放</translation>
     </message>
     <message>
         <source>Remaining</source>
-        <translation>还剩</translation>
+        <translation type="vanished">还剩</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
* drawnstatus: Ensure hover tooltip width accounts for negative values

> The tooltip width was computed from the current duration text, which never contains a negative sign.
> 
> In remaining time mode, the actual hover text is mostly negative and therefore wider, causing the tooltip to be too narrow.
> 
> Use the displayed hover text itself as the width template.
> 
> Fixes: 336c722bb4b3ba527af510f401b65694e04eb220 ("widgets: add status time hover tooltip and double-click goto")

* drawnstatus: Include hover tooltip formatting in translation

> Allows translators to change left-right direction and spacing between Played/Remaining and ":".