### PR TITLE
translations: Add missing string

### DIFF
--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4291,10 +4291,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4476,6 +4472,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4690,7 +4690,7 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Altura de vídeo màxima:</translation>
+        <translation type="vanished">Altura de vídeo màxima:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4878,6 +4878,10 @@ arxiu multimèdia reproduït</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4706,7 +4706,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Maximální výška videa:</translation>
+        <translation type="vanished">Maximální výška videa:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4886,6 +4886,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4694,7 +4694,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Maximale Videohöhe:</translation>
+        <translation type="vanished">Maximale Videohöhe:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4882,6 +4882,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4736,7 +4736,7 @@ media file played</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Max video height:</translation>
+        <translation type="vanished">Max video height:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4920,6 +4920,10 @@ media file played</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4511,10 +4511,6 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4696,6 +4692,10 @@ archivo multimedia reproducido</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4317,10 +4317,6 @@ toistetulle mediatiedostolle</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4502,6 +4498,10 @@ toistetulle mediatiedostolle</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4674,7 +4674,7 @@ fichier média lu</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Hauteur maximale des vidéos&#xa0;:</translation>
+        <translation type="vanished">Hauteur maximale des vidéos&#xa0;:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4871,6 +4871,10 @@ fichier média lu</translation>
     <message>
         <source>Close to tray</source>
         <translation>Fermer dans la zone de notification</translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4498,7 +4498,7 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Tinggi video maksimum:</translation>
+        <translation type="vanished">Tinggi video maksimum:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4686,6 +4686,10 @@ file media yang diputar</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4427,10 +4427,6 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4612,6 +4608,10 @@ ogni file multimediale riprodotto</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4742,7 +4742,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>ビデオの最大高さ :</translation>
+        <translation type="vanished">ビデオの最大高さ :</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4939,6 +4939,10 @@ media file played</source>
     <message>
         <source>Close to tray</source>
         <translation>閉じるでトレイへ</translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4668,10 +4668,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4849,6 +4845,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4108,10 +4108,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4433,6 +4429,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4275,10 +4275,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4460,6 +4456,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4603,10 +4603,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4784,6 +4780,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -4731,10 +4731,6 @@ ficheiro de média reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4912,6 +4908,10 @@ ficheiro de média reproduzido</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4347,10 +4347,6 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4532,6 +4528,10 @@ arquivo de mídia reproduzido</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4662,7 +4662,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Максимальная высота видео:</translation>
+        <translation type="vanished">Максимальная высота видео:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4846,6 +4846,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4718,7 +4718,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>அதிகபட்ச வீடியோ உயரம்:</translation>
+        <translation type="vanished">அதிகபட்ச வீடியோ உயரம்:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4906,6 +4906,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4714,7 +4714,7 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>En çok video yüksekliği:</translation>
+        <translation type="vanished">En çok video yüksekliği:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4902,6 +4902,10 @@ yeni bir &amp;oynatıcı aç</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4423,10 +4423,6 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Max video height:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Custom mpv options:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4604,6 +4600,10 @@ media file played</source>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -4735,7 +4735,7 @@ tệp phương tiện đã được phát</translation>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>Chiều cao video tối đa:</translation>
+        <translation type="vanished">Chiều cao video tối đa:</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4919,6 +4919,10 @@ tệp phương tiện đã được phát</translation>
     </message>
     <message>
         <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4618,7 +4618,7 @@ media file played</source>
     </message>
     <message>
         <source>Max video height:</source>
-        <translation>最大视频高度：</translation>
+        <translation type="vanished">最大视频高度：</translation>
     </message>
     <message>
         <source>Custom mpv options:</source>
@@ -4815,6 +4815,10 @@ media file played</source>
     <message>
         <source>Close to tray</source>
         <translation>关闭到托盘</translation>
+    </message>
+    <message>
+        <source>Maximum video resolution:</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixes: dc160af61bc53b91af754a3b3ac2fd807f5bf74d ("yt-dlp: sort by res instead of filtering by height")