### PR TITLE
mainwindow: Don't hide mouse in fullscreen with context menu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1347,6 +1347,10 @@ void MainWindow::updateMouseHideTime()
                                  : mouseHideTimeWindowed);
 }
 
+void MainWindow::disableMouseHideTime()
+{
+    mpvObject_->setMouseHideTime(0);
+}
 
 void MainWindow::updateDiscList()
 {
@@ -3605,7 +3609,9 @@ void MainWindow::mpvw_customContextMenuRequested(const QPoint &pos)
 {
     if (mpvw == nullptr)
         return;
-    contextMenu->popup(mpvw->mapToGlobal(pos));
+    disableMouseHideTime();
+    contextMenu->exec(mpvw->mapToGlobal(pos));
+    updateMouseHideTime();
 }
 
 void MainWindow::position_sliderMoved(int position)

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -115,6 +115,7 @@ private:
     void updateOnTop();
     void updateWindowFlags();
     void updateMouseHideTime();
+    void disableMouseHideTime();
     void updateDiscList();
     void showOsdTimer(bool onSeek);
     void showSubsMenu();


### PR DESCRIPTION
When the main context menu is shown in fullscreen in Wayland mode, don't hide the mouse cursor when it's not on the context menu. It can also happen on Windows.

Requires changing the context menu from asynchronous to synchronous mode.
But it doesn't seem to have any side effect, with mpv being in a different thread and the rest of the UI already being non interactive while the context menu is shown.