### PR TITLE
Speed up video preview generation

### DIFF
--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -379,11 +379,15 @@ void MpvObject::stepForward()
     emit ctrlCommand("frame_step");
 }
 
-void MpvObject::seek(double amount, bool exact)
+void MpvObject::seek(double amount, bool exact, bool keyframes, bool absolute)
 {
     QVariantList payload({"seek", amount});
+    if (absolute)
+        payload.append("absolute");
     if (exact)
         payload.append("exact");
+    if (keyframes)
+        payload.append("keyframes");
     emit ctrlCommand(payload);
 }
 

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -60,7 +60,7 @@ public:
     void stopPlayback();
     void stepBackward();
     void stepForward();
-    void seek(double amount, bool exact);
+    void seek(double amount, bool exact, bool keyframes = false, bool absolute = false);
     void screenshot(const QString &fileName, Helpers::ScreenshotRender render);
     void setMouseHideTime(int msec);
     void setIsInBottomArea(bool entered);

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -65,7 +65,7 @@ void VideoPreview::updatePalette()
 void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)
 {
     textLabel->setText(text);
-    mpv->setTime(videoPosition);
+    mpv->seek(videoPosition, false, true, true);
     mpv->setPaused(true);
     videoWidget->update();
     setPreviewPosition(where, mainWindowWidth);

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -29,8 +29,6 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
 
     connect(mpv, &MpvObject::aspectChanged,
             this, &VideoPreview::updateWidth);
-    connect(mpv, &MpvObject::playTimeChanged,
-            this, &VideoPreview::positionChanged);
 
     shouldBeShown = false;
     hide();
@@ -54,10 +52,6 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     mpv->urlOpen(fileUrl);
     mpv->setPaused(true);
     aspectRatioSet = false;
-    currentPosition = 0;
-    lastRequestedPosition = -1;
-    lastHoverDirection = Direction::None;
-    isSeeking = false;
 }
 
 void VideoPreview::updatePalette()
@@ -71,40 +65,11 @@ void VideoPreview::updatePalette()
 void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)
 {
     textLabel->setText(text);
-    requestedPosition = videoPosition;
-    if (!isSeeking)
-        seek();
+    mpv->setTime(videoPosition);
+    mpv->setPaused(true);
     videoWidget->update();
     setPreviewPosition(where, mainWindowWidth);
     show();
-}
-
-void VideoPreview::seek()
-{
-    if (requestedPosition == currentPosition)
-        return;
-
-    Direction hoverDirection = Direction::None;
-    if (lastRequestedPosition != -1) {
-        if (requestedPosition < lastRequestedPosition)
-            hoverDirection = Direction::Backward;
-        else if (requestedPosition > lastRequestedPosition)
-            hoverDirection = Direction::Forward;
-    } else {
-        if (requestedPosition < currentPosition)
-            hoverDirection = Direction::Backward;
-        else if (requestedPosition > currentPosition)
-            hoverDirection = Direction::Forward;
-    }
-    if (hoverDirection == lastHoverDirection &&
-        ((hoverDirection == Direction::Forward && currentPosition > requestedPosition) ||
-        (hoverDirection == Direction::Backward && currentPosition < requestedPosition)))
-        return;
-
-    lastHoverDirection = hoverDirection;
-    lastRequestedPosition = requestedPosition;
-    isSeeking = true;
-    mpv->seek(requestedPosition - currentPosition, false);
 }
 
 void VideoPreview::setPreviewPosition(const QPoint &where, int mainWindowWidth)
@@ -134,12 +99,6 @@ void VideoPreview::updateWidth(double newAspect)
         hide();
 }
 
-void VideoPreview::positionChanged(double position)
-{
-    currentPosition = position;
-    isSeeking = false;
-}
-
 void VideoPreview::show()
 {
     if (!aspectRatioSet) {
@@ -156,7 +115,4 @@ void VideoPreview::hide() {
     shouldBeShown = false;
     videoWidget->move(-50000, -50000);
     textLabel->move(-50000, -50000);
-    lastRequestedPosition = -1;
-    lastHoverDirection = Direction::None;
-    mpv->setTime(0);
 }

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -14,21 +14,13 @@ class VideoPreview : public QWidget {
         void hide();
         
     private:
-        void seek();
         void setPreviewPosition(const QPoint &where, int mainWindowWidth);
         void show();
         void updateWidth(double newAspect);
-        void positionChanged(double position);
 
         QLabel *textLabel;
         MpvObject *mpv = nullptr;
         MpvGlWidget *videoWidget = nullptr;
-        double currentPosition = 0;
-        double requestedPosition = 0;
-        double lastRequestedPosition = 0;
-        bool isSeeking = false;
-        enum class Direction { None, Backward, Forward };
-        Direction lastHoverDirection = Direction::None;
         bool aspectRatioSet = false;
         bool shouldBeShown = false;
         QPoint previewBottomLeft;


### PR DESCRIPTION
* Revert "videopreview: Use relative seeking to keyframes"

> This reverts commit https://github.com/mpc-qt/mpc-qt/commit/6c36134d0506b11b6a29b7b42d252cc5ebe4706c.
> 
> The aim is to use absolute seeking to keyframes instead.

* Use absolute seeking to keyframes for the video preview

> It's as fast as relative seeking to keyframes and much simpler.