### PR TITLE
mainwindow: Fix play / pause after closing context menus

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -890,7 +890,10 @@ void MainWindow::setupStatus()
 {
     ui->tinyicon->setPixmap(renderPixmapFromSvg(tinyIconPath));
     connect(ui->statusTime, &StatusTime::customContextMenuRequested,
-            ui->statusTime, &StatusTime::showContextMenu);
+            ui->statusTime, [this](const QPointF &p) {
+                ui->statusTime->showContextMenu(p);
+                mousePressedInBottomArea = false;
+            });
     connect(ui->statusTime, &StatusTime::doubleClicked,
             ui->actionNavigateGoto, &QAction::trigger);
 }
@@ -1388,11 +1391,13 @@ void MainWindow::showOsdTimer(bool onSeek)
 void MainWindow::showSubsMenu()
 {
     subsMenu->exec(QCursor::pos());
+    mousePressedInBottomArea = false;
 }
 
 void MainWindow::showMuteMenu()
 {
     muteMenu->exec(QCursor::pos());
+    mousePressedInBottomArea = false;
 }
 
 QList<QUrl> MainWindow::doQuickOpenFileDialog()


### PR DESCRIPTION
Manually reset `mousePressedInBottomArea`.

After closing the context menus of the subtitles, mute buttons (bfbe7fba2954682950f1e75b8c7ca196aaa24d86) and the status time (8c9aab2f06bd705e459365ebdb540d579d296374), `mousePressedInBottomArea` doesn't get reset in any of the mouse event handlers.

Fixes: 59d88ce187458b233b0b4b2686c7f72138654e8e ("mainwindow: Don't start playing on click in bottom area in fullscreen")