### PR TITLE
Don't retranslate UI when changing zoom or panels settings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1634,13 +1634,14 @@ void Flow::mpcHcServer_fileSelected(QString fileName)
     playbackManager->openSeveralFiles(urls, true);
 }
 
-void Flow::settingswindow_settingsData(const QVariantMap &settings)
+void Flow::settingswindow_settingsData(const QVariantMap &settings, bool updateTranslation)
 {
     Logger::log(logModule, "settingswindow_settingsData");
     // The selected options have changed, so write them to disk
     this->settings = settings;
     writeConfig(true);
-    setTranslation(true);
+    if (updateTranslation)
+        setTranslation(true);
 }
 
 void Flow::settingswindow_inhibitScreensaver(bool yes)

--- a/src/main.h
+++ b/src/main.h
@@ -94,7 +94,7 @@ private slots:
     void manager_startedPlayingFile(QUrl url);
     void manager_stoppedPlaying();
     void mpcHcServer_fileSelected(QString fileName);
-    void settingswindow_settingsData(const QVariantMap &settings);
+    void settingswindow_settingsData(const QVariantMap &settings, bool updateTranslation);
     void settingswindow_inhibitScreensaver(bool yes);
     void settingswindow_rememberHistory(bool yes, bool onlyVideos);
     void settingswindow_rememberFilePosition(bool yes);

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1128,7 +1128,7 @@ void SettingsWindow::sendSignals()
 
 void SettingsWindow::sendAcceptedSettings()
 {
-    emit settingsData(acceptedSettings.toVMap());
+    emit settingsData(acceptedSettings.toVMap(), true);
     emit keyMapData(acceptedKeyMap);
 }
 
@@ -1185,14 +1185,14 @@ void SettingsWindow::setZoomPreset(int which)
     ui->playbackAutoZoom->setChecked(autoZoom);
     ui->playbackAutoZoomMethod->setCurrentIndex(zoomMethod);
 
-    emit settingsData(acceptedSettings.toVMap());
+    emit settingsData(acceptedSettings.toVMap(), false);
 }
 
 void SettingsWindow::setHidePanels(bool hidden)
 {
     ui->fullscreenHidePanels->setChecked(hidden);
     WIDGET_LOOKUP(ui->fullscreenHidePanels).setValue(hidden);
-    emit settingsData(acceptedSettings.toVMap());
+    emit settingsData(acceptedSettings.toVMap(), false);
 }
 
 void SettingsWindow::setAudioFilter(QString filter, QString options, bool add)

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -81,7 +81,7 @@ private:
     int pageIndexForTreeItem(const QModelIndex &index) const;
 
 signals:
-    void settingsData(const QVariantMap &s);
+    void settingsData(const QVariantMap &s, bool updateTranslation);
     void keyMapData(const QVariantMap &s);
     void mouseWindowedMap(const MouseStateMap &map);
     void mouseFullscreenMap(const MouseStateMap &map);


### PR DESCRIPTION
Retranslating the UI resets dynamic strings (like the window title).

Applying settings from the settings window updates the window title through MainWindow::setTitleBarFormat, so it's not permanently affected by the UI retranslation.

Fixes: 11f9a573fb1237cd4c3bb5111a081707d77db19d ("Apply language change immediately")

Fixes #1018 ("Filename disappears from title bar when you hotkey zoom the window").