### PR TITLE
Display "Error" state in status bar on mpv playback error

### DIFF
--- a/src/ipc/http.cpp
+++ b/src/ipc/http.cpp
@@ -660,6 +660,10 @@ void MpcHcServer::setupHttp()
         QString state;
         QString stateString;
         switch(playbackState) {
+        case PlaybackManager::ErrorState:
+            state = QString::number(-2);
+            stateString = "Error";
+            break;
         case PlaybackManager::StoppedState:
             state = QString::number(-1);
             stateString = "N/A";

--- a/src/ipc/mpris.cpp
+++ b/src/ipc/mpris.cpp
@@ -219,7 +219,8 @@ QString MprisPlayerServer::playbackStatus()
 {
     if (playbackState == PlaybackManager::PausedState)
         return "Paused";
-    if (playbackState != PlaybackManager::StoppedState)
+    if (playbackState != PlaybackManager::StoppedState &&
+        playbackState != PlaybackManager::ErrorState)
         return "Playing";
     return "Stopped";
 }
@@ -424,7 +425,8 @@ void MprisPlayerServer::instance_setPlaylistHasItems(bool playlistHasItems)
 
 bool MprisPlayerServer::maybeChangeCanPlay()
 {
-    bool canPlay = playlistHasItems_ || playbackState != PlaybackManager::StoppedState;
+    bool canPlay = playlistHasItems_ || (playbackState != PlaybackManager::StoppedState &&
+                                         playbackState != PlaybackManager::ErrorState);
     if (canPlay_ != canPlay) {
         canPlay_ = canPlay;
         return true;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2185,8 +2185,12 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t 
     case PlaybackManager::WaitingState:
         ui->status->setText(tr("Unknown"));
         break;
+    case PlaybackManager::ErrorState:
+        ui->status->setText(tr("Error"));
+        break;
     }
-    isPlaying = state != PlaybackManager::StoppedState;
+    isPlaying = state != PlaybackManager::StoppedState &&
+                state != PlaybackManager::ErrorState;
     isPaused = state == PlaybackManager::PausedState;
     setUiEnabledState(state != PlaybackManager::StoppedState);
     if (isPaused) {

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -124,8 +124,8 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_pausedChanged);
         connect(mpvObject, &MpvObject::playbackIdling,
                 this, &PlaybackManager::mpvw_playbackIdling);
-        connect(mpvObject, &MpvObject::playbackFinished,
-                this, &PlaybackManager::mpvw_playbackFinished);
+        connect(mpvObject, &MpvObject::playbackError,
+                this, &PlaybackManager::mpvw_playbackError);
         connect(mpvObject, &MpvObject::eofReachedChanged,
                 this, &PlaybackManager::mpvw_eofReachedChanged);
         connect(mpvObject, &MpvObject::mediaTitleChanged,
@@ -185,7 +185,8 @@ bool PlaybackManager::eofReached()
 
 void PlaybackManager::drawLogo()
 {
-    if (playbackState_ == PlaybackManager::StoppedState)
+    if (playbackState_ == PlaybackManager::StoppedState ||
+        playbackState_ == PlaybackManager::ErrorState)
         mpvObject_->setDrawLogo(true);
 }
 
@@ -208,7 +209,8 @@ void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
                          && (important || nowPlayingItem == QUuid()))
                         || !playlistWindow_->isVisible()
                         || (appendToQuickPlaylist && (playbackState_ == StoppedState
-                                                  || playbackState_ == WaitingState));
+                                                  || playbackState_ == WaitingState
+                                                  || playbackState_ == ErrorState));
     PlaylistItem playlistItem = playlistWindow_->addToCurrentPlaylist(what);
     if (playAfterAdd && !playlistItem.item.isNull()) {
         QUrl urlToPlay = playlistWindow_->getUrlOf(playlistItem.list, playlistItem.item);
@@ -273,7 +275,8 @@ void PlaybackManager::loadSubtitle(QUrl with)
 void PlaybackManager::playPlayer()
 {
     unpausePlayer();
-    if (playbackState_ == StoppedState) {
+    if (playbackState_ == StoppedState ||
+        playbackState_ == ErrorState) {
         startPlayer();
     }
 }
@@ -441,7 +444,9 @@ void PlaybackManager::navigateToChapter(int64_t chapter)
 
 void PlaybackManager::navigateToTime(double time)
 {
-    if (playbackState_ == WaitingState || playbackState_ == StoppedState)
+    if (playbackState_ == WaitingState ||
+        playbackState_ == StoppedState ||
+        playbackState_ == ErrorState)
         mpvObject_->setStartTime(time);
     else
         mpvObject_->setTime(time);
@@ -1085,12 +1090,11 @@ void PlaybackManager::mpvw_playbackIdling(bool yes)
     }
 }
 
-void PlaybackManager::mpvw_playbackFinished() {
-    if (playbackState_ == LoadingState) {
-        playbackState_ = StoppedState;
-        emit stateChanged(playbackState_);
-        mpvw_eofReachedChanged(strTrue);
-    }
+void PlaybackManager::mpvw_playbackError()
+{
+    playbackState_ = ErrorState;
+    emit stateChanged(playbackState_);
+    checkAfterPlayback();
 }
 
 void PlaybackManager::mpvw_eofReachedChanged(QString eof) {

--- a/src/manager.h
+++ b/src/manager.h
@@ -47,8 +47,15 @@ class PlaybackManager : public QObject
 {
     Q_OBJECT
 public:
-    enum PlaybackState { StoppedState, PausedState, PlayingState,
-                         LoadingState, BufferingState, WaitingState };
+    enum PlaybackState {
+        StoppedState,
+        PausedState,
+        PlayingState,
+        LoadingState,
+        BufferingState,
+        WaitingState,
+        ErrorState
+    };
     enum PlaybackType { None, File, Disc, Stream, Device };
     enum class Deinterlace { Yes, Auto, No };
 
@@ -216,7 +223,7 @@ private slots:
     void mpvw_playbackStarted();
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling(bool yes);
-    void mpvw_playbackFinished();
+    void mpvw_playbackError();
     void mpvw_eofReachedChanged(QString eof);
     void mpvw_mediaTitleChanged(QString title);
     void mpvw_chaptersChanged(QVariantList chapters);

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -109,6 +109,8 @@ MpvObject::MpvObject(QObject *owner, const QString &clientName) : QObject(owner)
             this, &MpvObject::ctrl_hookEvent, Qt::QueuedConnection);
     connect(ctrl, &MpvController::unhandledMpvEvent,
             this, &MpvObject::ctrl_unhandledMpvEvent, Qt::QueuedConnection);
+    connect(ctrl, &MpvController::playbackError,
+            this, &MpvObject::ctrl_playbackError, Qt::QueuedConnection);
     connect(ctrl, &MpvController::videoSizeChanged,
             this, &MpvObject::ctrl_videoSizeChanged, Qt::QueuedConnection);
 
@@ -830,6 +832,13 @@ void MpvObject::ctrl_hookEvent(QString name, uint64_t selfId, uint64_t mpvId)
         emit playlistChanged(playlist);
     }
     emit ctrlContinueHook(mpvId);
+}
+
+void MpvObject::ctrl_playbackError(int mpvError)
+{
+    Q_UNUSED(mpvError)
+    Logger::log(logModule, QString("playback error, reason: %1").arg(mpv_error_string(mpvError)));
+    emit playbackError();
 }
 
 void MpvObject::ctrl_unhandledMpvEvent(int eventLevel)
@@ -1606,6 +1615,13 @@ void MpvController::handleMpvEvent(mpv_event *event)
         emit hookEvent(msg->name, event->reply_userdata, msg->id);
         break;
     }
+    case MPV_EVENT_END_FILE: {
+        auto const *endFile = static_cast<mpv_event_end_file *>(event->data);
+        if (endFile->reason == MPV_END_FILE_REASON_ERROR)
+            emit playbackError(endFile->error);
+        break;
+    }
+
     default:
         emit unhandledMpvEvent(event->event_id);
     }

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -129,6 +129,7 @@ signals:
 
     void playTimeChanged(double time);
     void playLengthChanged(double length);
+    void playbackError();
     void playbackLoading();
     void playbackStarted();
     void pausedChanged(bool yes);
@@ -182,6 +183,7 @@ private:
 private slots:
     void ctrl_mpvPropertyChanged(QString name, const QVariant &v);
     void ctrl_hookEvent(QString name, uint64_t selfId, uint64_t mpvId);
+    void ctrl_playbackError(int mpvError);
     void ctrl_unhandledMpvEvent(int eventLevel);
     void ctrl_videoSizeChanged(QSize size);
     void self_playTimeChanged(double playTime);
@@ -373,6 +375,7 @@ signals:
     void clientMessage(uint64_t id, QStringList args);
     void videoSizeChanged(QSize size);
     void hookEvent(QString hookName, uint64_t selfId, uint64_t mpvId);
+    void playbackError(int mpvError);
     void unhandledMpvEvent(int eventNumber);
 
 public slots:

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1341,6 +1341,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1467,6 +1467,10 @@ No s&apos;activarà cap acció.</translation>
         <translation>Memòria intermèdia (%1%)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Addició &amp;ràpida a llista de reproducció</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -1485,6 +1485,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Chyba</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1491,6 +1491,10 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation>Puffern (%1%)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Fehler</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Schnelles &amp;Hinzufügen zur Wiedergabeliste</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Quick Add To Playlist</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1433,6 +1433,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Adición rápida a la lista de reproducción</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1379,6 +1379,10 @@ Mitään toimintoa ei suoriteta.</translation>
         <translation>Puskuroidaan (%1%)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Lisää Nopeasti Soittolistaan</translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1443,6 +1443,10 @@ Aucune action ne sera déclenchée.</translation>
         <translation>Mise en mémoire tampon (%1 %)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Erreur</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Ajout &amp;rapide à la playlist</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1475,6 +1475,10 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <translation>Membuffer (%1%)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Kesalahan</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Tambah Cepat ke Daftar Putar</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1429,6 +1429,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Errori</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>Aggiungi &amp;rapidamente alla scaletta</translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1491,6 +1491,10 @@ No action will be triggered.</source>
         <translation>バッファリング (%1%)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">エラー</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>再生リストへクイック追加(&amp;Q)</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -1470,6 +1470,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1345,6 +1345,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1345,6 +1345,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -1465,6 +1465,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Błąd</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1365,6 +1365,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1465,6 +1465,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Ошибка</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Добавить в список воспроизведения</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1483,6 +1483,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">பிழை</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp; பிளேலிச்ட்டில் விரைவாக சேர்க்கவும்</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1483,6 +1483,10 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Arabelleğe alınıyor (%%1)</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">Hata</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>&amp;Tez Oynatma Listesine Ekle</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -1453,6 +1453,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1491,6 +1491,10 @@ No action will be triggered.</source>
         <translation>正在缓冲（%1%）</translation>
     </message>
     <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
         <source>&amp;Quick Add To Playlist</source>
         <translation>快速添加到播放列表(&amp;Q)</translation>
     </message>


### PR DESCRIPTION
Instead of the "Stopped" state, to better inform the user.

Checking for MPV_END_FILE_REASON_EOF in addition to MPV_END_FILE_REASON_ERROR would also trigger the error state on network disconnection instead of current paused state, which would skip the current item and try to play the next one. But both mpv and and MPC-HC pause on network disconnection happening in the *middle* of playback.

Replaces faking the eos state, with the advantage of not trying to repeat failing items (through PlaybackManager::mpvw_eofReachedChanged).

Reverts 509927bc3a8f41f507e2277346fa0e849096fd0f ("manager: fix early finish") which isn't needed anymore. Verified with the same link: MPC-QT skips the item if playback can't start.