### PR TITLE
settingswindow: Enable "Position ASS subs relative to video frame" by default

### DIFF
--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -6899,6 +6899,9 @@ media file played</string>
                      <property name="text">
                       <string>Position ASS subs relative to the video frame</string>
                      </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
                     </widget>
                    </item>
                   </layout>


### PR DESCRIPTION
Enable the "Position subtitles relative to the video frame" option by default (which sets sub-use-margins to the inverse of the UI option), restoring the behavior used before 88b0b58bfdbf1950bd8b521b586072572bc16154.

Fixes: 88b0b58bfdbf1950bd8b521b586072572bc16154 ("settingswindow: Implement more subtitle options")
Fixes #927 ("Subtitles extend beyond the edges of the natural resolution of the video when screen area is larger").