### PR TITLE
playlistwindow: Remove "Save As..." command from context menu

### DIFF
--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -978,14 +978,6 @@ void PlaylistWindow::playlist_contextMenuRequested(const QPoint &p, const QUuid 
     a->setDisabled(noItemSelected);
     m->addAction(a);
 
-    a = new QAction(m);
-    a->setText(tr("Save As..."));
-    connect(a, &QAction::triggered,
-            this, [this,playlistUuid]() {
-        savePlaylist(playlistUuid);
-    });
-    m->addAction(a);
-
     m->addSeparator();
 
     a = new QAction(m);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2047,10 +2047,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort By Label</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2244,7 +2244,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Desar com a...</translation>
+        <translation type="vanished">Desar com a...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2284,7 +2284,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Uložit jako...</translation>
+        <translation type="vanished">Uložit jako...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2266,7 +2266,7 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Speichern als...</translation>
+        <translation type="vanished">Speichern als...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2276,7 +2276,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Save As...</translation>
+        <translation type="vanished">Save As...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2132,7 +2132,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Guardar como...</translation>
+        <translation type="vanished">Guardar como...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2104,7 +2104,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Tallenna Nimellä...</translation>
+        <translation type="vanished">Tallenna Nimellä...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2214,7 +2214,7 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Enregistrer sous...</translation>
+        <translation type="vanished">Enregistrer sous...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2194,7 +2194,7 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Simpan Sebagai...</translation>
+        <translation type="vanished">Simpan Sebagai...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2123,10 +2123,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort By Label</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2278,7 +2278,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>名前を付けて保存...</translation>
+        <translation type="vanished">名前を付けて保存...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2260,10 +2260,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort By Label</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2036,7 +2036,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Lagre som …</translation>
+        <translation type="vanished">Lagre som …</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2055,10 +2055,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort By Label</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2256,7 +2256,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Zapisz jako...</translation>
+        <translation type="vanished">Zapisz jako...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2076,7 +2076,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Salvar Como...</translation>
+        <translation type="vanished">Salvar Como...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2224,7 +2224,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Сохранить как...</translation>
+        <translation type="vanished">Сохранить как...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2258,7 +2258,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>சேமி ...</translation>
+        <translation type="vanished">சேமி ...</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2258,7 +2258,7 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>Farklı Kaydet…</translation>
+        <translation type="vanished">Farklı Kaydet…</translation>
     </message>
     <message>
         <source>Sort By Label</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2167,10 +2167,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Save As...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Sort By Label</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2234,7 +2234,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Save As...</source>
-        <translation>保存为…</translation>
+        <translation type="vanished">保存为…</translation>
     </message>
     <message>
         <source>Sort By Label</source>


### PR DESCRIPTION
It's confusing because, unlike the "Copy To clipboard" above it, it exports the whole playlist instead of saving the selected item.
The playlist export command already has a dedicated button at the bottom and an entry in the playlist tab context menu.