### PR TITLE
Hide video preview during seek bar click and drag

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3552,7 +3552,7 @@ void MainWindow::position_sliderMoved(int position)
     emit timeSelected(position);
 }
 
-void MainWindow::position_hoverValue(double position, QString chapterInfo, double mouseX)
+void MainWindow::position_hoverValue(double position, QString chapterInfo, double mouseX, bool isDragging)
 {
     setCursor(Qt::PointingHandCursor);
 
@@ -3565,7 +3565,7 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
     QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), timeTooltipAbove ? -1 : 65));
-    if (videoPreview && isVideo_)
+    if (videoPreview && isVideo_ && !isDragging)
         videoPreview->show(t, position, where, this->width());
     else if (tooltip) {
         QString textTemplate = QString("%1%2%3").arg(Helpers::toDateFormatFixed(

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -481,7 +481,7 @@ private slots:
 
     void mpvw_customContextMenuRequested(const QPoint &pos);
     void position_sliderMoved(int position);
-    void position_hoverValue(double value, QString text, double mouseX);
+    void position_hoverValue(double value, QString text, double mouseX, bool isDragging);
     void position_hoverEnd();
     void on_play_clicked();
     void volume_sliderMoved(double position);

--- a/src/widgets/drawnslider.cpp
+++ b/src/widgets/drawnslider.cpp
@@ -449,8 +449,8 @@ void MediaSlider::leaveEvent(QEvent *event)
 void MediaSlider::handleHover(double x)
 {
     double valueOfX = xToValue(x);
-
-    emit hoverValue(valueOfX, valueToTickText(valueOfX), x);
+    emit hoverEnd();
+    emit hoverValue(valueOfX, valueToTickText(valueOfX), x, isDragging);
 }
 
 void MediaSlider::mousePressEvent(QMouseEvent *ev)
@@ -463,6 +463,9 @@ void MediaSlider::mousePressEvent(QMouseEvent *ev)
         }
         emit middleClicked(it.key());
         return;
+    } else if (ev->button() == Qt::LeftButton) {
+        isDragging = true;
+        handleHover(ev->position().x());
     }
     DrawnSlider::mousePressEvent(ev);
 }

--- a/src/widgets/drawnslider.h
+++ b/src/widgets/drawnslider.h
@@ -50,6 +50,7 @@ protected:
     void mouseMoveEvent(QMouseEvent *ev) override;
 
     bool highContrast = false;
+    bool isDragging = false;
     bool redrawHandle = true;
     bool redrawBackground = true;
     QImage backgroundPic;
@@ -65,7 +66,6 @@ protected:
 
 private:
 
-    bool isDragging = false;
     double xPosition = 0.0;
 
     double vValue = 0.0;
@@ -88,7 +88,7 @@ public:
 signals:
     void hoverBegin();
     void hoverEnd();
-    void hoverValue(double position, QString chapterInfo, double x);
+    void hoverValue(double position, QString chapterInfo, double x, bool isDragging);
     void middleClicked(double chapterTime);
 
 protected:


### PR DESCRIPTION
In those cases, the user is more interested in what is shown in the player, so show a time tooltip (if enabled) instead.