### PR TITLE
Add "Close / Minimize to tray" feature

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -731,6 +731,10 @@ void Flow::setupSettingsConnections()
     // settings -> mainwindow
     connect(settingsWindow, &SettingsWindow::trayIcon,
             mainWindow, &MainWindow::setTrayIcon);
+    connect(settingsWindow, &SettingsWindow::closeToTray,
+            mainWindow, &MainWindow::setCloseToTray);
+    connect(settingsWindow, &SettingsWindow::minimizeToTray,
+            mainWindow, &MainWindow::setMinimizeToTray);
     connect(settingsWindow, &SettingsWindow::titleBarFormat,
             mainWindow, &MainWindow::setTitleBarFormat);
     connect(settingsWindow, &SettingsWindow::mouseWindowedMap,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2016,6 +2016,8 @@ void MainWindow::setMediaTitle(const QString &title)
         newTitle = QString();
     if (!newTitle.isEmpty())
         windowTitle = newTitle;
+    if (trayIcon)
+        trayIcon->setToolTip(windowTitle);
 
     if (freestanding_)
         windowTitle.append(tr(" [Freestanding]"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -402,8 +402,14 @@ void MainWindow::changeEvent(QEvent *event)
             videoPreview->updatePalette();
         ui->statusTime->updatePalette();
     }
-    else if (event->type() == QEvent::WindowStateChange && isMaximized())
-        emit windowMaximized();
+    else if (event->type() == QEvent::WindowStateChange) {
+        if (isMaximized())
+            emit windowMaximized();
+        else if (isMinimized() && minimizeToTray) {
+            isHiddenToTray = true;
+            hide();
+        }
+    }
 }
 
 void MainWindow::moveEvent(QMoveEvent *event)
@@ -459,6 +465,12 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
 void MainWindow::closeEvent(QCloseEvent *event)
 {
     Logger::log(logModule, "closeEvent");
+    if (closeToTray && !isHiddenToTray && !reallyClose) {
+        hide();
+        isHiddenToTray = true;
+        event->ignore();
+        return;
+    }
     bool showPlaylist = ui->actionViewHidePlaylist->isChecked();
     playlistWindow_->close();
     ui->actionViewHidePlaylist->setChecked(showPlaylist);
@@ -733,6 +745,8 @@ void MainWindow::setupTrayIcon()
     Logger::log(logModule, "rendering trayIcon sizes");
     trayIcon->setIcon(createIconFromSvg(mpcQtIconPath, 64));
     Logger::log(logModule, "rendering trayIcon sizes done");
+    connect(trayIcon, &QSystemTrayIcon::activated,
+            this, &MainWindow::trayIcon_activated);
 }
 
 void MainWindow::setupActionGroups()
@@ -1817,6 +1831,16 @@ void MainWindow::setTrayIcon(bool enabled)
         trayIcon->hide();
 }
 
+void MainWindow::setCloseToTray(bool enabled)
+{
+    closeToTray = enabled;
+}
+
+void MainWindow::setMinimizeToTray(bool enabled)
+{
+    minimizeToTray = enabled;
+}
+
 void MainWindow::setTitleBarFormat(Helpers::TitlePrefix titlebarFormat)
 {
     titlebarFormat_ = titlebarFormat;
@@ -2709,6 +2733,7 @@ void MainWindow::on_actionFileClose_triggered()
 
 void MainWindow::on_actionFileExit_triggered()
 {
+    reallyClose = true;
     close();
 }
 
@@ -3670,6 +3695,17 @@ void MainWindow::hideTimer_timeout()
     if (fullscreenMode_ &&
             !ui->bottomArea->geometry().contains(mpvw->mapFromGlobal(QCursor::pos())))
         ui->bottomArea->hide();
+}
+
+void MainWindow::trayIcon_activated(QSystemTrayIcon::ActivationReason reason)
+{
+    if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick) {
+        isHiddenToTray ? show() : hide();
+        isHiddenToTray = !isHiddenToTray;
+    } else if (reason == QSystemTrayIcon::MiddleClick) {
+        reallyClose = true;
+        close();
+    }
 }
 
 void MainWindow::on_actionPlaylistRemoveSelected_triggered()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -250,6 +250,8 @@ public slots:
     void setFullscreenMode(bool fullscreenMode);
     void setNoVideoSize(const QSize &sz);
     void setTrayIcon(bool enabled);
+    void setCloseToTray(bool enabled);
+    void setMinimizeToTray(bool enabled);
     void setTitleBarFormat(Helpers::TitlePrefix titlebarFormat);
     void setWindowedMouseMap(const MouseStateMap &map);
     void setFullscreenMouseMap(const MouseStateMap &map);
@@ -491,6 +493,7 @@ private slots:
     void playlistWindow_windowDocked();
     void playlistWindow_playlistAddItem(const QUuid &playlistUuid);
     void hideTimer_timeout();
+    void trayIcon_activated(QSystemTrayIcon::ActivationReason reason);
 
     void on_actionFileLoadSubtitle_triggered();
 
@@ -525,6 +528,10 @@ private:
     QMenu *muteMenu = nullptr;
 
     bool freestanding_ = false;
+    bool closeToTray = false;
+    bool minimizeToTray = false;
+    bool isHiddenToTray = false;
+    bool reallyClose = false;
     Helpers::TitlePrefix titlebarFormat_ = Helpers::PrefixFileName;
     bool mainwindowIsClosing = false; // Prevents toggleViewAction from affecting saved setting for actionViewHidePlaylist
     DecorationState decorationState_ = AllDecorations;

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -719,6 +719,8 @@ void SettingsWindow::sendSignals()
 
     emit appendToQuickPlaylist(WIDGET_LOOKUP(ui->playerAppendToQuickPlaylist).toBool());
     emit trayIcon(WIDGET_LOOKUP(ui->playerTrayIcon).toBool());
+    emit closeToTray(WIDGET_LOOKUP(ui->playerCloseToTray).toBool());
+    emit minimizeToTray(WIDGET_LOOKUP(ui->playerMinimizeToTray).toBool());
     emit showOsd(WIDGET_LOOKUP(ui->playerOSD).toBool());
     emit limitProportions(WIDGET_LOOKUP(ui->playerLimitProportions).toBool());
     emit disableOpenDiscMenu(WIDGET_LOOKUP(ui->playerDisableOpenDisc).toBool());
@@ -1401,8 +1403,19 @@ void SettingsWindow::keyPressEvent(QKeyEvent *event)
 void SettingsWindow::on_playerOpenNew_toggled(bool checked)
 {
     ui->playerAppendToQuickPlaylist->setEnabled(!checked);
-    if (checked)
+    if (checked) {
         ui->playerAppendToQuickPlaylist->setChecked(false);
+        ui->playerCloseToTray->setChecked(false);
+        ui->playerMinimizeToTray->setChecked(false);
+    }
+}
+
+void SettingsWindow::on_playerTrayIcon_toggled(bool checked)
+{
+    if (!checked) {
+        ui->playerCloseToTray->setChecked(false);
+        ui->playerMinimizeToTray->setChecked(false);
+    }
 }
 
 void SettingsWindow::on_playerAppendToQuickPlaylist_toggled(bool checked)

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -88,6 +88,8 @@ signals:
 
     void appendToQuickPlaylist(bool yes);
     void trayIcon(bool yes);
+    void closeToTray(bool yes);
+    void minimizeToTray(bool yes);
     void showOsd(bool yes);
     void limitProportions(bool yes);
     void disableOpenDiscMenu(bool yes);
@@ -235,6 +237,8 @@ private slots:
     bool eventFilter(QObject *obj, QEvent *event) override;
 
     void on_playerOpenNew_toggled(bool checked);
+
+    void on_playerTrayIcon_toggled(bool checked);
 
     void on_playerAppendToQuickPlaylist_toggled(bool checked);
 

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>896</width>
-    <height>638</height>
+    <height>666</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -445,6 +445,20 @@ media file played</string>
                <widget class="QCheckBox" name="playerTrayIcon">
                 <property name="text">
                  <string>Tray icon</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="playerMinimizeToTray">
+                <property name="text">
+                 <string>Minimize to tray</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="playerCloseToTray">
+                <property name="text">
+                 <string>Close to tray</string>
                 </property>
                </widget>
               </item>
@@ -8761,6 +8775,22 @@ media file played</string>
     <hint type="destinationlabel">
      <x>537</x>
      <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>playerTrayIcon</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>playerCloseToTray</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>718</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>718</x>
+     <y>112</y>
     </hint>
    </hints>
   </connection>

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4470,6 +4470,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4872,6 +4872,14 @@ arxiu multimèdia reproduït</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4878,6 +4878,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4876,6 +4876,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4914,6 +4914,14 @@ media file played</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4690,6 +4690,14 @@ archivo multimedia reproducido</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4496,6 +4496,14 @@ toistetulle mediatiedostolle</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4864,6 +4864,14 @@ fichier média lu</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4680,6 +4680,14 @@ file media yang diputar</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4606,6 +4606,14 @@ ogni file multimediale riprodotto</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4932,6 +4932,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4843,6 +4843,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4427,6 +4427,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4454,6 +4454,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4778,6 +4778,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -4906,6 +4906,14 @@ ficheiro de média reproduzido</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4526,6 +4526,14 @@ arquivo de mídia reproduzido</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4842,6 +4842,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4900,6 +4900,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4896,6 +4896,14 @@ yeni bir &amp;oynatıcı aç</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4598,6 +4598,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -4913,6 +4913,14 @@ tệp phương tiện đã được phát</translation>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4808,6 +4808,14 @@ media file played</source>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Minimize to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StatusTime</name>


### PR DESCRIPTION
* Add "Close / Minimize to tray" feature

> Requires the tray icon and single window mode to be enabled.
> 
> The Exit command and middle-clicking the tray icon (newly added) always close MPC-QT.
> 
> Minimize to tray doesn't work (yet?) on Wayland in Wayland mode, it requires the Wayland compositor to let the window know that it's minimized.
> 
> Fixes https://github.com/mpc-qt/mpc-qt/issues/1053 ("Minimize to tray and keep running in tray?").

* mainwindow: Use same text for tray icon tooltip as the window title

> Especially useful to know what's playing when MPC-QT is hidden in the tray.