### PR TITLE
ci: Add a build test with an older Qt version

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,15 +21,23 @@ jobs:
         cmake \
         libboost-all-dev \
         libgl-dev \
-        libmpv-dev
-    - name: Install newer Qt version
-      uses: jurplel/install-qt-action@v4
-      with:
-        cache: true
+        libmpv-dev \
+        linguist-qt6 \
+        qt6-tools-dev \
+        qt6-base-dev \
+        libqt6svg6-dev \
     - uses: actions/checkout@v6.0.2
       with:
         fetch-depth: 1000
         fetch-tags: true
+    - name: Test build with an older Qt version
+      run: |
+        cmake -G Ninja -B old_build
+        cmake --build old_build
+    - name: Install newer Qt version
+      uses: jurplel/install-qt-action@v4
+      with:
+        cache: true
     - name: Set version
       run: |
         echo "FORCE_VERSION=" >> $GITHUB_ENV


### PR DESCRIPTION
Since 92ef57b13d00dfcb5743c82eace8098079652c99 ("Use latest Qt LTS for the CI and the AppImage"), the CI uses a newer Qt version than the one available in the system repositories.

Partially reverts f4cf6c5ba282d4c49242621df787eb9c4949af88 ("ci: Don't install Qt packages with apt").

Reference: 91e30a965395798009414bcdeda299a975f15af3 ("Fix building with Qt < 6.5")