### PR TITLE
settingswindow: Add a setting to increase the maximum volume

### DIFF
--- a/.github/actions/data/settings.json
+++ b/.github/actions/data/settings.json
@@ -418,7 +418,7 @@
     "tweaksTimeTooltip": false,
     "tweaksTimeTooltipLocation": 0,
     "tweaksVideoPreview": false,
-    "tweaksVolumeLimit": true,
+    "tweaksMaxVolume": false,
     "videoAlphaMode": 0,
     "videoDumbMode": false,
     "videoFramebuffer": 0,

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -777,7 +777,7 @@ void SettingsWindow::sendSignals()
     emit webserverRoot(WIDGET_PLACEHOLD_LOOKUP(ui->webRoot));
     emit webserverDefaultPage(WIDGET_PLACEHOLD_LOOKUP(ui->webDefaultPage));
 
-    int volmax = WIDGET_LOOKUP(ui->tweaksVolumeLimit).toBool() ? 100 : 130;
+    int volmax = WIDGET_LOOKUP(ui->tweaksMaxVolume).toBool() ? WIDGET_LOOKUP(ui->tweaksMaxVolumeValue).toInt() : 100;
     emit volumeMax(volmax);
     emit volumeStep(WIDGET_LOOKUP(ui->playbackVolumeStep).toInt());
     {
@@ -1743,6 +1743,11 @@ void SettingsWindow::on_screenshotDirectoryBrowse_clicked()
         return;
 
     ui->screenshotDirectoryValue->setText(dir);
+}
+
+void SettingsWindow::on_tweaksMaxVolume_toggled(bool checked)
+{
+    ui->tweaksMaxVolumeValue->setEnabled(checked);
 }
 
 // REMOVEME: Disable auto zoom in Wayland mode as window centering isn't possible yet

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -328,6 +328,8 @@ private slots:
 
     void on_screenshotDirectoryBrowse_clicked();
 
+    void on_tweaksMaxVolume_toggled(bool checked);
+
     void on_tweaksPreferWayland_toggled(bool checked);
 
     void on_tweaksTimeTooltip_toggled(bool checked);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7905,17 +7905,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="5" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksVolumeLimit">
-             <property name="text">
-              <string>Limit volume to 100% like mpc-hc</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="6" column="0" colspan="2">
+           <item row="9" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksPreferWayland">
              <property name="enabled">
               <bool>false</bool>
@@ -7928,21 +7918,21 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="7" column="0" colspan="2">
+           <item row="10" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvMouseEvents">
              <property name="text">
               <string>Send mouse events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="8" column="0" colspan="2">
+           <item row="11" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvKeyEvents">
              <property name="text">
               <string>Send key events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
+           <item row="12" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksVideoPreview">
              <property name="text">
               <string>Show video preview (restart required)</string>
@@ -7952,7 +7942,7 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="13" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="0,0">
              <item>
               <widget class="QCheckBox" name="tweaksTimeTooltip">
@@ -7989,14 +7979,14 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="11" column="0" colspan="2">
+           <item row="14" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksOsdTimerOnSeek">
              <property name="text">
               <string>Show OSD timer on seek</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
+           <item row="15" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksOsdFontLayout" stretch="0,1,0">
              <item>
               <widget class="QCheckBox" name="tweaksOsdFontChkBox">
@@ -8051,7 +8041,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="13" column="0" colspan="2">
+           <item row="16" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksMpvOptionsLayout" stretch="0,1">
              <item>
               <widget class="QCheckBox" name="tweaksMpvOptionsChkBox">
@@ -8084,7 +8074,7 @@ media file played</string>
              </item>
             </layout>
            </item>
-           <item row="14" column="0">
+           <item row="17" column="0">
             <spacer name="verticalSpacer_9">
              <property name="orientation">
               <enum>Qt::Orientation::Vertical</enum>
@@ -8096,6 +8086,45 @@ media file played</string>
               </size>
              </property>
             </spacer>
+           </item>
+           <item row="7" column="0">
+            <layout class="QHBoxLayout" name="tweaksMaxVolumeLayout">
+             <item>
+              <widget class="QCheckBox" name="tweaksMaxVolume">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string>Increase maximum volume to:</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="tweaksMaxVolumeValue">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="suffix">
+                <string>%</string>
+               </property>
+               <property name="minimum">
+                <number>110</number>
+               </property>
+               <property name="maximum">
+                <number>2000</number>
+               </property>
+               <property name="singleStep">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>130</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -3931,10 +3931,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4464,6 +4460,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4306,7 +4306,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Limitar el volum al 100% igual que mpc-hc</translation>
+        <translation type="vanished">Limitar el volum al 100% igual que mpc-hc</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4855,6 +4855,10 @@ arxiu multimèdia reproduït</translation>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>Torna al primer/últim fitxer de la carpeta si cal</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4315,10 +4315,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
         <translation type="vanished">Shorten the playback time indicator like mpc-hc</translation>
     </message>
@@ -4868,6 +4864,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4322,7 +4322,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Lautstärke auf 100% begrenzen (wie mpc-hc)</translation>
+        <translation type="vanished">Lautstärke auf 100% begrenzen (wie mpc-hc)</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4859,6 +4859,10 @@ media file played</source>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>Springe zurück zur ersten/letzten Datei im Verzeichnis, wenn nötig</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4348,7 +4348,7 @@ media file played</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Limit volume to 100% like mpc-hc</translation>
+        <translation type="vanished">Limit volume to 100% like mpc-hc</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4900,6 +4900,10 @@ media file played</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4155,10 +4155,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4684,6 +4680,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -3961,10 +3961,6 @@ toistetulle mediatiedostolle</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4490,6 +4486,10 @@ toistetulle mediatiedostolle</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4282,7 +4282,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Limiter le volume à 100 % comme mpc-hc</translation>
+        <translation type="vanished">Limiter le volume à 100 % comme mpc-hc</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4847,6 +4847,10 @@ fichier média lu</translation>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>Retourner au premier/dernier fichier du dossier si nécessaire</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4130,7 +4130,7 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Batasi volume hingga 100% seperti mpc-hc</translation>
+        <translation type="vanished">Batasi volume hingga 100% seperti mpc-hc</translation>
     </message>
     <message>
         <source>HDR Compute Peak</source>
@@ -4663,6 +4663,10 @@ file media yang diputar</translation>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>Ulangi ke file pertama/terakhir di folder jika perlu</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4071,10 +4071,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,6 +4596,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4350,7 +4350,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>MPC-HC のように音量を 100% に制限する</translation>
+        <translation type="vanished">MPC-HC のように音量を 100% に制限する</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4915,6 +4915,10 @@ media file played</source>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>必要に応じて、フォルダー内の最初または最後のファイルに戻る</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4284,10 +4284,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
         <translation type="vanished">Shorten the playback time indicator like mpc-hc</translation>
     </message>
@@ -4837,6 +4833,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -3896,10 +3896,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4421,6 +4417,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -3911,10 +3911,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4448,6 +4444,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4216,7 +4216,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Ogranicz głośność do 100% jak w mpc-hc</translation>
+        <translation type="vanished">Ogranicz głośność do 100% jak w mpc-hc</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4768,6 +4768,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -4347,10 +4347,6 @@ ficheiro de média reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
         <translation type="vanished">Shorten the playback time indicator like mpc-hc</translation>
     </message>
@@ -4900,6 +4896,10 @@ ficheiro de média reproduzido</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -3983,10 +3983,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4520,6 +4516,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4276,7 +4276,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>Ограничить громкость до 100%</translation>
+        <translation type="vanished">Ограничить громкость до 100%</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4832,6 +4832,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4330,7 +4330,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>MPC-HC போன்ற அளவை 100% ஆக கட்டுப்படுத்தவும்</translation>
+        <translation type="vanished">MPC-HC போன்ற அளவை 100% ஆக கட்டுப்படுத்தவும்</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4886,6 +4886,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4318,7 +4318,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>mpc-hc gibi ses düzeyini %100 olarak sınırla</translation>
+        <translation type="vanished">mpc-hc gibi ses düzeyini %100 olarak sınırla</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4878,6 +4878,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4059,10 +4059,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>HDR Compute Peak</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4592,6 +4588,10 @@ media file played</source>
     </message>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -4346,10 +4346,6 @@ tệp phương tiện đã được phát</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Limit volume to 100% like mpc-hc</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
         <translation type="vanished">Shorten the playback time indicator like mpc-hc</translation>
     </message>
@@ -4900,6 +4896,10 @@ tệp phương tiện đã được phát</translation>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>Nếu cần, hãy quay lại tệp đầu tiên/cuối cùng trong thư mục</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4242,7 +4242,7 @@ media file played</source>
     </message>
     <message>
         <source>Limit volume to 100% like mpc-hc</source>
-        <translation>将音量限制为100%，如 MPC-HC</translation>
+        <translation type="vanished">将音量限制为100%，如 MPC-HC</translation>
     </message>
     <message>
         <source>Shorten the playback time indicator like mpc-hc</source>
@@ -4791,6 +4791,10 @@ media file played</source>
     <message>
         <source>Loop back to first/last file in folder if needed</source>
         <translation>如果需要，循环返回到文件夹中的第一个/最后一个文件</translation>
+    </message>
+    <message>
+        <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Replaces the "Limit volume to 100% like mpc-hc" setting (instead of mpv default 130%) and allows increasing the maximum volume up to 2000%.