### PR TITLE
videopreview: Add fallback formats and QuickJS support for yt-dlp 

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -23,7 +23,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
-    emit mpv->ctrlSetOptionVariant("ytdl-format", QString("bestvideo[height>=?%1]").arg(videoHeight));
+    emit mpv->ctrlSetOptionVariant("ytdl-format", QString("bestvideo[height>=?%1]/best[height>=?%1]/bestvideo/best").arg(videoHeight));
     emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "format-sort=[+size,+br,+res,+fps]");
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -24,7 +24,9 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
     emit mpv->ctrlSetOptionVariant("ytdl-format", QString("bestvideo[height>=?%1]/best[height>=?%1]/bestvideo/best").arg(videoHeight));
-    emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "format-sort=[+size,+br,+res,+fps]");
+    emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "js-runtimes=quickjs,"\
+                                                    "remote-components=ejs:github,"\
+                                                    "format-sort=[+size,+br,+res,+fps]");
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 
     connect(mpv, &MpvObject::aspectChanged,


### PR DESCRIPTION
* videopreview: Add fallback formats for yt-dlp
With outdated versions of yt-dlp, less formats are sometimes available.
* videopreview: Add QuickJS support for yt-dlp and enable auto EJS update
Same as https://github.com/mpc-qt/mpc-qt/commit/505583561bc1f43e7fc7bcaa3ca4980e07e95c77 but for the seek bar video preview.