### PR TITLE
yt-dlp: sort by res instead of filtering by height

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -796,8 +796,8 @@ void SettingsWindow::sendSignals()
 
     emit afterPlaybackDefault(Helpers::AfterPlayback(WIDGET_LOOKUP(ui->afterPlaybackDefault).toInt()));
 
-    emit option("ytdl-format", QString("bestvideo[height<=?%1]+bestaudio/best").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
-    emit option("ytdl-raw-options", "js-runtimes=quickjs,remote-components=ejs:github");
+    emit option("ytdl-format", QString("bestvideo+bestaudio/best"));
+    emit option("ytdl-raw-options", QString("format-sort=res:%1,js-runtimes=quickjs,remote-components=ejs:github").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
 
     emit zoomCenter(WIDGET_LOOKUP(ui->playbackAutoCenterWindow).toBool());
     double factor = WIDGET_LOOKUP(ui->playbackAutoFitFactor).toInt() / 100.0;

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -1557,7 +1557,7 @@ media file played</string>
               <item>
                <widget class="QLabel" name="ytdlpLabel">
                 <property name="text">
-                 <string>Max video height:</string>
+                 <string>Maximum video resolution:</string>
                 </property>
                </widget>
               </item>

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -22,10 +22,9 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
     emit mpv->ctrlSetOptionVariant("hr-seek", "no");
     emit mpv->ctrlSetOptionVariant("audio", "no");
     emit mpv->ctrlSetOptionVariant("audio-display", "no");
-    setYtdlFormat();
-    emit mpv->ctrlSetOptionVariant("ytdl-raw-options", "js-runtimes=quickjs,"\
-                                                    "remote-components=ejs:github,"\
-                                                    "format-sort=[+size,+br,+res,+fps]");
+    emit mpv->ctrlSetOptionVariant("ytdl-format",
+        "bestvideo/best");
+    setYtdlRawOptions();
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
 
     connect(mpv, &MpvObject::aspectChanged,
@@ -71,7 +70,7 @@ void VideoPreview::show(const QString &text, double videoPosition, const QPoint 
     if (previewHeight != videoWidget->height()) {
         videoWidget->setFixedHeight(previewHeight);
         updateWidth(aspectRatio);
-        setYtdlFormat();
+        setYtdlRawOptions();
     }
     mpv->seek(videoPosition, false, true, true);
     mpv->setPaused(true);
@@ -108,10 +107,11 @@ void VideoPreview::updateWidth(double newAspect)
         hide();
 }
 
-void VideoPreview::setYtdlFormat()
+void VideoPreview::setYtdlRawOptions()
 {
-    emit mpv->ctrlSetOptionVariant("ytdl-format",
-        QString("bestvideo[height>=?%1]/best[height>=?%1]/bestvideo/best").arg(videoWidget->height()));
+    emit mpv->ctrlSetOptionVariant("ytdl-raw-options", QString("js-runtimes=quickjs,"\
+                                                    "remote-components=ejs:github,"\
+                                                    "format-sort=[res:%1,+size,+br,+fps]").arg(videoWidget->height()));
 }
 
 void VideoPreview::show()

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -17,7 +17,7 @@ class VideoPreview : public QWidget {
         void setPreviewPosition(const QPoint &where, int mainWindowWidth);
         void show();
         void updateWidth(double newAspect);
-        void setYtdlFormat();
+        void setYtdlRawOptions();
 
         QLabel *textLabel;
         MpvObject *mpv = nullptr;


### PR DESCRIPTION
Filtering by height somehow doesn't always work.
For instance with a horizontal video available in 480x272 and 1920x1080, and max height set to 360, it would wrongly select the 1920x1080 one. But it does work when sorting by height.

In addition of fixing the above, when sorting instead of filtering, if no video is below the setting, the closest one will be selected instead of a random one.

Using the "video resolution" (smallest dimension) instead of the height also makes it work for vertical videos.

Fixes #1065 ("MPC-QT is not selecting the SD 360p SD quality for "my.mail.ru" videos, even though I set "playback / yt-dlp (web videos) /maximum video height/360"").