### PR TITLE
main: Switch to matching playlist when opening file from recents

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1434,8 +1434,10 @@ void Flow::mainwindow_recentOpened(const TrackInfo &track)
     // attempt to play the playlist item if possible, otherwise act like it
     // is a new file
     QUrl old = mainWindow->playlistWindow()->getUrlOf(track.list, track.item);
-    if (!old.isEmpty())
+    if (!old.isEmpty()) {
+        mainWindow->playlistWindow()->setCurrentPlaylist(track.list);
         playbackManager->playItem(track.list, track.item);
+    }
     else
         playbackManager->openFile(track.url);
 }


### PR DESCRIPTION
When opening a file from the Recent Files or Favorites menu, if the file is already present in an existing playlist, MPC-QT reuses that playlist entry instead of adding a new one to the Quick Playlist.

Switch to the corresponding playlist tab when this occurs. This makes it easier to track the currently playing file and ensures playback can be resumed correctly on the next application start.