### PR TITLE
paletteeditor: Add missing color roles

### DIFF
--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -30,7 +30,9 @@ Q_GLOBAL_STATIC_WITH_ARGS(RoleLabels, roleText, ({
     { QPalette::AlternateBase, QObject::tr("Base (alternate)") },
     { QPalette::NoRole, QObject::tr("No role") },
     { QPalette::ToolTipBase, QObject::tr("Tooltip base") },
-    { QPalette::ToolTipText, QObject::tr("Tooltip text") }
+    { QPalette::ToolTipText, QObject::tr("Tooltip text") },
+    { QPalette::PlaceholderText, QObject::tr("Placeholder text") },
+    { QPalette::Accent, QObject::tr("Accent") }
 }));
 
 using GroupLabels = QList<QPair<QPalette::ColorGroup, QString>>;
@@ -181,7 +183,8 @@ QPalette PaletteEditor::darkPalette()
         { QColor("#ff1d1f22"), QColor("#ff1c1e20"), QColor("#ff1d1f22") }, // AlternateBase
         { QColor("#ff000000"), QColor("#ff000000"), QColor("#ff000000") }, // NoRole
         { QColor("#ff292c30"), QColor("#ff292c30"), QColor("#ff292c30") }, // ToolTipBase
-        { QColor("#fffcfcfc"), QColor("#fffcfcfc"), QColor("#fffcfcfc") }  // ToolTipText
+        { QColor("#fffcfcfc"), QColor("#fffcfcfc"), QColor("#fffcfcfc") }, // ToolTipText
+        { QColor("#ffa1a9b1"), QColor("#ff42464a"), QColor("#ffa1a9b1") } // PlaceholderText
     };
 
     const QVector<QPalette::ColorRole> roles {
@@ -204,7 +207,8 @@ QPalette PaletteEditor::darkPalette()
         QPalette::AlternateBase,
         QPalette::NoRole,
         QPalette::ToolTipBase,
-        QPalette::ToolTipText
+        QPalette::ToolTipText,
+        QPalette::PlaceholderText
     };
 
     const QVector<QPalette::ColorGroup> groups {

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2334,6 +2334,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2566,6 +2566,14 @@ No s&apos;activarà cap acció.</translation>
         <translation>Text dels missatges d&apos;ajuda</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Actiu</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2582,6 +2582,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Aktivní</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2598,6 +2598,14 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation>Tooltip Text</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Aktiv</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2608,6 +2608,14 @@ No action will be triggered.</source>
         <translation>Tooltip text</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Active</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2452,6 +2452,14 @@ No action will be triggered.</source>
         <translation>Texto de ayuda emergente</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Activo</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2422,6 +2422,14 @@ Mitään toimintoa ei suoriteta.</translation>
         <translation>Työkaluvihjeen teksti</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Aktiivinen</translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2542,6 +2542,14 @@ Aucune action ne sera déclenchée.</translation>
         <translation>Texte info-bulle</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Actif</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2518,6 +2518,14 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <translation>Teks tooltip</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Aktif</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2428,6 +2428,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2610,6 +2610,14 @@ No action will be triggered.</source>
         <translation>ツールチップ テキスト</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>アクティブ</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2551,6 +2551,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2331,6 +2331,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2338,6 +2338,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2574,6 +2574,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Aktywny</translation>
     </message>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -2608,6 +2608,14 @@ No action will be triggered.</source>
         <translation>Dica texto</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Ativo</translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2380,6 +2380,14 @@ No action will be triggered.</source>
         <translation>Dica texto</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Ativo</translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2544,6 +2544,14 @@ No action will be triggered.</source>
         <translation>Текст всплывающей подсказки</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Активный</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2590,6 +2590,14 @@ No action will be triggered.</source>
         <translation>உதவிக்குறிப்பு உரை</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>செயலில்</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2590,6 +2590,14 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Araç ipucu metni</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>Etkin</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2454,6 +2454,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -318,7 +318,7 @@ Do you want to use it for &quot;%3&quot; instead?</source>
     <name>Flow</name>
     <message>
         <source>Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>Start a new process without saving data.</source>
@@ -423,7 +423,7 @@ Do you want to use it for &quot;%3&quot; instead?</source>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Clear</translation>
     </message>
     <message>
         <source>Save File</source>
@@ -450,7 +450,7 @@ No action will be triggered.</source>
     <name>MainWindow</name>
     <message>
         <source>Media Player Classic Qute Theater</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>Play</source>
@@ -1210,7 +1210,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Close Tab</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Close Tab</translation>
     </message>
     <message>
         <source>Ctrl+Shift+W</source>
@@ -1981,11 +1981,11 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Left</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Right</translation>
     </message>
     <message>
         <source>Middle</source>
@@ -2154,7 +2154,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Button</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nút bấm</translation>
     </message>
     <message>
         <source>Button &amp;&amp; Window</source>
@@ -2307,7 +2307,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Xóa</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -2335,7 +2335,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Khôi phục</translation>
     </message>
     <message>
         <source>Shuffle</source>
@@ -2604,6 +2604,14 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Tooltip text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2940,7 +2948,7 @@ media file played</source>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tự động</translation>
     </message>
     <message>
         <source>Time step</source>
@@ -3012,7 +3020,7 @@ media file played</source>
     </message>
     <message>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Tổng quan</translation>
     </message>
     <message>
         <source>Framebuffer</source>
@@ -3124,7 +3132,7 @@ media file played</source>
     </message>
     <message>
         <source>No</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Không</translation>
     </message>
     <message>
         <source>Size</source>
@@ -3196,7 +3204,7 @@ media file played</source>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Cửa sổ</translation>
     </message>
     <message>
         <source>Box</source>
@@ -3672,7 +3680,7 @@ media file played</source>
     </message>
     <message>
         <source>Remove</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Xóa</translation>
     </message>
     <message>
         <source>Add to shaders</source>
@@ -3684,7 +3692,7 @@ media file played</source>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Lưu</translation>
     </message>
     <message>
         <source>Delete</source>
@@ -3949,7 +3957,7 @@ media file played</source>
     </message>
     <message>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Đúng</translation>
     </message>
     <message>
         <source>Yes and only zoom signs</source>
@@ -4733,7 +4741,7 @@ media file played</source>
     </message>
     <message>
         <source>Shadow</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Đổ bóng</translation>
     </message>
     <message>
         <source>Enable shadow</source>
@@ -4919,7 +4927,7 @@ media file played</source>
     <name>ThumbnailerWindow</name>
     <message>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Nguồn</translation>
     </message>
     <message>
         <source>&amp;Browse...</source>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2566,6 +2566,14 @@ No action will be triggered.</source>
         <translation>提示文本</translation>
     </message>
     <message>
+        <source>Placeholder text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Active</source>
         <translation>激活</translation>
     </message>


### PR DESCRIPTION
Add the `PlaceholderText` and `Accent` color roles and add a dark palette for `PlaceholderText`.

Fixes: 83267497fb25ff8e8e7f95515050305f06c8ffe6 ("Add "Use dark colors" option")

Fixes: 93019590d473e0be87fbdbdfe4959e16b07f99d6 ("settingswindow: Use dark colors if a dark colors system theme is detected") which depends on the above.

Fixes #1007 (""Search settings..." is not following dark mode color?").