### PR TITLE
settingswindow: Strip `--` from custom mpv options

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1261,13 +1261,10 @@ QList<MpvOption> SettingsWindow::parseMpvOptions(const QString &optionsInline) c
     const QStringList options = optionsInline.split(' ', Qt::SkipEmptyParts);
     for (const QString &option : options) {
         int equalPos = option.indexOf('=');
-        if (equalPos > 0) {
-            QString name = option.left(equalPos).trimmed();
-            QString value = option.mid(equalPos + 1).trimmed();
-            mpvOptions.append(MpvOption{name, value});
-        } else {
-            mpvOptions.append(MpvOption{option.trimmed(), QString()});
-        }
+        QString name = equalPos > 0 ? option.left(equalPos) : option;
+        QString value = equalPos > 0 ? option.mid(equalPos + 1) : QString();
+        name = name.startsWith("--") ? name.sliced(2) : name;
+        mpvOptions.append(MpvOption{name, value});
     }
     return mpvOptions;
 }


### PR DESCRIPTION
The mpv manual documents options as command-line arguments, so users may naturally prefix option names with `--` when entering custom options.

Strip the prefix during parsing so both `ytdl-raw-options=` and `--ytdl-raw-options=` are accepted.

Fixes: b0323fdd86585b6cdf0847a9d84b136868f25277 ("Add support for custom mpv options")

Fixes #1020 ("Codec preference isn't respected").