### PR TITLE
thumbnailerwindow: Fix Windows local file path handling

### DIFF
--- a/src/thumbnailerwindow.cpp
+++ b/src/thumbnailerwindow.cpp
@@ -95,7 +95,7 @@ void ThumbnailerWindow::open(QUrl sourceUrl)
     QString saveFile = Helpers::parseFormatEx(thumbFormat, sourceUrl, screenshotDirectory, screenshotFormat,
                                               Helpers::NothingDisabled, Helpers::SubtitlesDisabled,
                                               0.0, 0.0, 0.0);
-    ui->mediaSource->setText(sourceUrl.path());
+    ui->mediaSource->setText(sourceUrl.toLocalFile());
     ui->saveImage->setText(saveFile);
     ui->actionProgress->setValue(0);
     show();
@@ -107,7 +107,7 @@ void ThumbnailerWindow::begin()
     setEnabled(false);
 
     MpvThumbnailer::Params p;
-    p.sourceUrl = ui->mediaSource->text();
+    p.sourceUrl = QUrl::fromLocalFile(ui->mediaSource->text());
     p.imageFile = ui->saveImage->text();
     p.jpegQuality = ui->imageQuality->value();
     p.imageWidth = ui->imageWidth->value();


### PR DESCRIPTION
Use QUrl::toLocalFile() when populating the media source field and QUrl::fromLocalFile() when reading it back.

Fixes: 3f90729f09f3141c582fcc8e34257ab56ed196dc ("Don't percent-encode filename or path for thumbnails")

Fixes #1013 ("Windows: thumbnailer not working").