### PR TITLE
paletteeditor: Fix missing PlaceholderText on Qt < 6.6

### DIFF
--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -30,12 +30,12 @@ Q_GLOBAL_STATIC_WITH_ARGS(RoleLabels, roleText, ({
     { QPalette::AlternateBase, QObject::tr("Base (alternate)") },
     { QPalette::NoRole, QObject::tr("No role") },
     { QPalette::ToolTipBase, QObject::tr("Tooltip base") },
-#if QT_VERSION >= QT_VERSION_CHECK(6,6,0)
     { QPalette::ToolTipText, QObject::tr("Tooltip text") },
+#if QT_VERSION >= QT_VERSION_CHECK(6,6,0)
     { QPalette::PlaceholderText, QObject::tr("Placeholder text") },
     { QPalette::Accent, QObject::tr("Accent") }
 #else
-    { QPalette::ToolTipText, QObject::tr("Tooltip text") }
+    { QPalette::PlaceholderText, QObject::tr("Placeholder text") }
 #endif
 }));
 


### PR DESCRIPTION
Fixes: 000c30690567c355b0e281b37489b2f530b8d77f ("paletteeditor: Fix building with Qt < 6.6")