### PR TITLE
logger: Always enable logging with --log-to-console

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -199,7 +199,7 @@ void Logger::setLoggingEnabled(bool enabled)
         makeLogPrefixed(logModule, "enabling logging");
         if (!immediateMode)
             flushTimer->start();
-    } else if (!enabled && loggingEnabled) {
+    } else if (!enabled && loggingEnabled && !logToConsole) {
         makeLogPrefixed(logModule, "disabling logging");
         flushMessages();
         flushTimer->stop();


### PR DESCRIPTION
We obviously want logging to be enabled when we use the command line argument --log-to-console.