### PR TITLE
Display "Seeking" state in status bar on mpv seek

### DIFF
--- a/src/ipc/http.cpp
+++ b/src/ipc/http.cpp
@@ -672,6 +672,10 @@ void MpcHcServer::setupHttp()
             state = QString::number(1);
             stateString = "Paused";
             break;
+        case PlaybackManager::SeekingState:
+            state = QString::number(3);
+            stateString = "Seeking";
+            break;
         default:
             state = QString::number(2);
             stateString = "Playing";

--- a/src/ipc/http.cpp
+++ b/src/ipc/http.cpp
@@ -669,6 +669,10 @@ void MpcHcServer::setupHttp()
             state = QString::number(-1);
             stateString = "N/A";
             break;
+        case PlaybackManager::SeekingState:
+            state = QString::number(3);
+            stateString = "Seeking";
+            break;
         default:
             state = QString::number(2);
             stateString = "Playing";

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2259,6 +2259,8 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
     ui->play->setChecked(state != PlaybackManager::StoppedState &&
                          state != PlaybackManager::ErrorState &&
                          !isPlaybackPaused);
+    if (ui->play->isChecked())
+        ui->play->setFocus();
     ui->pause->setChecked(isPaused && state != PlaybackManager::StoppedState);
     ui->stop->setChecked(state == PlaybackManager::StoppedState);
     updateOnTop();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2256,7 +2256,9 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
         positionSlider_->setLoopB(-1);
         ui->actionPlayLoopUse->setChecked(false);
     }
-    ui->play->setChecked(state == PlaybackManager::PlayingState && !isPlaybackPaused);
+    ui->play->setChecked(state != PlaybackManager::StoppedState &&
+                         state != PlaybackManager::ErrorState &&
+                         !isPlaybackPaused);
     ui->pause->setChecked(isPaused && state != PlaybackManager::StoppedState);
     ui->stop->setChecked(state == PlaybackManager::StoppedState);
     updateOnTop();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2225,6 +2225,9 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t 
     case PlaybackManager::BufferingState:
         ui->status->setText(tr("Buffering (%1%)").arg(bufferFillState));
         break;
+    case PlaybackManager::SeekingState:
+        ui->status->setText(tr("Seeking"));
+        break;
     case PlaybackManager::WaitingState:
         ui->status->setText(tr("Unknown"));
         break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2234,6 +2234,9 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
     case PlaybackManager::BufferingState:
         ui->status->setText(tr("Buffering (%1%)").arg(bufferFillState));
         break;
+    case PlaybackManager::SeekingState:
+        ui->status->setText(tr("Seeking"));
+        break;
     case PlaybackManager::WaitingState:
         ui->status->setText(tr("Loading"));
         break;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -122,6 +122,10 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_playbackStarted);
         connect(mpvObject, &MpvObject::pausedChanged,
                 this, &PlaybackManager::mpvw_pausedChanged);
+        connect(mpvObject, &MpvObject::playbackSeeking,
+                this, &PlaybackManager::mpvw_playbackSeeking);
+        connect(mpvObject, &MpvObject::playbackRestart,
+                this, &PlaybackManager::mpvw_playbackStarted);
         connect(mpvObject, &MpvObject::playbackIdling,
                 this, &PlaybackManager::mpvw_playbackIdling);
         connect(mpvObject, &MpvObject::playbackError,
@@ -1063,6 +1067,12 @@ void PlaybackManager::mpvw_bufferFillStateChanged(int64_t percentage)
 void PlaybackManager::mpvw_playbackStarted()
 {
     playbackState_ = PlayingState;
+    emit stateChanged(playbackState_, isPlaybackPaused);
+}
+
+void PlaybackManager::mpvw_playbackSeeking()
+{
+    playbackState_ = PlaybackState::SeekingState;
     emit stateChanged(playbackState_, isPlaybackPaused);
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -122,6 +122,10 @@ void PlaybackManager::setMpvObject(MpvObject *mpvObject, bool makeConnections)
                 this, &PlaybackManager::mpvw_playbackStarted);
         connect(mpvObject, &MpvObject::pausedChanged,
                 this, &PlaybackManager::mpvw_pausedChanged);
+        connect(mpvObject, &MpvObject::playbackSeeking,
+                this, &PlaybackManager::mpvw_playbackSeeking);
+        connect(mpvObject, &MpvObject::playbackRestart,
+                this, &PlaybackManager::mpvw_playbackStarted);
         connect(mpvObject, &MpvObject::playbackIdling,
                 this, &PlaybackManager::mpvw_playbackIdling);
         connect(mpvObject, &MpvObject::playbackError,
@@ -1063,6 +1067,12 @@ void PlaybackManager::mpvw_bufferFillStateChanged(int64_t percentage)
 void PlaybackManager::mpvw_playbackStarted()
 {
     playbackState_ = playbackStartState;
+    emit stateChanged(playbackState_);
+}
+
+void PlaybackManager::mpvw_playbackSeeking()
+{
+    playbackState_ = PlaybackState::SeekingState;
     emit stateChanged(playbackState_);
 }
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -52,6 +52,7 @@ public:
         PlayingState,
         LoadingState,
         BufferingState,
+        SeekingState,
         WaitingState,
         ErrorState
     };
@@ -221,6 +222,7 @@ private slots:
     void mpvw_pausedForCache(QString paused);
     void mpvw_bufferFillStateChanged(int64_t percentage);
     void mpvw_playbackStarted();
+    void mpvw_playbackSeeking();
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling(bool yes);
     void mpvw_playbackError();

--- a/src/manager.h
+++ b/src/manager.h
@@ -53,6 +53,7 @@ public:
         PlayingState,
         LoadingState,
         BufferingState,
+        SeekingState,
         WaitingState,
         ErrorState
     };
@@ -221,6 +222,7 @@ private slots:
     void mpvw_pausedForCache(QString paused);
     void mpvw_bufferFillStateChanged(int64_t percentage);
     void mpvw_playbackStarted();
+    void mpvw_playbackSeeking();
     void mpvw_pausedChanged(bool yes);
     void mpvw_playbackIdling(bool yes);
     void mpvw_playbackError();

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -862,6 +862,18 @@ void MpvObject::ctrl_unhandledMpvEvent(int eventLevel)
         emit playbackFinished();
         break;
     }
+    case MPV_EVENT_SEEK: {
+        if (debugMessages)
+            Logger::log(logModule, "seek");
+        emit playbackSeeking();
+        break;
+    }
+    case MPV_EVENT_PLAYBACK_RESTART: {
+        if (debugMessages)
+            Logger::log(logModule, "playback restart");
+        emit playbackRestart();
+        break;
+    }
     case MPV_EVENT_SHUTDOWN: {
         if (debugMessages)
             Logger::log(logModule, "event shutdown");

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -135,6 +135,8 @@ signals:
     void pausedChanged(bool yes);
     void eofReachedChanged(QString eof);
     void playbackFinished();
+    void playbackSeeking();
+    void playbackRestart();
     void playbackIdling(bool yes);
     void mediaTitleChanged(QString title);
     void metaDataChanged(QVariantMap metadata);

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -1341,6 +1341,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -1467,6 +1467,10 @@ No s&apos;activarà cap acció.</translation>
         <translation>Memòria intermèdia (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -1487,6 +1487,10 @@ No action will be triggered.</source>
         <translation>Načítání (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -1487,6 +1487,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -1491,6 +1491,10 @@ Es wird keine Aktion ausgelöst.</translation>
         <translation>Puffern (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Fehler</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -1433,6 +1433,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Error</translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -1379,6 +1379,10 @@ Mitään toimintoa ei suoriteta.</translation>
         <translation>Puskuroidaan (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -1443,6 +1443,10 @@ Aucune action ne sera déclenchée.</translation>
         <translation>Mise en mémoire tampon (%1 %)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -1475,6 +1475,10 @@ Tidak ada tindakan yang akan dipicu.</translation>
         <translation>Membuffer (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Kesalahan</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -1429,6 +1429,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Errori</translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -1491,6 +1491,10 @@ No action will be triggered.</source>
         <translation>バッファリング (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>エラー</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -1470,6 +1470,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -1345,6 +1345,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -1345,6 +1345,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -1465,6 +1465,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -1365,6 +1365,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -1467,6 +1467,10 @@ No action will be triggered.</source>
         <translation>Буферизация (%1%)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -1483,6 +1483,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">பிழை</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1483,6 +1483,10 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Arabelleğe alınıyor (%%1)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished">Hata</translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -1483,6 +1483,10 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
         <translation>Arabelleğe alınıyor (%%1)</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>Hata</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -1453,6 +1453,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -1477,6 +1477,10 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -1491,6 +1491,10 @@ No action will be triggered.</source>
         <translation>正在缓冲（%1%）</translation>
     </message>
     <message>
+        <source>Seeking</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Error</source>
         <translation>错误</translation>
     </message>


### PR DESCRIPTION
* Display "Seeking" state in status bar on mpv seek

> Instead of the "Playing" state, to better inform the user.

* mainwindow: Keep the play button checked while seeking, buffering, or loading

> Keep the play button checked (showing that the player is playing) while seeking, buffering, or loading.
> 
> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/23f05647521a9698f3f0415e6e8fd15692decd51 ("Split paused state from PlaybackState") and 23454aa61eaab95226635b0c920fc666b8c174d0 ("Display "Seeking" state in status bar on mpv seek").

* mainwindow: Refocus the play button after changing file

> When we used to switch to the StoppedState between files (and before https://github.com/mpc-qt/mpc-qt/commit/ae2952c0ac66b58bbaa96053231a5c9504a680c4 to the BufferingState), the pause button was losing its focus every time, preventing this visual bug where the pause button gains focus.
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/17ed2ee04e93dc15dd9027775ec0802d6fa73788 ("manager: Don't change playback state to StoppedState between files")