### PR TITLE
Move about dialog and version-related variables to dedicated class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ configure_file(
 )
 
 set(SOURCES
+    about.cpp about.h
     favoriteswindow.cpp favoriteswindow.h favoriteswindow.ui
     gotowindow.cpp gotowindow.h gotowindow.ui
     helpers.cpp helpers.h

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -1,0 +1,89 @@
+#include "about.h"
+#include "helpers.h"
+#include "platform/unify.h"
+#include "version.h"
+#include <QApplication>
+#include <QDateTime>
+#include <QMessageBox>
+
+void About::showAbout(QWidget *parent, QString mpvVersion, QString ffmpegVersion)
+{
+#if defined(MPCQT_DEVELOPMENT)
+#define BUILD_VERSION_STR QString("%1 (%2)").arg(devBuild, MPCQT_VERSION_STR)
+#elif defined(MPCQT_VERSION_STR)
+#define BUILD_VERSION_STR versionFmt.arg(MPCQT_VERSION_STR)
+#else
+#define BUILD_VERSION_STR devBuild
+#endif
+    QString devBuild = tr("Development Build");
+    QString versionFmt = tr("Version %1");
+    QString dateLineFmt = tr("Built on %1 at %2");
+    QString dateLine;
+
+#if defined(MPCQT_DEVELOPMENT)
+    QDate buildDate = Helpers::dateFromCFormat(__DATE__);
+    QTime buildTime = Helpers::timeFromCFormat(__TIME__);
+    QString dateFormat = QLocale().dateFormat(QLocale::ShortFormat);
+    QString timeFormat = QLocale().timeFormat(QLocale::ShortFormat);
+    dateLine = "<br>" + dateLineFmt.arg(QLocale().toString(buildDate, dateFormat),
+                                                QLocale().toString(buildTime, timeFormat));
+#endif
+    QString packageLine = packageType();
+    packageLine = packageLine.isEmpty() ? "" : " (" + packageLine + ")";
+    QString displayMode = tr("(Unknown)");
+    if (QGuiApplication::platformName() == "wayland")
+        displayMode = "Wayland";
+    else {
+        if (qEnvironmentVariable("XDG_SESSION_TYPE") == "wayland")
+            displayMode = "XWayland";
+        else
+            displayMode = "X11";
+    }
+    QMessageBox::about(parent, tr("About Media Player Classic Qute Theater"),
+      "<h2>" + tr("Media Player Classic Qute Theater") + "</h2>" +
+      "<p>" +  tr("A clone of Media Player Classic written in Qt") +
+      "<br>" + tr("Based on Qt %1 and %2").arg(QT_VERSION_STR, mpvVersion) +
+      "<br>" + QString("ffmpeg %1").arg(ffmpegVersion) +
+      (Platform::isUnix ? "<br>" + tr("Running on %1").arg(displayMode) : "") +
+      "<p>" +  BUILD_VERSION_STR + (Platform::isUnix ? packageLine : "") +
+      dateLine +
+      "<h3>LICENSE</h3>"
+      "<p>   Copyright (C) 2015"
+      "<p>"
+      "This program is free software; you can redistribute it and/or modify "
+      "it under the terms of the GNU General Public License as published by "
+      "the Free Software Foundation; either version 2 of the License, or "
+      "(at your option) any later version."
+      "<p>"
+      "This program is distributed in the hope that it will be useful, "
+      "but WITHOUT ANY WARRANTY; without even the implied warranty of "
+      "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the "
+      "GNU General Public License for more details."
+      "<p>"
+      "You should have received a copy of the GNU General Public License "
+      "along with this program; if not, write to the Free Software "
+      "Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA "
+      "02110-1301 USA.");
+}
+
+QString About::version()
+{
+    return MPCQT_VERSION_STR;
+}
+
+QString About::buildTime()
+{
+    return (QString) __DATE__ + " " + __TIME__;
+}
+
+QString About::packageType()
+{
+    QString package;
+    if (qEnvironmentVariableIsSet("FLATPAK_ID"))
+        package = "Flatpak";
+    else if (qEnvironmentVariableIsSet("APPIMAGE"))
+        package = "AppImage";
+    else if (qEnvironmentVariableIsSet("SNAP"))
+        package = "Snap";
+    return package;
+}

--- a/src/about.h
+++ b/src/about.h
@@ -1,0 +1,17 @@
+#ifndef ABOUT_H
+#define ABOUT_H
+
+#include <QObject>
+
+class About : public QObject
+{
+    Q_OBJECT
+
+public:
+    static void showAbout(QWidget *parent, QString mpvVersion, QString ffmpegVersion);
+    static QString version();
+    static QString buildTime();
+    static QString packageType();
+};
+
+#endif // ABOUT_H

--- a/src/ipc/http.cpp
+++ b/src/ipc/http.cpp
@@ -2,8 +2,8 @@
 #include <QFile>
 #include <QFileInfo>
 #include <QTcpSocket>
+#include "about.h"
 #include "helpers.h"
-#include "version.h"
 #include "ipc/http.h"
 #include "platform/devicemanager.h"
 #include "platform/unify.h"
@@ -639,7 +639,7 @@ void MpcHcServer::setupHttp()
     http.route("/info.html", [this](HttpRequest &req, HttpResponse &res) {
         (void)req;
         QString str("&laquo; %1 &bull; %2 &bull; %3/%4 &bull; %5 &raquo;");
-        QString version("MPC-QT v" MPCQT_VERSION_STR);
+        QString version("MPC-QT v" + About::version());
         QString time(Helpers::toDateFormatFixed(fileTime, Helpers::ShortFormat));
         QString duration(Helpers::toDateFormatFixed(fileDuration, Helpers::ShortFormat));
         QString size(Helpers::fileSizeToStringShort(fileSize));
@@ -682,7 +682,7 @@ void MpcHcServer::setupHttp()
         QString playbackRate = QString::number(this->playbackRate);
         QString size = Helpers::fileSizeToStringShort(fileSize);
         QString reloadTime = "0";
-        QString version = MPCQT_VERSION_STR;
+        QString version = About::version();
 
         QList<QPair<QString,QString>> variables = {
             { "file", file },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #ifdef HAVE_BOOST
 #include <boost/stacktrace.hpp>
 #endif
+#include "about.h"
 #include "logger.h"
 #include "main.h"
 #include "qprocess.h"
@@ -23,7 +24,6 @@
 #include "settingswindow.h"
 #include "mpvwidget.h"
 #include "propertieswindow.h"
-#include "version.h"
 #include "ipc/mpris.h"
 #include "platform/devicemanager.h"
 #include "platform/unify.h"
@@ -83,10 +83,7 @@ int main(int argc, char *argv[])
     qRegisterMetaType<uint64_t>("uint64_t");
     qRegisterMetaType<uint16_t>("uint16_t");
 
-#ifndef MPCQT_VERSION_STR
-#define MPCQT_VERSION_STR MainWindow::tr("Development Build")
-#endif
-    QCoreApplication::setApplicationVersion(MPCQT_VERSION_STR);
+    QCoreApplication::setApplicationVersion(About::version());
 
     // Spin up the application
     Flow f;
@@ -1273,25 +1270,16 @@ bool Flow::isNvidiaGPU()
 
 void Flow::showVersionInfo()
 {
-    QString package = "Native build";
-    if (qEnvironmentVariableIsSet("FLATPAK_ID")) {
-        package = "Flatpak";
-        mainWindow->setRemoveFileNotRecycle();
-    }
-    else if (qEnvironmentVariableIsSet("APPIMAGE"))
-        package = "AppImage";
-    else if (qEnvironmentVariableIsSet("SNAP"))
-        package = "Snap";
-
     static constexpr char spaces[] = "               ";
     QString logMessages = "Version information:\n";
     logMessages += (QString) spaces + "OS: " + QSysInfo::productType() + " " + QSysInfo::productVersion() + "\n";
     logMessages += (QString) spaces + "Qt: " + (QString) QT_VERSION_STR + "\n";
     logMessages += (QString) spaces + mainWindow->mpvObject()->mpvVersion() + "\n";
     logMessages += (QString) spaces + "ffmpeg " + mainWindow->mpvObject()->ffmpegVersion() + "\n";
-    logMessages += (QString) spaces + "mpc-qt: " + (QString) MPCQT_VERSION_STR;
-    logMessages += " " + (QString) __DATE__ + " " + __TIME__  + "\n";
-    logMessages += (QString) spaces + "Package: " + package;
+    logMessages += (QString) spaces + "mpc-qt: " + About::version();
+    logMessages += " " + About::buildTime();
+    QString packageType = About::packageType();
+    logMessages += packageType.isEmpty() ? "" : "\n" + (QString) spaces + "Package: " + packageType;
     LogStream(logModule) << logMessages;
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,10 +1,10 @@
 #include <cmath>
+#include "about.h"
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
 #include "openfiledialog.h"
 #include "helpers.h"
 #include "logger.h"
-#include "version.h"
 #include "platform/unify.h"
 #include "platform/devicemanager.h"
 #include <QActionGroup>
@@ -76,6 +76,7 @@ MainWindow::MainWindow(QWidget *parent) :
         hide();
         setAttribute(Qt::WA_DontShowOnScreen, false);
     }
+    setRemoveFileNotRecycle();
 }
 
 MainWindow::~MainWindow()
@@ -357,7 +358,8 @@ void MainWindow::setActionPlayLoopUse()
 
 void MainWindow::setRemoveFileNotRecycle()
 {
-    ui->actionFileMoveToRecycleBin->setText(tr("Re&move File"));
+    if (qEnvironmentVariableIsSet("FLATPAK_ID"))
+        ui->actionFileMoveToRecycleBin->setText(tr("Re&move File"));
 }
 
 void MainWindow::updateLanguage()
@@ -3535,62 +3537,8 @@ void MainWindow::on_actionHelpHomepage_triggered()
 
 void MainWindow::on_actionHelpAbout_triggered()
 {
-#if defined(MPCQT_DEVELOPMENT)
-#define BUILD_VERSION_STR QString("%1 (%2)").arg(devBuild, MPCQT_VERSION_STR)
-#elif defined(MPCQT_VERSION_STR)
-#define BUILD_VERSION_STR versionFmt.arg(MPCQT_VERSION_STR)
-#else
-#define BUILD_VERSION_STR devBuild
-#endif
-    QString devBuild = tr("Development Build");
-    QString versionFmt = tr("Version %1");
-    QString dateLineFmt = tr("Built on %1 at %2");
-    QString dateLine;
-
-#if defined(MPCQT_DEVELOPMENT)
-    QDate buildDate = Helpers::dateFromCFormat(__DATE__);
-    QTime buildTime = Helpers::timeFromCFormat(__TIME__);
-    QString dateFormat = QLocale().dateFormat(QLocale::ShortFormat);
-    QString timeFormat = QLocale().timeFormat(QLocale::ShortFormat);
-    dateLine = "<br>" + dateLineFmt.arg(QLocale().toString(buildDate, dateFormat),
-                                        QLocale().toString(buildTime, timeFormat));
-#endif
-    QString displayMode = tr("(Unknown)");
-    if (QGuiApplication::platformName() == "wayland")
-        displayMode = "Wayland";
-    else {
-        if (qEnvironmentVariable("XDG_SESSION_TYPE") == "wayland")
-            displayMode = "XWayland";
-        else
-            displayMode = "X11";
-    }
-    QMessageBox::about(this, tr("About Media Player Classic Qute Theater"),
-      "<h2>" + tr("Media Player Classic Qute Theater") + "</h2>" +
-      "<p>" +  tr("A clone of Media Player Classic written in Qt") +
-      "<br>" + tr("Based on Qt %1 and %2").arg(QT_VERSION_STR, mpvObject_->mpvVersion()) +
-      "<br>" + QString("ffmpeg %1").arg(mpvObject_->ffmpegVersion()) +
-      (Platform::isUnix ? "<br>" + tr("Running under %1").arg(displayMode) : "") +
-      "<p>" +  BUILD_VERSION_STR +
-      dateLine +
-      "<h3>LICENSE</h3>"
-      "<p>   Copyright (C) 2015"
-      "<p>"
-      "This program is free software; you can redistribute it and/or modify "
-      "it under the terms of the GNU General Public License as published by "
-      "the Free Software Foundation; either version 2 of the License, or "
-      "(at your option) any later version."
-      "<p>"
-      "This program is distributed in the hope that it will be useful, "
-      "but WITHOUT ANY WARRANTY; without even the implied warranty of "
-      "MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the "
-      "GNU General Public License for more details."
-      "<p>"
-      "You should have received a copy of the GNU General Public License "
-      "along with this program; if not, write to the Free Software "
-      "Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA "
-      "02110-1301 USA.");
+    About::showAbout(this, mpvObject_->mpvVersion(), mpvObject_->ffmpegVersion());
 }
-
 
 void MainWindow::mpvw_customContextMenuRequested(const QPoint &pos)
 {

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ar">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1326,30 +1365,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+Q</source>
         <translation type="vanished">Alt+Q</translation>
     </message>
@@ -1547,14 +1562,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ca">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Compilació de desenvolupament</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Versió %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Compilat el %1 a les %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Sobre el Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Un clon del Media Player Classic escrit en Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Basant en Qt %1 i %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1451,27 +1490,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Compilació de desenvolupament</translation>
+        <translation type="vanished">Compilació de desenvolupament</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Versió %1</translation>
+        <translation type="vanished">Versió %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Sobre el Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Sobre el Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Un clon del Media Player Classic escrit en Qt</translation>
+        <translation type="vanished">Un clon del Media Player Classic escrit en Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Basant en Qt %1 i %2</translation>
+        <translation type="vanished">Basant en Qt %1 i %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Compilat el %1 a les %2</translation>
+        <translation type="vanished">Compilat el %1 a les %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1719,14 +1758,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="cs">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(Neznámý)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1470,30 +1509,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+Q</source>
         <translation type="vanished">Alt+Q</translation>
     </message>
@@ -1739,11 +1754,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(Neznámý)</translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">(Neznámý)</translation>
     </message>
     <message>
         <source>XWayland or X11</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="de">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Entwicklerversion</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Version %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Gebaut auf %1 um %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(unbekannt)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Über Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Ein Klon von Media Player Classic, geschrieben in Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Basierend auf Qt %1 und %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">Läuft unter %1</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1473,27 +1516,27 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Entwicklerversion</translation>
+        <translation type="vanished">Entwicklerversion</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Version %1</translation>
+        <translation type="vanished">Version %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Über Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Über Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Ein Klon von Media Player Classic, geschrieben in Qt</translation>
+        <translation type="vanished">Ein Klon von Media Player Classic, geschrieben in Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Basierend auf Qt %1 und %2</translation>
+        <translation type="vanished">Basierend auf Qt %1 und %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Gebaut auf %1 um %2</translation>
+        <translation type="vanished">Gebaut auf %1 um %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1745,11 +1788,11 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(unbekannt)</translation>
+        <translation type="vanished">(unbekannt)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>Läuft unter %1</translation>
+        <translation type="vanished">Läuft unter %1</translation>
     </message>
     <message>
         <source>XWayland or X11</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="en">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Development Build</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Version %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Built on %1 at %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(Unknown)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">About Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">A clone of Media Player Classic written in Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Based on Qt %1 and %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">Running under %1</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1459,27 +1502,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Development Build</translation>
+        <translation type="vanished">Development Build</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Version %1</translation>
+        <translation type="vanished">Version %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>About Media Player Classic Qute Theater</translation>
+        <translation type="vanished">About Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>A clone of Media Player Classic written in Qt</translation>
+        <translation type="vanished">A clone of Media Player Classic written in Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Based on Qt %1 and %2</translation>
+        <translation type="vanished">Based on Qt %1 and %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Built on %1 at %2</translation>
+        <translation type="vanished">Built on %1 at %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1731,11 +1774,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(Unknown)</translation>
+        <translation type="vanished">(Unknown)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>Running under %1</translation>
+        <translation type="vanished">Running under %1</translation>
     </message>
     <message>
         <source>XWayland or X11</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Compilación de desarrollo</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Versión %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Compilado el %1 a las %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Acerca de Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Reproductor multimedia clásico Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Un clón de Media Player Classic escrito usando Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Basado en Qt %1 y %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1419,27 +1458,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Compilación de desarrollo</translation>
+        <translation type="vanished">Compilación de desarrollo</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Versión %1</translation>
+        <translation type="vanished">Versión %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Acerca de Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Acerca de Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Un clón de Media Player Classic escrito usando Qt</translation>
+        <translation type="vanished">Un clón de Media Player Classic escrito usando Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Basado en Qt %1 y %2</translation>
+        <translation type="vanished">Basado en Qt %1 y %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Compilado el %1 a las %2</translation>
+        <translation type="vanished">Compilado el %1 a las %2</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1611,14 +1650,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fi">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Kehittäjäversio</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Versio %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Tietoja Media Player Classic Qute Theaterista</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Media Player Classicin klooni, joka on kirjoitettu Qt:llä</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Perustuu Qt %1 ja %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1363,27 +1402,23 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Kehittäjäversio</translation>
+        <translation type="vanished">Kehittäjäversio</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Versio %1</translation>
+        <translation type="vanished">Versio %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Tietoja Media Player Classic Qute Theaterista</translation>
+        <translation type="vanished">Tietoja Media Player Classic Qute Theaterista</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Media Player Classicin klooni, joka on kirjoitettu Qt:llä</translation>
+        <translation type="vanished">Media Player Classicin klooni, joka on kirjoitettu Qt:llä</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Perustuu Qt %1 ja %2</translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Perustuu Qt %1 ja %2</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1579,14 +1614,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="fr">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Version de développement</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Version %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Construit le %1 à %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(inconnu)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">À propos de Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Un clone de Media Player Classic écrit en Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Basé sur Qt %1 et %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">Fonctionne sous %1</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1425,27 +1468,27 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Version de développement</translation>
+        <translation type="vanished">Version de développement</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Version %1</translation>
+        <translation type="vanished">Version %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>À propos de Media Player Classic Qute Theater</translation>
+        <translation type="vanished">À propos de Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Un clone de Media Player Classic écrit en Qt</translation>
+        <translation type="vanished">Un clone de Media Player Classic écrit en Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Basé sur Qt %1 et %2</translation>
+        <translation type="vanished">Basé sur Qt %1 et %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Construit le %1 à %2</translation>
+        <translation type="vanished">Construit le %1 à %2</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1669,11 +1712,11 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(inconnu)</translation>
+        <translation type="vanished">(inconnu)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>Fonctionne sous %1</translation>
+        <translation type="vanished">Fonctionne sous %1</translation>
     </message>
     <message>
         <source>XWayland or X11</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="id">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Versi untuk Pengembang</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Versi &amp;1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Dibangun dari %1 pada %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(Tidak Diketahui)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Tentang Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Sebuah klon dari Media Player Classic menggunakan Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Dibuat dengan Qt %1 dan %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">Berjalan di bawah %1</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1457,27 +1500,27 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Versi untuk Pengembang</translation>
+        <translation type="vanished">Versi untuk Pengembang</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Versi &amp;1</translation>
+        <translation type="vanished">Versi &amp;1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Tentang Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Tentang Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Sebuah klon dari Media Player Classic menggunakan Qt</translation>
+        <translation type="vanished">Sebuah klon dari Media Player Classic menggunakan Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Dibuat dengan Qt %1 dan %2</translation>
+        <translation type="vanished">Dibuat dengan Qt %1 dan %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Dibangun dari %1 pada %2</translation>
+        <translation type="vanished">Dibangun dari %1 pada %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1693,11 +1736,11 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(Tidak Diketahui)</translation>
+        <translation type="vanished">(Tidak Diketahui)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>Berjalan di bawah %1</translation>
+        <translation type="vanished">Berjalan di bawah %1</translation>
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="it">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Compilato il %1 alle %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Informazioni su Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Un clone di Media Player Classic scritto in Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Basato su Qt %1 e %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1414,28 +1453,20 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Informazioni su Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Informazioni su Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Un clone di Media Player Classic scritto in Qt</translation>
+        <translation type="vanished">Un clone di Media Player Classic scritto in Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Basato su Qt %1 e %2</translation>
+        <translation type="vanished">Basato su Qt %1 e %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Compilato il %1 alle %2</translation>
+        <translation type="vanished">Compilato il %1 alle %2</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1607,14 +1638,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ja">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">開発ビルド</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">バージョン %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Built on %1 at %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(不明)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater について</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Qt で書かれた Media Player Classic のクローン</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Qt %1 および %2 に基づく</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">%1 で実行中</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1473,27 +1516,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>開発ビルド</translation>
+        <translation type="vanished">開発ビルド</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>バージョン %1</translation>
+        <translation type="vanished">バージョン %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Media Player Classic Qute Theater について</translation>
+        <translation type="vanished">Media Player Classic Qute Theater について</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Qt で書かれた Media Player Classic のクローン</translation>
+        <translation type="vanished">Qt で書かれた Media Player Classic のクローン</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Qt %1 および %2 に基づく</translation>
+        <translation type="vanished">Qt %1 および %2 に基づく</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Built on %1 at %2</translation>
+        <translation type="vanished">Built on %1 at %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1745,11 +1788,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(不明)</translation>
+        <translation type="vanished">(不明)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>%1 で実行中</translation>
+        <translation type="vanished">%1 で実行中</translation>
     </message>
     <message>
         <source>XWayland or X11</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1455,30 +1494,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+Q</source>
         <translation type="vanished">Alt+Q</translation>
     </message>
@@ -1716,14 +1731,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nb_NO">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Utviklingsbygg</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Versjon %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1331,27 +1370,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Utviklingsbygg</translation>
+        <translation type="vanished">Utviklingsbygg</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Versjon %1</translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Versjon %1</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1643,14 +1666,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>More Files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="nl">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1330,30 +1369,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+Q</source>
         <translation type="vanished">Alt+Q</translation>
     </message>
@@ -1551,14 +1566,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pl">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Build deweloperski</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Wersja %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Zbudowany %1 o %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">O: Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Klon Media Player Classic napisany w Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Bazowany na Qt %1 i %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1451,27 +1490,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Build deweloperski</translation>
+        <translation type="vanished">Build deweloperski</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Wersja %1</translation>
+        <translation type="vanished">Wersja %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>O: Media Player Classic Qute Theater</translation>
+        <translation type="vanished">O: Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Klon Media Player Classic napisany w Qt</translation>
+        <translation type="vanished">Klon Media Player Classic napisany w Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Bazowany na Qt %1 i %2</translation>
+        <translation type="vanished">Bazowany na Qt %1 i %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Zbudowany %1 o %2</translation>
+        <translation type="vanished">Zbudowany %1 o %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1715,14 +1754,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="pt_BR">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Sobre o Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Um clone de Media Player Classic escrito em Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1350,28 +1389,12 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Sobre o Media Player Classic Qute Theater</translation>
+        <translation type="vanished">Sobre o Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Um clone de Media Player Classic escrito em Qt</translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Um clone de Media Player Classic escrito em Qt</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1571,14 +1594,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Версия для разработчиков</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Версия %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">Скомпилировано %1 в %2</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">О Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Клон Media Player Classic, написанный на Qt</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Используется Qt %1 и %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1451,27 +1490,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Версия для разработчиков</translation>
+        <translation type="vanished">Версия для разработчиков</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Версия %1</translation>
+        <translation type="vanished">Версия %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>О Media Player Classic Qute Theater</translation>
+        <translation type="vanished">О Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Клон Media Player Classic, написанный на Qt</translation>
+        <translation type="vanished">Клон Media Player Classic, написанный на Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Используется Qt %1 и %2</translation>
+        <translation type="vanished">Используется Qt %1 и %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>Скомпилировано %1 в %2</translation>
+        <translation type="vanished">Скомпилировано %1 в %2</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1700,14 +1739,6 @@ No action will be triggered.</source>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
         <translation>v: 0 кбит/с, a: 0 кбит/с</translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ta">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">வளர்ச்சி உருவாக்கம்</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">பதிப்பு %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">%1 இல் %2 இல் கட்டப்பட்டது</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(தெரியாது)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">மீடியா பிளேயர் கிளாசிக் கியூட் தியேட்டர் பற்றி</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">மீடியா பிளேயர் கிளாசிக் கியூட் தியேட்டர்</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">கியுடி இல் எழுதப்பட்ட மீடியா பிளேயர் கிளாசிக் ஒரு நகலி</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">கியுடி %1 மற்றும் %2 ஐ அடிப்படையாகக் கொண்டது</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">% 1 இன் கீழ் இயங்குகிறது</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1465,27 +1508,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>வளர்ச்சி உருவாக்கம்</translation>
+        <translation type="vanished">வளர்ச்சி உருவாக்கம்</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>பதிப்பு %1</translation>
+        <translation type="vanished">பதிப்பு %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>மீடியா பிளேயர் கிளாசிக் கியூட் தியேட்டர் பற்றி</translation>
+        <translation type="vanished">மீடியா பிளேயர் கிளாசிக் கியூட் தியேட்டர் பற்றி</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>கியுடி இல் எழுதப்பட்ட மீடியா பிளேயர் கிளாசிக் ஒரு நகலி</translation>
+        <translation type="vanished">கியுடி இல் எழுதப்பட்ட மீடியா பிளேயர் கிளாசிக் ஒரு நகலி</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>கியுடி %1 மற்றும் %2 ஐ அடிப்படையாகக் கொண்டது</translation>
+        <translation type="vanished">கியுடி %1 மற்றும் %2 ஐ அடிப்படையாகக் கொண்டது</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>%1 இல் %2 இல் கட்டப்பட்டது</translation>
+        <translation type="vanished">%1 இல் %2 இல் கட்டப்பட்டது</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1737,11 +1780,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(தெரியாது)</translation>
+        <translation type="vanished">(தெரியாது)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>% 1 இன் கீழ் இயங்குகிறது</translation>
+        <translation type="vanished">% 1 இன் கீழ் இயங்குகிறது</translation>
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="tr">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">Geliştirme Yapısı</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">Sürüm %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">%1 üzerine %2 tarihinde yapıldı</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">(Bilinmeyen)</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater Hakkında</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">Media Player Classic’in Qt ile yazılmış bir klonu</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">Qt %1 ve %2 tabanlı</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">%1 altında çalışıyor</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1465,27 +1508,27 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>Geliştirme Yapısı</translation>
+        <translation type="vanished">Geliştirme Yapısı</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>Sürüm %1</translation>
+        <translation type="vanished">Sürüm %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>Media Player Classic Qute Theater Hakkında</translation>
+        <translation type="vanished">Media Player Classic Qute Theater Hakkında</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>Media Player Classic’in Qt ile yazılmış bir klonu</translation>
+        <translation type="vanished">Media Player Classic’in Qt ile yazılmış bir klonu</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>Qt %1 ve %2 tabanlı</translation>
+        <translation type="vanished">Qt %1 ve %2 tabanlı</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>%1 üzerine %2 tarihinde yapıldı</translation>
+        <translation type="vanished">%1 üzerine %2 tarihinde yapıldı</translation>
     </message>
     <message>
         <source>Alt+Q</source>
@@ -1737,11 +1780,11 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>(Bilinmeyen)</translation>
+        <translation type="vanished">(Bilinmeyen)</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>%1 altında çalışıyor</translation>
+        <translation type="vanished">%1 altında çalışıyor</translation>
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2,6 +2,45 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ur">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1438,30 +1477,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Development Build</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Version %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Built on %1 at %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Alt+Q</source>
         <translation type="vanished">Alt+Q</translation>
     </message>
@@ -1667,14 +1682,6 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>v: 0 kb/s, a: 0kb/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(Unknown)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Running under %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2,6 +2,49 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="zh_CN">
 <context>
+    <name>About</name>
+    <message>
+        <source>Development Build</source>
+        <translation type="unfinished">开发构建</translation>
+    </message>
+    <message>
+        <source>Version %1</source>
+        <translation type="unfinished">版本 %1</translation>
+    </message>
+    <message>
+        <source>Built on %1 at %2</source>
+        <translation type="unfinished">于 %1 %2 构建</translation>
+    </message>
+    <message>
+        <source>(Unknown)</source>
+        <translation type="unfinished">（未知）</translation>
+    </message>
+    <message>
+        <source>About Media Player Classic Qute Theater</source>
+        <translation type="unfinished">关于 Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>Media Player Classic Qute Theater</source>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+    </message>
+    <message>
+        <source>A clone of Media Player Classic written in Qt</source>
+        <translation type="unfinished">使用 Qt 编写的 Media Player Classic 克隆</translation>
+    </message>
+    <message>
+        <source>Based on Qt %1 and %2</source>
+        <translation type="unfinished">基于 Qt %1 和 %2</translation>
+    </message>
+    <message>
+        <source>Running on %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Running under %1</source>
+        <translation type="obsolete">在 1% 中运行</translation>
+    </message>
+</context>
+<context>
     <name>ActionEditor</name>
     <message>
         <source>Command</source>
@@ -1473,27 +1516,27 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Development Build</source>
-        <translation>开发构建</translation>
+        <translation type="vanished">开发构建</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation>版本 %1</translation>
+        <translation type="vanished">版本 %1</translation>
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation>关于 Media Player Classic Qute Theater</translation>
+        <translation type="vanished">关于 Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation>使用 Qt 编写的 Media Player Classic 克隆</translation>
+        <translation type="vanished">使用 Qt 编写的 Media Player Classic 克隆</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation>基于 Qt %1 和 %2</translation>
+        <translation type="vanished">基于 Qt %1 和 %2</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation>于 %1 %2 构建</translation>
+        <translation type="vanished">于 %1 %2 构建</translation>
     </message>
     <message>
         <source>Ctrl+Q</source>
@@ -1701,11 +1744,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>(Unknown)</source>
-        <translation>（未知）</translation>
+        <translation type="vanished">（未知）</translation>
     </message>
     <message>
         <source>Running under %1</source>
-        <translation>在 1% 中运行</translation>
+        <translation type="vanished">在 1% 中运行</translation>
     </message>
     <message>
         <source>XWayland or X11</source>


### PR DESCRIPTION
Avoids duplicating the package detection.
Reduces the number of files rebuilt on change (only about.cpp instead of ipc/http.cpp, main.cpp and especially mainwindow.cpp).

Follow-up to 1f193ed50cb9ae6a7f185c89b80a8ae699188d0f ("Replace compiler parameter with version.h for versioning").