### PR TITLE
Fix building with Qt < 6.5

### DIFF
--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -1,6 +1,7 @@
 #include <QDockWidget>
 #include <QMainWindow>
 #include <QMetaMethod>
+#include <QGuiApplication>
 #include <QStyle>
 #include <QWidget>
 #include "helpers.h"

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -746,10 +746,14 @@ void SettingsWindow::sendSignals()
     emit highContrastWidgets(WIDGET_LOOKUP(ui->interfaceWidgetHighContast).toBool());
     bool useCustomColors = WIDGET_LOOKUP(ui->interfaceWidgetCustom).toBool();
     bool useDarkColors = WIDGET_LOOKUP(ui->interfaceWidgetDark).toBool();
+    // REMOVEME: Apply a dark palette manually because Qt doesn't propagate it
+    bool darkColorScheme = false;
+#if QT_VERSION >= QT_VERSION_CHECK(6,5,0)
+    darkColorScheme = QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+#endif
     if (useCustomColors)
         emit applicationPalette(paletteEditor->variantToPalette(WIDGET_LOOKUP(paletteEditor)));
-    // REMOVEME: Apply a dark palette manually because Qt doesn't propagate it
-    else if (useDarkColors || QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark)
+    else if (useDarkColors || darkColorScheme)
         emit applicationPalette(paletteEditor->darkPalette());
     else
         emit applicationPalette(paletteEditor->systemPalette());


### PR DESCRIPTION
QGuiApplication is somehow already included with Qt >= 6.5.

Qt::ColorScheme requires Qt 6.5.

Fixes: 93019590d473e0be87fbdbdfe4959e16b07f99d6 ("settingswindow: Use dark colors if a dark colors system theme is detected")

Fixes: 05f5f83d17967629b98342970f5514b3cf9169d5 ("windowmanager: Don't set geometry when exiting fullscreen in Wayland mode")

Fixes #1003 ("Xubuntu 24.04, Qt 6.4.2, mpc-qt 26.07: Failed to build").