### PR TITLE
drawnslider: Jump to start of current chapter on middle-click in progress bar

### DIFF
--- a/src/widgets/drawnslider.cpp
+++ b/src/widgets/drawnslider.cpp
@@ -457,9 +457,11 @@ void MediaSlider::mousePressEvent(QMouseEvent *ev)
 {
     if (ev->button() == Qt::MiddleButton && !ticks.isEmpty()) {
         double clickTime = xToValue(ev->position().x());
-        auto it = ticks.upperBound(clickTime);
-        if (it != ticks.constEnd())
-            emit middleClicked(it.key());
+        auto it = ticks.lowerBound(clickTime);
+        if (it == ticks.constEnd() || std::round(it.key()) > std::round(clickTime)) {
+            --it;
+        }
+        emit middleClicked(it.key());
         return;
     }
     DrawnSlider::mousePressEvent(ev);


### PR DESCRIPTION
Modifies 97a887859ef5183dbd03336ffce166c79dd3c065 to jump to start (instead of end) of current chapter on middle-click in progress bar.

It's less surprising for users as it rewinds the chapter they see in the (preview) tooltip. It also makes it possible to seek to the start of the first chapter.

Round the times before comparison so that the behavior is consistent with the times shown in the tooltip. Clicking while the tooltip shows the same time (accuracy in seconds) as the chapter start will rewind to that chapter start even if the cursor is actually a few milliseconds before the start.

Follow-up to 97a887859ef5183dbd03336ffce166c79dd3c065 ("widgets: jump to next chapter on middle-click in progress bar")