### PR TITLE
Avoid showing the menu bar after the rest of the window on X11/XWayland startup

### DIFF
--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -3,6 +3,7 @@
 #include <QMetaMethod>
 #include <QGuiApplication>
 #include <QStyle>
+#include <QTimer>
 #include <QWidget>
 #include "helpers.h"
 #include "logger.h"
@@ -98,6 +99,19 @@ void WindowManager::restoreAppWindow(MainWindow *window, const CliInfo &cliInfo)
     if (cliInfo.validCliPos)
         desiredPlace = cliInfo.cliPos;
 
+    // On X11/XWayland the first child paints and the window-manager
+    // decorations can arrive asynchronously, which may show the menu bar
+    // shortly after the rest of the window.  Map the window transparent
+    // and reveal it once the first complete frame is ready.  Systems without
+    // compositing ignore the opacity value.
+    QVariantMap savedState = data[keyState].toMap();
+    bool delayedReveal = QGuiApplication::platformName() == "xcb"
+            && !data.value(keyMaximized, false).toBool()
+            && !savedState.value("actionViewFullscreen", false).toBool();
+
+    if (delayedReveal)
+        window->setWindowOpacity(0.0);
+
     window->setGeometry(QRect(desiredPlace, desiredSize));
 
     if (data.value(keyMaximized, false).toBool())
@@ -106,6 +120,13 @@ void WindowManager::restoreAppWindow(MainWindow *window, const CliInfo &cliInfo)
         window->show();
     window->raise();
     window->setState(data[keyState].toMap());
+
+    if (delayedReveal) {
+        QTimer::singleShot(50, window, [window]() {
+            window->setWindowOpacity(1.0);
+            window->update();
+        });
+    }
 }
 
 void WindowManager::restoreDocks(QMainWindow *dockHost, QList<QDockWidget *> dockWidgets)


### PR DESCRIPTION
## Problem

On X11/XWayland, the first child paints and the window-manager decorations
can arrive asynchronously. The menu bar may appear slightly after the rest of
the window, which makes startup feel less crisp.

## Change

In `WindowManager::restoreAppWindow()`, when running on `xcb` and not
restoring a maximized or fullscreen window, map the window with opacity 0 and
restore its opacity 50 ms later.

Systems without compositing ignore the opacity value, so they are unaffected.

This is intentionally not enabled on native Wayland, where the delayed reveal
did not improve the issue reliably and would only delay startup.

The default window size fix has been split into #1079.

## Testing

- KDE Wayland / XWayland: 10/10 launches opened in one step, with no visible
  menu-bar delay.
- KDE Wayland / native Wayland: the delayed reveal is disabled there; 10/10
  launches also opened in one step.
- On current master, the test system still shows a very slight menu-bar
  delay, while this patch makes startup consistently crisp in the same
  environment.
