### PR TITLE
manager: Show track name if available

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -42,6 +42,11 @@ TrackData TrackData::fromMap(const QVariantMap &map)
         td.lang = map["lang"].toString();
     if (map.contains("title"))
         td.title = map["title"].toString();
+    else if (map.contains("metadata")) {
+        QVariantMap metadata = map["metadata"].toMap();
+        if (metadata.contains("name"))
+            td.title = metadata["name"].toString();
+    }
     if (map.contains("forced"))
         td.isForced = map["forced"].toBool();
     if (map.contains("external"))


### PR DESCRIPTION
For some files, mpv outputs the tracks titles in the "name" part of the metadata.

Fixes #1037 ("[Feature Request] Allow MPC-QT to be able to read the Audiotrack title from the "tkhd" header atom value").