### PR TITLE
settingswindow: Fix "Close / Minimize to tray" settings

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -719,8 +719,8 @@ void SettingsWindow::sendSignals()
 
     emit appendToQuickPlaylist(WIDGET_LOOKUP(ui->playerAppendToQuickPlaylist).toBool());
     emit trayIcon(WIDGET_LOOKUP(ui->playerTrayIcon).toBool());
-    emit closeToTray(WIDGET_LOOKUP(ui->playerCloseToTray).toBool());
-    emit minimizeToTray(WIDGET_LOOKUP(ui->playerMinimizeToTray).toBool());
+    emit closeToTray(ui->playerCloseToTray->isEnabled() && WIDGET_LOOKUP(ui->playerCloseToTray).toBool());
+    emit minimizeToTray(ui->playerMinimizeToTray->isEnabled() && WIDGET_LOOKUP(ui->playerMinimizeToTray).toBool());
     emit showOsd(WIDGET_LOOKUP(ui->playerOSD).toBool());
     emit limitProportions(WIDGET_LOOKUP(ui->playerLimitProportions).toBool());
     emit disableOpenDiscMenu(WIDGET_LOOKUP(ui->playerDisableOpenDisc).toBool());
@@ -1405,14 +1405,6 @@ void SettingsWindow::on_playerOpenNew_toggled(bool checked)
     ui->playerAppendToQuickPlaylist->setEnabled(!checked);
     if (checked) {
         ui->playerAppendToQuickPlaylist->setChecked(false);
-        ui->playerCloseToTray->setChecked(false);
-        ui->playerMinimizeToTray->setChecked(false);
-    }
-}
-
-void SettingsWindow::on_playerTrayIcon_toggled(bool checked)
-{
-    if (!checked) {
         ui->playerCloseToTray->setChecked(false);
         ui->playerMinimizeToTray->setChecked(false);
     }

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -238,8 +238,6 @@ private slots:
 
     void on_playerOpenNew_toggled(bool checked);
 
-    void on_playerTrayIcon_toggled(bool checked);
-
     void on_playerAppendToQuickPlaylist_toggled(bool checked);
 
     void on_playerKeepHistory_toggled(bool checked);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -450,6 +450,9 @@ media file played</string>
               </item>
               <item>
                <widget class="QCheckBox" name="playerMinimizeToTray">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="text">
                  <string>Minimize to tray</string>
                 </property>
@@ -457,6 +460,9 @@ media file played</string>
               </item>
               <item>
                <widget class="QCheckBox" name="playerCloseToTray">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
                 <property name="text">
                  <string>Close to tray</string>
                 </property>
@@ -8782,6 +8788,22 @@ media file played</string>
    <sender>playerTrayIcon</sender>
    <signal>toggled(bool)</signal>
    <receiver>playerCloseToTray</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>718</x>
+     <y>84</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>718</x>
+     <y>112</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>playerTrayIcon</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>playerMinimizeToTray</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
Disable the checkboxes when the tray icon isn't enabled.

Fixes: c03dc4625d08b5b18f41d0b37621fa64fc4fdb46 ("Add "Close / Minimize to tray" feature")