### PR TITLE
settingswindow: Use mpv default subtitles shadow color

### DIFF
--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7015,7 +7015,7 @@ media file played</string>
                         <string notr="true">HHHHHHHH</string>
                        </property>
                        <property name="text">
-                        <string notr="true">FF000000</string>
+                        <string notr="true">AF000000</string>
                        </property>
                       </widget>
                      </item>


### PR DESCRIPTION
Use #AF000000 (~30% transparent black) instead of solid black as default subtitles shadow color like mpv >= 0.40.