### PR TITLE
Fix "Exit fullscreen at end of playback"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -953,8 +953,8 @@ void Flow::setupFlowConnections()
             this, &Flow::manager_aboutToStartPlayingFile);
     connect(playbackManager, &PlaybackManager::startedPlayingFile,
             this, &Flow::manager_startedPlayingFile);
-    connect(playbackManager, &PlaybackManager::stoppedPlaying,
-            this, &Flow::manager_stoppedPlaying);
+    connect(playbackManager, &PlaybackManager::stoppedPlayingAtEof,
+            this, &Flow::manager_stoppedPlayingAtEof);
     connect(playbackManager, &PlaybackManager::stateChanged,
             this, &Flow::manager_stateChanged);
     connect(playbackManager, &PlaybackManager::fileClosed,
@@ -1622,7 +1622,7 @@ void Flow::manager_startedPlayingFile(QUrl url)
     }
     playbackManager->navigateToTime(position);
 }
-void Flow::manager_stoppedPlaying()
+void Flow::manager_stoppedPlayingAtEof()
 {
     // Reset the position on stop
     updateRecentPosition(true);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -620,6 +620,8 @@ void Flow::setupMainWindowConnections()
             mainWindow, &MainWindow::setMediaTitle);
     connect(playbackManager, &PlaybackManager::videoSizeChanged,
             mainWindow, &MainWindow::setVideoSize);
+    connect(playbackManager, &PlaybackManager::noMoreFilesToPlay,
+            mainWindow, &MainWindow::checkExitFullscreenOnEnd);
     connect(playbackManager, &PlaybackManager::stateChanged,
             mainWindow, &MainWindow::setPlaybackState);
     connect(playbackManager, &PlaybackManager::typeChanged,

--- a/src/main.h
+++ b/src/main.h
@@ -92,7 +92,7 @@ private slots:
     void manager_openingNewFile();
     void manager_aboutToStartPlayingFile();
     void manager_startedPlayingFile(QUrl url);
-    void manager_stoppedPlaying();
+    void manager_stoppedPlayingAtEof();
     void mpcHcServer_fileSelected(QString fileName);
     void settingswindow_settingsData(const QVariantMap &settings, bool updateTranslation);
     void settingswindow_inhibitScreensaver(bool yes);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2148,13 +2148,17 @@ void MainWindow::setFullscreenHidePanels(bool hidden)
     }
 }
 
+void MainWindow::checkExitFullscreenOnEnd()
+{
+    if (fullscreenExitOnEnd && fullscreenMode_)
+        ui->actionViewFullscreen->setChecked(false);
+}
+
 void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState)
 {
     // Update the fullscreen state
     if (state == PlaybackManager::StoppedState) {
-        if (fullscreenExitOnEnd && fullscreenMode_ == true) {
-            ui->actionViewFullscreen->setChecked(false);
-        }
+        checkExitFullscreenOnEnd();
     } else if (state == PlaybackManager::PlayingState) {
         if (fullscreenOnPlay && fullscreenMode_ == false) {
             ui->actionViewFullscreen->setChecked(true);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -279,6 +279,7 @@ public slots:
     void setTimeTooltip(bool show, bool above);
     void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
+    void checkExitFullscreenOnEnd();
     void setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState);
     void setPlaybackType(PlaybackManager::PlaybackType type);
     void disableChaptersMenus();

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1101,7 +1101,7 @@ void PlaybackManager::mpvw_eofReachedChanged(QString eof) {
     }
     eofReached_ = true;
 
-    emit stoppedPlaying();
+    emit stoppedPlayingAtEof();
 
     int extraTimes = playlistWindow_->extraPlayTimes(nowPlayingList, nowPlayingItem);
     playlistWindow_->setExtraPlayTimes(nowPlayingList, nowPlayingItem, extraTimes - 1);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -933,6 +933,7 @@ bool PlaybackManager::playNextTrack(bool replaceMpvPlaylist)
                           false, QUrl(), false, replaceMpvPlaylist);
         return true;
     }
+    emit noMoreFilesToPlay();
     return false;
 }
 
@@ -992,7 +993,10 @@ bool PlaybackManager::playNextFileUrl(QUrl url, int delta, bool replaceMpvPlayli
 bool PlaybackManager::playNextFile(bool replaceMpvPlaylist, int delta)
 {
     QUrl url = playlistWindow_->getUrlOfFirst(nowPlayingList);
-    return playNextFileUrl(url, delta, replaceMpvPlaylist);
+    bool success = playNextFileUrl(url, delta, replaceMpvPlaylist);
+    if (!success && delta == 1)
+        emit noMoreFilesToPlay();
+    return success;
 }
 
 void PlaybackManager::playPrevFile()

--- a/src/manager.h
+++ b/src/manager.h
@@ -96,7 +96,7 @@ signals:
     void aboutToStartPlayingFile(QUrl url);
     void startedPlayingFile(QUrl url);
     void removePlaylistItemRequested(QUuid itemUuid);
-    void stoppedPlaying();
+    void stoppedPlayingAtEof();
     void noMoreFilesToPlay();
     void videoFilter(QString filter, QString options, bool add);
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -97,6 +97,7 @@ signals:
     void startedPlayingFile(QUrl url);
     void removePlaylistItemRequested(QUuid itemUuid);
     void stoppedPlaying();
+    void noMoreFilesToPlay();
     void videoFilter(QString filter, QString options, bool add);
 
     void fpsChanged(double fps);


### PR DESCRIPTION
* Fix "Exit fullscreen at end of playback"

> Notify the main window when there is no more files to play.
> 
> Since 418f8085bf6e80f28c3589e29518cd4965fb67fd the player is paused instead of stopped at the end of playback, so checking that state isn't enough.
> 
> Fixes: 418f8085bf6e80f28c3589e29518cd4965fb67fd ("Recents and eof fixes for play next/previous in folder")
> 
> Fixes #1029 ("Issue with Full Screen Mode when playing a Playlist").

* Rename `stoppedPlaying` signal to `stoppedPlayingAtEof`

> It is sent at end-of-file (EOF).