### PR TITLE
Add a feature to loop over to first/last file when using 'use next/prev file in folder when only one file in playlist'

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -407,6 +407,7 @@
     "tweaksMpvKeyEvents": false,
     "tweaksMpvMouseEvents": false,
     "tweaksOpenNextFile": true,
+    "tweaksLoopFolder": false,
     "tweaksOsdFont": "Segoe UI",
     "tweaksOsdFontChkBox": false,
     "tweaksOsdSize": 30,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -814,6 +814,8 @@ void Flow::setupSettingsConnections()
             playbackManager, &PlaybackManager::setFastSeek);
     connect(settingsWindow, &SettingsWindow::fallbackToFolder,
             playbackManager, &PlaybackManager::setFolderFallback);
+    connect(settingsWindow, &SettingsWindow::loopFolder,
+            playbackManager, &PlaybackManager::setLoopFolder);
     connect(settingsWindow, &SettingsWindow::subsPreferDefaultForced,
             playbackManager, &PlaybackManager::setSubtitlesPreferDefaultForced);
     connect(settingsWindow, &SettingsWindow::subsPreferExternal,

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -661,6 +661,11 @@ void PlaybackManager::setFolderFallback(bool yes)
     folderFallback = yes;
 }
 
+void PlaybackManager::setLoopFolder(bool yes)
+{
+    loopFolder = yes;
+}
+
 void PlaybackManager::sendCurrentTrackInfo()
 {
     QUrl url(playlistWindow_->getUrlOf(nowPlayingList, nowPlayingItem));
@@ -959,8 +964,12 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta, bool replaceMpvPlayli
         return false;
     do {
         index += delta;
-        if (index < 0 || index >= files.count())
-            return false;
+        if (index < 0 || index >= files.count()) {
+            if (!loopFolder)
+                return false;
+            else
+                index = (index % files.count() + files.count()) % files.count();
+        }
         nextFile = dir.filePath(files.value(index));
         url = QUrl::fromLocalFile(nextFile);
     } while (!Helpers::urlSurvivesFilter(url, true));

--- a/src/manager.h
+++ b/src/manager.h
@@ -174,6 +174,7 @@ public slots:
     void setPlaybackForever(bool yes);
     void setFastSeek(bool yes);
     void setFolderFallback(bool yes);
+    void setLoopFolder(bool yes);
 
     // misc functions
     void sendCurrentTrackInfo();
@@ -283,6 +284,7 @@ private:
     bool playbackForever = false;
     bool fastSeek = true;
     bool folderFallback = false;
+    bool loopFolder = false;
     bool appendToQuickPlaylist = false;
 
     PlaybackManager::AspectNameChanged showAspectOsdTriggeredBy = AspectNameChanged::OnOpen;

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1105,6 +1105,7 @@ void SettingsWindow::sendSignals()
     emit fastSeek(WIDGET_LOOKUP(ui->tweaksFastSeek).toBool());
     emit option("hr-seek-framedrop", WIDGET_LOOKUP(ui->tweaksSeekFramedrop).toBool());
     emit fallbackToFolder(WIDGET_LOOKUP(ui->tweaksOpenNextFile).toBool());
+    emit loopFolder(WIDGET_LOOKUP(ui->tweaksLoopFolder).toBool());
     emit mpvMouseEvents(WIDGET_LOOKUP(ui->tweaksMpvMouseEvents).toBool());
     emit mpvKeyEvents(WIDGET_LOOKUP(ui->tweaksMpvKeyEvents).toBool());
     emit videoPreview(WIDGET_LOOKUP(ui->tweaksVideoPreview).toBool());

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -181,6 +181,7 @@ signals:
     void hwdecBackend(QString backend);
     void fastSeek(bool yes);
     void fallbackToFolder(bool yes);
+    void loopFolder(bool yes);
     void volumeMax(int maximum);
     void mpvMouseEvents(bool yes);
     void mpvKeyEvents(bool yes);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7896,6 +7896,16 @@ media file played</string>
             </widget>
            </item>
            <item row="4" column="0" colspan="2">
+            <widget class="QCheckBox" name="tweaksLoopFolder">
+             <property name="text">
+              <string>Loop back to first/last file in folder if needed</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksVolumeLimit">
              <property name="text">
               <string>Limit volume to 100% like mpc-hc</string>
@@ -7905,7 +7915,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0" colspan="2">
+           <item row="6" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksPreferWayland">
              <property name="enabled">
               <bool>false</bool>
@@ -7918,21 +7928,21 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="6" column="0" colspan="2">
+           <item row="7" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvMouseEvents">
              <property name="text">
               <string>Send mouse events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0" colspan="2">
+           <item row="8" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvKeyEvents">
              <property name="text">
               <string>Send key events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="0" colspan="2">
+           <item row="9" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksVideoPreview">
              <property name="text">
               <string>Show video preview (restart required)</string>
@@ -7942,7 +7952,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
+           <item row="10" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="0,0">
              <item>
               <widget class="QCheckBox" name="tweaksTimeTooltip">
@@ -7979,14 +7989,14 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="11" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
              <property name="text">
               <string>Show OSD timer on seek</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="0" colspan="2">
+           <item row="12" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="0,1,0">
              <item>
               <widget class="QCheckBox" name="tweaksOsdFontChkBox">
@@ -8041,7 +8051,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="12" column="0" colspan="2">
+           <item row="13" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksMpvOptionsLayout" stretch="0,1">
              <item>
               <widget class="QCheckBox" name="tweaksMpvOptionsChkBox">
@@ -8074,7 +8084,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="13" column="0">
+           <item row="14" column="0">
             <spacer name="verticalSpacer_9">
              <property name="orientation">
               <enum>Qt::Orientation::Vertical</enum>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4447,6 +4447,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4807,6 +4807,10 @@ arxiu multimèdia reproduït</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4843,6 +4843,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4801,6 +4801,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4843,6 +4843,10 @@ media file played</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4639,6 +4639,10 @@ archivo multimedia reproducido</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4445,6 +4445,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4789,6 +4789,10 @@ fichier média lu</translation>
         <source>A&amp;pplication name only</source>
         <translation>Nom de l&apos;a&amp;pplication</translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4605,6 +4605,10 @@ file media yang diputar</translation>
         <source>A&amp;pplication name only</source>
         <translation>Hanya nama aplikasi</translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4567,6 +4567,10 @@ ogni file multimediale riprodotto</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4857,6 +4857,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation>アプリケーション名のみ(&amp;P)</translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4820,6 +4820,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4392,6 +4392,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4431,6 +4431,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4723,6 +4723,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4491,6 +4491,10 @@ arquivo de mídia reproduzido</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4787,6 +4787,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4829,6 +4829,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4821,6 +4821,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4575,6 +4575,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4733,6 +4733,10 @@ media file played</source>
         <source>A&amp;pplication name only</source>
         <translation>仅应用程序名称(&amp;P)</translation>
     </message>
+    <message>
+        <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>


### PR DESCRIPTION
Adds optional looping behavior when 'Use next/previous file in folder when there is only one item in the playlist' is enabled. When reaching the last file, navigation wraps to the first file, and vice versa.

If this feature is already implemented in some form, I was unable to find and enable it, so please let me know

I wasn't sure about some of the conventions used, so feedback is appreciated.

I did not include non-english translation for the option.

If it doesn't end up included please consider this a feature request.