### PR TITLE
Fix gapless playback-related issues, prevent mpv error when clearing filters

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -726,7 +726,8 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
         emit startedPlayingFile(what);
     mpvObject_->fileOpen(what.isLocalFile() ? what.toLocalFile()
                                             : QUrl::fromPercentEncoding(what.toEncoded()),
-                         replaceMpvPlaylist);
+                         replaceMpvPlaylist,
+                         !videoList.isEmpty() && !videoListData[1].isImage);
     if (!with.isEmpty())
         mpvObject_->setSubFile(with.toString());
     mpvObject_->setPaused(playbackStartPaused);

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -435,13 +435,15 @@ void MpvObject::setLogoBackground(const QColor &color)
 void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersList)
 {
     emit ctrlCommand("no-osd af clear");
-    emit ctrlCommand("no-osd af set \"" + formatFiltersList(filtersList) + "\"");
+    if (!filtersList.empty())
+        emit ctrlCommand("no-osd af set \"" + formatFiltersList(filtersList) + "\"");
 }
 
 void MpvObject::setVideoFilters(const QList<QPair<QString, QString>> &filtersList)
 {
     emit ctrlCommand("no-osd vf clear");
-    emit ctrlCommand("no-osd vf set \"" + formatFiltersList(filtersList) + "\"");
+    if (!filtersList.empty())
+        emit ctrlCommand("no-osd vf set \"" + formatFiltersList(filtersList) + "\"");
 }
 
 QString MpvObject::formatFiltersList(const QList<QPair<QString, QString>> &filtersList)

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -432,16 +432,18 @@ void MpvObject::setLogoBackground(const QColor &color)
         widget->setLogoBackground(color);
 }
 
-void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersList)
+void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters)
 {
-    emit ctrlCommand("no-osd af clear");
+    if (clearFilters)
+        emit ctrlCommand("no-osd af clear");
     if (!filtersList.empty())
         emit ctrlCommand("no-osd af set \"" + formatFiltersList(filtersList) + "\"");
 }
 
-void MpvObject::setVideoFilters(const QList<QPair<QString, QString>> &filtersList)
+void MpvObject::setVideoFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters)
 {
-    emit ctrlCommand("no-osd vf clear");
+    if (clearFilters)
+        emit ctrlCommand("no-osd vf clear");
     if (!filtersList.empty())
         emit ctrlCommand("no-osd vf set \"" + formatFiltersList(filtersList) + "\"");
 }

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -342,15 +342,17 @@ void MpvObject::urlOpen(QUrl url)
                                : QUrl::fromPercentEncoding(url.toEncoded()));
 }
 
-void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist)
+void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist, bool previousWasVideo)
 {
     clearSubFiles();
-    setMpvPropertyVariant("vid", "no");
-    if (replaceMpvPlaylist)
+    if (replaceMpvPlaylist || previousWasVideo) {
+        setMpvPropertyVariant("vid", "no"); // clear last frame of previous video file
         emit ctrlCommand(QStringList({"loadfile", filename}));
-    else
+        setMpvPropertyVariant("vid", "auto");
+    }
+    else { // gapless playback
         emit ctrlCommand(QStringList({"loadfile", filename, "append-play"}));
-    setMpvPropertyVariant("vid", "auto");
+    }
     setMouseHideTime(hideTimer->interval());
 }
 

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -55,7 +55,7 @@ public:
     int selectedStatsPage();
 
     void urlOpen(QUrl url);
-    void fileOpen(QString filename, bool replaceMpvPlaylist = true);
+    void fileOpen(QString filename, bool replaceMpvPlaylist = true, bool previousWasVideo = false);
     void discFilesOpen(QString path);
     void stopPlayback();
     void stepBackward();

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -66,8 +66,8 @@ public:
     void setIsInBottomArea(bool entered);
     void setLogoUrl(const QString &filename);
     void setLogoBackground(const QColor &color);
-    void setAudioFilters(const QList<QPair<QString, QString>> &filtersList);
-    void setVideoFilters(const QList<QPair<QString, QString>> &filtersList);
+    void setAudioFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters);
+    void setVideoFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters);
     QString formatFiltersList(const QList<QPair<QString, QString>> &filtersList);
     void setSubFile(QString filename);
     void addSubFile(QString filename);

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1193,17 +1193,17 @@ void SettingsWindow::setHidePanels(bool hidden)
 
 void SettingsWindow::setAudioFilter(QString filter, QString options, bool add)
 {
-    setFilter(audioFiltersList, filter, options, add);
-    emit audioFilters(audioFiltersList);
+    bool clearFilters = setFilter(audioFiltersList, filter, options, add);
+    emit audioFilters(audioFiltersList, clearFilters);
 }
 
 void SettingsWindow::setVideoFilter(QString filter, QString options, bool add)
 {
-    setFilter(videoFiltersList, filter, options, add);
-    emit videoFilters(videoFiltersList);
+    bool clearFilters = setFilter(videoFiltersList, filter, options, add);
+    emit videoFilters(videoFiltersList, clearFilters);
 }
 
-void SettingsWindow::setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add)
+bool SettingsWindow::setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add)
 {
     auto it = std::find_if(filtersList.begin(),
                                      filtersList.end(),
@@ -1211,7 +1211,8 @@ void SettingsWindow::setFilter(QList<QPair<QString, QString>> &filtersList, QStr
         return pair.first == filter;
     });
 
-    if (it != filtersList.end()) { // Filter found
+    bool filterFound = it != filtersList.end();
+    if (filterFound) {
         int i = std::distance(filtersList.begin(), it);
         if (add)
             filtersList.replace(i, QPair<QString, QString>(filter, options));
@@ -1220,6 +1221,8 @@ void SettingsWindow::setFilter(QList<QPair<QString, QString>> &filtersList, QStr
     }
     else if (add)
         filtersList.append(QPair<QString, QString>(filter, options));
+
+    return filterFound;
 }
 
 void SettingsWindow::setCustomMpvOptions()

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -196,8 +196,8 @@ signals:
     void logDelay(int msecs);
     void logHistory(int lines);
 
-    void audioFilters(const QList<QPair<QString, QString>> &audioFiltersList);
-    void videoFilters(const QList<QPair<QString, QString>> &videoFiltersList);
+    void audioFilters(const QList<QPair<QString, QString>> &audioFiltersList, bool clearFilters);
+    void videoFilters(const QList<QPair<QString, QString>> &videoFiltersList, bool clearFilters);
 
 public slots:
     void takeActions(const QList<QAction*> actions);
@@ -218,7 +218,7 @@ public slots:
     void setHidePanels(bool hidden);
 
 private slots:
-    void setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add);
+    bool setFilter(QList<QPair<QString, QString>> &filtersList, QString filter, QString options, bool add);
     void setCustomMpvOptions();
     void colorPick_clicked(QLineEdit *colorValue);
     void colorPick_changed(const QLineEdit *colorValue, QPushButton *colorPick);


### PR DESCRIPTION
* mpvwidget: Only set filters when filter list isn't empty

> When combined with gapless playback (https://github.com/mpc-qt/mpc-qt/commit/a2d46911776d25ac22ce1a724e2d0487a1e35ac6), which uses the mpv playlist, trying to set empty filters causes mpv to skip one or more files.
> 
> Part 1 of fixing https://github.com/mpc-qt/mpc-qt/issues/982 ("Toggling yadif causes mpc-qt to overwrite the wrong playlist entry").
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/f8c35f2b678918e969c6b2b99f997fed0463e9c3 ("Add pre-defined audio and video filters support")
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/a2d46911776d25ac22ce1a724e2d0487a1e35ac6 ("Implement gapless playback")

* Only clear filters when needed

> Avoid clearing filters when none are set, as mpv reports an error in that case.
>
> Fixes: 848f86dea7a24938cc9166486c1ec4022d5450fb ("mpvwidget: Clear audio/video filters before we set them")

* Only use gapless playback for audio-to-audio transitions

> Gapless playback relies on the mpv playlist, and is more prone to edge cases.
> 
> Besides the issue fixed by https://github.com/mpc-qt/mpc-qt/commit/0df29a39e53325371808800ccea21d2f78a13907, disabling video before loading a file and re-enabling it afterwards (https://github.com/mpc-qt/mpc-qt/commit/2868d2a1327abc02589e6e25b91e7d2362a5f4e4) causes mpv to report EOF for the new file.
> 
> Since gapless playback is only useful when transitioning between audio files, enable it only when opening an audio file while another audio file is already playing.
> 
> Part 2 of fixing https://github.com/mpc-qt/mpc-qt/issues/982 ("Toggling yadif causes mpc-qt to overwrite the wrong playlist entry").
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/2868d2a1327abc02589e6e25b91e7d2362a5f4e4 ("mpvwidget: Force mpv to clear last frame of previous video file")