### PR TITLE
videopreview: Only pause once

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -27,6 +27,7 @@ VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
                                                     "remote-components=ejs:github,"\
                                                     "format-sort=[+size,+br,+res,+fps]");
     emit mpv->ctrlSetOptionVariant("clipboard-backends", "clr");
+    mpv->setPaused(true);
 
     connect(mpv, &MpvObject::aspectChanged,
             this, &VideoPreview::updateWidth);
@@ -51,7 +52,6 @@ void VideoPreview::openFile(const QUrl &fileUrl)
     if (fileUrl.isEmpty())
         return;
     mpv->urlOpen(fileUrl);
-    mpv->setPaused(true);
     aspectRatioSet = false;
     aspectRatio = 0;
 }
@@ -74,7 +74,6 @@ void VideoPreview::show(const QString &text, double videoPosition, const QPoint 
         setYtdlFormat();
     }
     mpv->seek(videoPosition, false, true, true);
-    mpv->setPaused(true);
     videoWidget->update();
     setPreviewPosition(where, mainWindowWidth);
     show();


### PR DESCRIPTION
mpv persists the pause state across files and we were already pausing once too many times.