### PR TITLE
Don't draw logo when launched with a file

### DIFF
--- a/src/ipc/json.cpp
+++ b/src/ipc/json.cpp
@@ -217,6 +217,8 @@ void MpcQtServer::ipc_playFiles(const QVariantMap &map)
     }
     if (!files.empty()) {
         playbackManager->openSeveralFiles(files, important);
+    } else {
+        playbackManager->drawLogo();
     }
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -178,6 +178,12 @@ bool PlaybackManager::eofReached()
     return eofReached_;
 }
 
+void PlaybackManager::drawLogo()
+{
+    if (playbackState_ == PlaybackManager::StoppedState)
+        mpvObject_->setDrawLogo(true);
+}
+
 PlaybackManager::PlaybackState PlaybackManager::playbackState()
 {
     return playbackState_;

--- a/src/manager.h
+++ b/src/manager.h
@@ -58,6 +58,7 @@ public:
     QUrl nowPlaying();
     PlaybackState playbackState();
     bool eofReached();
+    void drawLogo();
 
 signals:
     void timeChanged(double time, double length);

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -289,7 +289,7 @@ private:
     static constexpr char logModule[] = "glwidget";
     mpv_render_context *render = nullptr;
     LogoDrawer *logo = nullptr;
-    bool drawLogo = true;
+    bool drawLogo = false;
     int glWidth = 0;
     int glHeight = 0;
     bool windowDragging = false;


### PR DESCRIPTION
Only draw the logo when MPC-QT is started without a file to play immediately.

Avoids briefly showing the logo before playback begins when launching MPC-QT with a file.

Follow-up to 3eccf09b2e4ee621b733ec3653788314e555e99e ("Only draw logo when no video file is loaded or loading").