### PR TITLE
Let the user customize dark colors in the palette editor

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1436,6 +1436,11 @@ void SettingsWindow::on_interfaceWidgetCustom_toggled(bool checked)
     paletteEditor->setEnabled(checked);
 }
 
+void SettingsWindow::on_interfaceWidgetDark_toggled(bool checked)
+{
+    paletteEditor->setUseDarkColors(checked);
+}
+
 void SettingsWindow::on_interfaceIconsCustomBrowse_clicked()
 {
     static QFileDialog::Options options = QFileDialog::Options();

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -244,6 +244,8 @@ private slots:
 
     void on_interfaceWidgetCustom_toggled(bool checked);
 
+    void on_interfaceWidgetDark_toggled(bool checked);
+
     void on_interfaceIconsCustomBrowse_clicked();
 
     void on_ccHdrMapper_currentIndexChanged(int index);

--- a/src/widgets/paletteeditor.cpp
+++ b/src/widgets/paletteeditor.cpp
@@ -147,10 +147,10 @@ PaletteEditor::PaletteEditor(QWidget *parent) : QWidget(parent)
             this, &PaletteEditor::generateButtonWindow_clicked);
     layout->addWidget(button, row, col++);
 
-    button = new QPushButton(tr("Reset to System"), this);
-    connect(button, &QPushButton::clicked,
+    resetButton = new QPushButton(tr("Reset to System"), this);
+    connect(resetButton, &QPushButton::clicked,
             this, &PaletteEditor::resetPalette);
-    layout->addWidget(button, row, col++);
+    layout->addWidget(resetButton, row, col++);
 
     setLayout(layout);
 
@@ -245,6 +245,12 @@ void PaletteEditor::setEnabled(bool enabled)
     editorEnabled = enabled;
 }
 
+void PaletteEditor::setUseDarkColors(bool enabled)
+{
+    useDarkColors = enabled;
+    resetButton->setText(enabled ? tr("Dark colors") : tr("Reset to System"));
+}
+
 QVariant PaletteEditor::variant()
 {
     QVariant v = paletteToVariant(selected);
@@ -296,7 +302,7 @@ void PaletteEditor::setVariant(const QVariant &value)
 
 void PaletteEditor::resetPalette()
 {
-    setPalette(system);
+    setPalette(useDarkColors ? darkPalette() : system);
 }
 
 void PaletteEditor::colorField_valueSelected(PaletteEditor::ColorPair entry, QColor color)

--- a/src/widgets/paletteeditor.h
+++ b/src/widgets/paletteeditor.h
@@ -5,6 +5,8 @@
 #include <QWidget>
 #include <QVariant>
 
+class QPushButton;
+
 class PaletteBox : public QWidget
 {
     Q_OBJECT
@@ -47,6 +49,7 @@ public:
 
     bool isEnabled() const;
     void setEnabled(bool enabled);
+    void setUseDarkColors(bool enabled);
 
     // custom variant et al routines are needed for json serialisation
     QVariant variant();
@@ -70,8 +73,10 @@ private slots:
 private:
     QPalette system;
     QPalette selected;
+    QPushButton *resetButton;
     BoxMap boxes;
     bool editorEnabled = false;
+    bool useDarkColors = false;
 };
 
 #endif // PALETTEEDITOR_H

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1932,6 +1932,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2127,6 +2127,14 @@ No s&apos;activarà cap acció.</translation>
         <translation>Restablir als valors del sistema</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Utilitzar colors foscos</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generar</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2145,6 +2145,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Použít tmavé barvy</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generate</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2167,6 +2167,14 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation>Auf Systemeinstellungen zurücksetzen</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Dunkle Farben nutzen</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Erstellen</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2169,6 +2169,10 @@ No action will be triggered.</source>
         <translation>Reset to System</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generate</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2016,6 +2016,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation>Reiniciar a los valores predefinidos</translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1983,6 +1983,10 @@ Mitään toimintoa ei suoriteta.</translation>
         <translation>Palauta Järjestelmään</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Luo</translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2107,6 +2107,14 @@ Aucune action ne sera déclenchée.</translation>
         <translation>Réinitialiser au système</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Utiliser des couleurs sombres</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Générer</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2106,6 +2106,14 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <source>Reset to System</source>
         <translation>Atur Ulang ke Sistem</translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Gunakan warna gelap</translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2004,6 +2004,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2171,6 +2171,14 @@ No action will be triggered.</source>
         <translation>既定へリセット</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">ダークカラーを使用</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">生成</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2122,6 +2122,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generate</translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1916,6 +1916,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1936,6 +1936,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2137,6 +2137,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generuj</translation>
     </message>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -2169,6 +2169,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generate</translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1960,6 +1960,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2105,6 +2105,10 @@ No action will be triggered.</source>
         <translation>Сбросить на системные</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Сгенерировать</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2151,6 +2151,10 @@ No action will be triggered.</source>
         <translation>கணினிக்கு மீட்டமை</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">உருவாக்கு</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2151,6 +2151,14 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Sistem Ayarlarına Sıfırla</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Koyu renkleri kullan</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Üret</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2044,6 +2044,10 @@ No action will be triggered.</source>
         <source>Reset to System</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PlaybackManager</name>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -2169,6 +2169,14 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">Sử dụng màu tối</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">Generate</translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2127,6 +2127,14 @@ No action will be triggered.</source>
         <translation>重置为系统默认值</translation>
     </message>
     <message>
+        <source>Dark colors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use dark colors</source>
+        <translation type="obsolete">使用深色</translation>
+    </message>
+    <message>
         <source>Generate</source>
         <translation type="vanished">生成</translation>
     </message>


### PR DESCRIPTION
When both "Use dark colors" and "Use custom colors" are enabled, change the button to generate the palette from system colors to "Dark colors".

This loads the built-in dark colors in the palette editor so the user can use them as a base for a dark palette.

Fixes #861 ("Suggestion about UI change related to colors").