### PR TITLE
mpvwidget: Fix clearing filters

### DIFF
--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -452,7 +452,7 @@ void MpvObject::setLogoBackground(const QColor &color)
 void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters)
 {
     if (clearFilters)
-        emit ctrlCommand("no-osd af clear");
+        emit ctrlCommand("no-osd af clr ''");
     if (!filtersList.empty())
         emit ctrlCommand("no-osd af set \"" + formatFiltersList(filtersList) + "\"");
 }
@@ -460,7 +460,7 @@ void MpvObject::setAudioFilters(const QList<QPair<QString, QString>> &filtersLis
 void MpvObject::setVideoFilters(const QList<QPair<QString, QString>> &filtersList, bool clearFilters)
 {
     if (clearFilters)
-        emit ctrlCommand("no-osd vf clear");
+        emit ctrlCommand("no-osd vf clr ''");
     if (!filtersList.empty())
         emit ctrlCommand("no-osd vf set \"" + formatFiltersList(filtersList) + "\"");
 }


### PR DESCRIPTION
Add missing argument for clr command.
Use standard clr command.

mpv requires two arguments for the af and vf commands (error: "Command
af: required argument value not set").

While "clear" works, "clr" is the documented command.

Makes 0d2cff05efe02836640461bf46360c6437ba9690 ("Only clear filters when needed") optional, but it doesn't hurt and it's faster.

Link: https://mpv.io/manual/master/#command-interface-af-%3Coperation%3E-%3Cvalue%3E

Fixes: 848f86dea7a24938cc9166486c1ec4022d5450fb ("mpvwidget: Clear audio/video filters before we set them")