### PR TITLE
mpvwidget: Prevent compiler warning

### DIFF
--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -336,7 +336,7 @@ int MpvObject::selectedStatsPage()
     return shownStatsPage;
 }
 
-static QString normalizeWindowsPath(QString filename, bool isLocalFile)
+static QString normalizeWindowsPath(QString filename, [[maybe_unused]] bool isLocalFile)
 {
 #ifdef Q_OS_WINDOWS
     if (!isLocalFile)


### PR DESCRIPTION
isLocalFile is only used on Windows.

Fixes: 8d8ba9269eeaafe73bf785bb192aa9d6b56965c6 ("mpvwidget: Add Windows long path support")