### PR TITLE
Only convert local paths to UNC (Windows)

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -732,6 +732,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
         emit startedPlayingFile(what);
     mpvObject_->fileOpen(what.isLocalFile() ? what.toLocalFile()
                                             : QUrl::fromPercentEncoding(what.toEncoded()),
+                         what.isLocalFile(),
                          replaceMpvPlaylist,
                          !videoList.isEmpty() && !videoListData[1].isImage);
     if (!with.isEmpty())

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -336,9 +336,12 @@ int MpvObject::selectedStatsPage()
     return shownStatsPage;
 }
 
-static QString normalizeWindowsPath(QString filename)
+static QString normalizeWindowsPath(QString filename, bool isLocalFile)
 {
 #ifdef Q_OS_WINDOWS
+    if (!isLocalFile)
+        return filename;
+
     filename = QDir::toNativeSeparators(filename);
     if (filename.size() >= 260 && !filename.startsWith(u"\\\\?\\")) {
         if (filename.startsWith(u"\\\\"))
@@ -353,13 +356,13 @@ static QString normalizeWindowsPath(QString filename)
 void MpvObject::urlOpen(QUrl url)
 {
     fileOpen(url.isLocalFile() ? url.toLocalFile()
-                               : QUrl::fromPercentEncoding(url.toEncoded()));
+                               : QUrl::fromPercentEncoding(url.toEncoded()), url.isLocalFile());
 }
 
-void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist, bool previousWasVideo)
+void MpvObject::fileOpen(QString filename, bool isLocalFile, bool replaceMpvPlaylist, bool previousWasVideo)
 {
     clearSubFiles();
-    filename = normalizeWindowsPath(filename);
+    filename = normalizeWindowsPath(filename, isLocalFile);
     if (replaceMpvPlaylist || previousWasVideo) {
         setMpvPropertyVariant("vid", "no"); // clear last frame of previous video file
         emit ctrlCommand(QStringList({"loadfile", filename}));
@@ -374,9 +377,9 @@ void MpvObject::fileOpen(QString filename, bool replaceMpvPlaylist, bool previou
 void MpvObject::discFilesOpen(QString path) {
     QStringList entryList = QDir(path).entryList();
     if (entryList.contains("VIDEO_TS") || entryList.contains("AUDIO_TS")) {
-        fileOpen(path + "/VIDEO_TS/VIDEO_TS.IFO");
+        fileOpen(path + "/VIDEO_TS/VIDEO_TS.IFO", true);
     } else if (entryList.contains("BDMV") || entryList.contains("AACS")) {
-        fileOpen("bluray://" + path);
+        fileOpen("bluray://" + path, true);
     }
 }
 

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -55,7 +55,7 @@ public:
     int selectedStatsPage();
 
     void urlOpen(QUrl url);
-    void fileOpen(QString filename, bool replaceMpvPlaylist = true, bool previousWasVideo = false);
+    void fileOpen(QString filename, bool isLocalFile, bool replaceMpvPlaylist = true, bool previousWasVideo = false);
     void discFilesOpen(QString path);
     void stopPlayback();
     void stepBackward();


### PR DESCRIPTION
normalizeWindowsPath starts by converting the path to native separators (`\` instead of `/` on Windows), so loading a URL with yt-dlp then fails.

Fixes: 8d8ba9269eeaafe73bf785bb192aa9d6b56965c6 ("mpvwidget: Add Windows long path support")