### PR TITLE
Add a setting to change video preview size

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2088,7 +2088,7 @@ void MainWindow::setBottomAreaHideTime(int milliseconds)
     hideTimer.setInterval(milliseconds);
 }
 
-void MainWindow::setVideoPreview(bool enable)
+void MainWindow::setVideoPreview(bool enable, int heightPercent)
 {
     if (!videoPreview && enable) {
         videoPreview = new VideoPreview(this);
@@ -2098,6 +2098,7 @@ void MainWindow::setVideoPreview(bool enable)
         videoPreview->deleteLater();
         videoPreview = nullptr;
     }
+    previewHeightPercent = heightPercent;
 }
 
 void MainWindow::setTimeTooltip(bool shown, bool above)
@@ -3573,8 +3574,13 @@ void MainWindow::position_hoverValue(double position, QString chapterInfo, doubl
                                       chapterInfo.isEmpty() ? "" : " - ",
                                       chapterInfo);
     QPoint where = positionSlider_->mapTo(this, QPoint(std::round(mouseX), timeTooltipAbove ? -1 : 65));
-    if (videoPreview && isVideo_ && !isDragging)
-        videoPreview->show(t, position, where, this->width());
+    if (videoPreview && isVideo_ && !isDragging) {
+        auto screen = this->screen();
+        if (!screen)
+            return;
+        int previewHeight = screen->geometry().height() * previewHeightPercent / 100;
+        videoPreview->show(t, position, where, this->width(), previewHeight);
+    }
     else if (tooltip) {
         QString textTemplate = QString("%1%2%3").arg(Helpers::toDateFormatFixed(
                                                         0,

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -275,7 +275,7 @@ public slots:
     void setMouseHideTimeWindowed(int msec);
     void setBottomAreaBehavior(Helpers::ControlHiding method);
     void setBottomAreaHideTime(int milliseconds);
-    void setVideoPreview(bool enable);
+    void setVideoPreview(bool enable, int heightPercent);
     void setTimeTooltip(bool show, bool above);
     void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
@@ -575,6 +575,7 @@ private:
     int currentAngle = 0;
     QUrl currentFile;
     QString currentFileTitle;
+    int previewHeightPercent = 0;
 
     IconThemer themer;
     QList<QAction *> menuFavoritesTail;

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1112,7 +1112,7 @@ void SettingsWindow::sendSignals()
     emit loopFolder(WIDGET_LOOKUP(ui->tweaksLoopFolder).toBool());
     emit mpvMouseEvents(WIDGET_LOOKUP(ui->tweaksMpvMouseEvents).toBool());
     emit mpvKeyEvents(WIDGET_LOOKUP(ui->tweaksMpvKeyEvents).toBool());
-    emit videoPreview(WIDGET_LOOKUP(ui->tweaksVideoPreview).toBool());
+    emit videoPreview(WIDGET_LOOKUP(ui->tweaksVideoPreview).toBool(), WIDGET_LOOKUP(ui->tweaksVideoPreviewHeight).toInt());
     emit timeTooltip(WIDGET_LOOKUP(ui->tweaksTimeTooltip).toBool(),
                      WIDGET_LOOKUP(ui->tweaksTimeTooltipLocation).toInt() == 0);
     emit osdTimerOnSeek(WIDGET_LOOKUP(ui->tweaksOsdTimerOnSeek).toBool());

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -185,7 +185,7 @@ signals:
     void volumeMax(int maximum);
     void mpvMouseEvents(bool yes);
     void mpvKeyEvents(bool yes);
-    void videoPreview(bool enable);
+    void videoPreview(bool enable, int heightPercent);
     void timeTooltip(bool yes, bool above);
     void osdTimerOnSeek(bool yes);
 

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -7905,7 +7905,46 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="9" column="0" colspan="2">
+           <item row="7" column="0">
+            <layout class="QHBoxLayout" name="tweaksMaxVolumeLayout">
+             <item>
+              <widget class="QCheckBox" name="tweaksMaxVolume">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="text">
+                <string>Increase maximum volume to:</string>
+               </property>
+               <property name="checked">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="tweaksMaxVolumeValue">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="suffix">
+                <string>%</string>
+               </property>
+               <property name="minimum">
+                <number>110</number>
+               </property>
+               <property name="maximum">
+                <number>2000</number>
+               </property>
+               <property name="singleStep">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>130</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="8" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksPreferWayland">
              <property name="enabled">
               <bool>false</bool>
@@ -7918,29 +7957,46 @@ media file played</string>
              </property>
             </widget>
            </item>
-           <item row="10" column="0" colspan="2">
+           <item row="9" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvMouseEvents">
              <property name="text">
               <string>Send mouse events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="11" column="0" colspan="2">
+           <item row="10" column="0" colspan="2">
             <widget class="QCheckBox" name="tweaksMpvKeyEvents">
              <property name="text">
               <string>Send key events to mpv</string>
              </property>
             </widget>
            </item>
-           <item row="12" column="0" colspan="2">
-            <widget class="QCheckBox" name="tweaksVideoPreview">
-             <property name="text">
-              <string>Show video preview (restart required)</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
+           <item row="12" column="0">
+            <layout class="QHBoxLayout" name="tweaksVideoPreviewLayout">
+             <item>
+              <widget class="QCheckBox" name="tweaksVideoPreview">
+               <property name="text">
+                <string>Show video preview (restart required), set its height to (% of screen):</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="tweaksVideoPreviewHeight">
+               <property name="minimum">
+                <number>5</number>
+               </property>
+               <property name="maximum">
+                <number>80</number>
+               </property>
+               <property name="value">
+                <number>20</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item row="13" column="0" colspan="2">
             <layout class="QHBoxLayout" name="tweaksTimeTooltipLayout" stretch="0,0">
@@ -8086,45 +8142,6 @@ media file played</string>
               </size>
              </property>
             </spacer>
-           </item>
-           <item row="7" column="0">
-            <layout class="QHBoxLayout" name="tweaksMaxVolumeLayout">
-             <item>
-              <widget class="QCheckBox" name="tweaksMaxVolume">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Increase maximum volume to:</string>
-               </property>
-               <property name="checked">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="tweaksMaxVolumeValue">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="suffix">
-                <string>%</string>
-               </property>
-               <property name="minimum">
-                <number>110</number>
-               </property>
-               <property name="maximum">
-                <number>2000</number>
-               </property>
-               <property name="singleStep">
-                <number>10</number>
-               </property>
-               <property name="value">
-                <number>130</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
            </item>
           </layout>
          </widget>

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -4,7 +4,6 @@
 static constexpr char logModule[] =  "videopreview";
 static constexpr int previewMarginX = 20;
 static constexpr int labelHeight = 20;
-static constexpr int videoHeight = 180;
 
 VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
 {
@@ -23,7 +22,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
-    emit mpv->ctrlSetOptionVariant("ytdl-format", QString("bestvideo[height>=?%1]/best[height>=?%1]/bestvideo/best").arg(videoHeight));
+    setYtdlFormat();
     emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "js-runtimes=quickjs,"\
                                                     "remote-components=ejs:github,"\
                                                     "format-sort=[+size,+br,+res,+fps]");
@@ -54,6 +53,7 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     mpv->urlOpen(fileUrl);
     mpv->setPaused(true);
     aspectRatioSet = false;
+    aspectRatio = 0;
 }
 
 void VideoPreview::updatePalette()
@@ -64,9 +64,15 @@ void VideoPreview::updatePalette()
     textLabel->setPalette(palette);
 }
 
-void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth)
+void VideoPreview::show(const QString &text, double videoPosition, const QPoint &where,
+                        int mainWindowWidth, int previewHeight)
 {
     textLabel->setText(text);
+    if (previewHeight != videoWidget->height()) {
+        videoWidget->setFixedHeight(previewHeight);
+        updateWidth(aspectRatio);
+        setYtdlFormat();
+    }
     mpv->seek(videoPosition, false, true, true);
     mpv->setPaused(true);
     videoWidget->update();
@@ -91,14 +97,21 @@ void VideoPreview::updateWidth(double newAspect)
         aspectRatioSet = false;
         return;
     }
-    int newWidth = int(videoHeight * newAspect);
-    videoWidget->setFixedSize(newWidth, videoHeight);
+    aspectRatio = newAspect;
+    int newWidth = int(videoWidget->height() * newAspect);
+    videoWidget->setFixedWidth(newWidth);
     textLabel->setFixedSize(newWidth, labelHeight);
     aspectRatioSet = true;
     if (shouldBeShown)
         show();
     else
         hide();
+}
+
+void VideoPreview::setYtdlFormat()
+{
+    emit mpv->ctrlSetOptionVariant("ytdl-format",
+        QString("bestvideo[height>=?%1]/best[height>=?%1]/bestvideo/best").arg(videoWidget->height()));
 }
 
 void VideoPreview::show()

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -10,17 +10,19 @@ class VideoPreview : public QWidget {
         ~VideoPreview();
         void openFile(const QUrl &fileUrl);
         void updatePalette();
-        void show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth);
+        void show(const QString &text, double videoPosition, const QPoint &where, int mainWindowWidth, int previewHeight);
         void hide();
         
     private:
         void setPreviewPosition(const QPoint &where, int mainWindowWidth);
         void show();
         void updateWidth(double newAspect);
+        void setYtdlFormat();
 
         QLabel *textLabel;
         MpvObject *mpv = nullptr;
         MpvGlWidget *videoWidget = nullptr;
+        double aspectRatio = 0;
         bool aspectRatioSet = false;
         bool shouldBeShown = false;
         QPoint previewBottomLeft;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4347,10 +4347,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4464,6 +4460,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4742,7 +4742,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Mostrar la previsualització de vídeo (requereix reiniciar)</translation>
+        <translation type="vanished">Mostrar la previsualització de vídeo (requereix reiniciar)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4858,6 +4858,10 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4755,10 +4755,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4868,6 +4864,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4746,7 +4746,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Video-Vorschau anzeigen (erfordert Neustart)</translation>
+        <translation type="vanished">Video-Vorschau anzeigen (erfordert Neustart)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4862,6 +4862,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4792,7 +4792,7 @@ media file played</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Show video preview (restart required)</translation>
+        <translation type="vanished">Show video preview (restart required)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4904,6 +4904,10 @@ media file played</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4567,10 +4567,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4684,6 +4680,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4373,10 +4373,6 @@ toistetulle mediatiedostolle</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4490,6 +4486,10 @@ toistetulle mediatiedostolle</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4726,7 +4726,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Afficher l&apos;aperçu vidéo (redémarrage requis)</translation>
+        <translation type="vanished">Afficher l&apos;aperçu vidéo (redémarrage requis)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4850,6 +4850,10 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4550,7 +4550,7 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Tampilkan pratinjau video (perlu mulai ulang)</translation>
+        <translation type="vanished">Tampilkan pratinjau video (perlu mulai ulang)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4666,6 +4666,10 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4483,10 +4483,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,6 +4596,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4794,7 +4794,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>ビデオ プレビューを表示 (再起動が必要です)</translation>
+        <translation type="vanished">ビデオ プレビューを表示 (再起動が必要です)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4918,6 +4918,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4724,10 +4724,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4837,6 +4833,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4268,10 +4268,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Show time tooltip:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4421,6 +4417,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4331,10 +4331,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4448,6 +4444,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4727,10 +4727,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Replay Gain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4772,6 +4768,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -4787,10 +4787,6 @@ ficheiro de média reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4900,6 +4896,10 @@ ficheiro de média reproduzido</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4403,10 +4403,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4520,6 +4516,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4719,10 +4719,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4836,6 +4832,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4774,7 +4774,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>வீடியோ முன்னோட்டத்தைக் காட்டு (மறுதொடக்கம் தேவை)</translation>
+        <translation type="vanished">வீடியோ முன்னோட்டத்தைக் காட்டு (மறுதொடக்கம் தேவை)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4890,6 +4890,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4766,7 +4766,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Video önizlemelerini göster (yeniden başlatma gerekir)</translation>
+        <translation type="vanished">Video önizlemelerini göster (yeniden başlatma gerekir)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4882,6 +4882,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4547,10 +4547,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Show video preview (restart required)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Replay Gain</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4592,6 +4588,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -4787,7 +4787,7 @@ tệp phương tiện đã được phát</translation>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>Hiển thị bản xem trước video (cần khởi động lại)</translation>
+        <translation type="vanished">Hiển thị bản xem trước video (cần khởi động lại)</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4899,6 +4899,10 @@ tệp phương tiện đã được phát</translation>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4670,7 +4670,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview (restart required)</source>
-        <translation>显示视频预览（需要重启）</translation>
+        <translation type="vanished">显示视频预览（需要重启）</translation>
     </message>
     <message>
         <source>There is not much reason to use this. HDMI supports uncompressed multichannel PCM, and mpv supports lossless DTS-HD</source>
@@ -4794,6 +4794,10 @@ media file played</source>
     </message>
     <message>
         <source>Increase maximum volume to:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
In Tweaks, allows to set the height in percent of screen height, from 5 to 80%.

Fixes #417 ("Custom seek video preview size option").