### PR TITLE
mainwindow: Add context menus to subtitles and mute buttons

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -893,6 +893,12 @@ void MainWindow::setupBottomArea()
     foreach(QWidget *w, bottomWidgets)
         w->setMouseTracking(true);
     ui->bottomArea->setMouseTracking(true);
+    subsMenu = new QMenu();
+    muteMenu = new QMenu();
+    connect(ui->subs, &QPushButton::customContextMenuRequested,
+            this, &MainWindow::showSubsMenu);
+    connect(ui->mute, &QPushButton::customContextMenuRequested,
+            this, &MainWindow::showMuteMenu);
 }
 
 void MainWindow::setupIconThemer()
@@ -1363,6 +1369,16 @@ void MainWindow::showOsdTimer(bool onSeek)
                                                   Helpers::toDateFormatFixed(length,
                                                          Helpers::ShortFormat)));
     }
+}
+
+void MainWindow::showSubsMenu()
+{
+    subsMenu->exec(QCursor::pos());
+}
+
+void MainWindow::showMuteMenu()
+{
+    muteMenu->exec(QCursor::pos());
 }
 
 QList<QUrl> MainWindow::doQuickOpenFileDialog()
@@ -2245,7 +2261,9 @@ void MainWindow::setChapters(QList<Chapter> chapters)
 void MainWindow::setAudioTracks(QList<Track> tracks)
 {
     ui->menuPlayAudio->clear();
+    muteMenu->clear();
     ui->menuPlayAudio->setEnabled(false);
+    muteMenu->setEnabled(false);
     if (audioTracksGroup) {
         audioTracksGroup->deleteLater();
         audioTracksGroup = nullptr;
@@ -2256,6 +2274,7 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
     if (!hasAudio)
         return;
     ui->menuPlayAudio->setEnabled(true);
+    muteMenu->setEnabled(true);
     audioTracksGroup = new QActionGroup(this);
     for (const Track &track : tracks) {
         QAction *action = new QAction(ui->menuPlayAudio);
@@ -2269,6 +2288,7 @@ void MainWindow::setAudioTracks(QList<Track> tracks)
             setVolumeMuteState(false, true);
         });
         ui->menuPlayAudio->addAction(action);
+        muteMenu->addAction(action);
     }
     ui->menuPlayAudio->addSeparator();
     ui->menuPlayAudio->addMenu(ui->menuPlayAudioFilters);
@@ -2319,7 +2339,9 @@ void MainWindow::setVideoTracks(QList<Track> tracks)
 void MainWindow::setSubtitleTracks(QList<Track > tracks)
 {
     ui->menuPlaySubtitles->clear();
+    subsMenu->clear();
     ui->menuPlaySubtitles->setEnabled(false);
+    subsMenu->setEnabled(false);
     if (subtitleTracksGroup) {
         subtitleTracksGroup->deleteLater();
         subtitleTracksGroup = nullptr;
@@ -2332,6 +2354,7 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
     if (!hasSubs)
         return;
     ui->menuPlaySubtitles->setEnabled(true);
+    subsMenu->setEnabled(true);
     subtitleTracksGroup = new QActionGroup(this);
     for (const Track &track : tracks) {
         QAction *action = new QAction(ui->menuPlaySubtitles);
@@ -2346,6 +2369,7 @@ void MainWindow::setSubtitleTracks(QList<Track > tracks)
                 setSubtitlesEnabled(true, true);
         });
         ui->menuPlaySubtitles->addAction(action);
+        subsMenu->addAction(action);
     }
     ui->menuPlaySubtitles->addSeparator();
     ui->menuPlaySubtitles->addAction(ui->actionPlaySubtitlesEnabled);
@@ -3253,6 +3277,7 @@ void MainWindow::on_actionPlayStop_triggered()
     isPlaying = false;
     updateSize();
     ui->play->setFocus();
+    muteMenu->clear();
 }
 
 void MainWindow::on_actionPlayFrameBackward_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -117,6 +117,8 @@ private:
     void updateMouseHideTime();
     void updateDiscList();
     void showOsdTimer(bool onSeek);
+    void showSubsMenu();
+    void showMuteMenu();
     void resizePlaylistToFit();
     QList<QUrl> doQuickOpenFileDialog();
     void showStepAndSubsButtons(bool show);
@@ -519,6 +521,8 @@ private:
     QActionGroup* videoTracksGroup = nullptr;
     QActionGroup* subtitleTracksGroup = nullptr;
     QAction * escShortcutActionBackup = nullptr;
+    QMenu *subsMenu = nullptr;
+    QMenu *muteMenu = nullptr;
 
     bool freestanding_ = false;
     Helpers::TitlePrefix titlebarFormat_ = Helpers::PrefixFileName;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -564,6 +564,9 @@
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="contextMenuPolicy">
+                <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+               </property>
                <property name="toolTip">
                 <string>Subtitles</string>
                </property>
@@ -588,6 +591,9 @@
              </item>
              <item>
               <widget class="QPushButton" name="mute">
+               <property name="contextMenuPolicy">
+                <enum>Qt::ContextMenuPolicy::CustomContextMenu</enum>
+               </property>
                <property name="toolTip">
                 <string>Mute</string>
                </property>


### PR DESCRIPTION
And show the subtitles and audio tracks to let users quickly change them.

Fixes #1022 ("[Request] Audio and Subtitle buttons on the bar").