### PR TITLE
Split paused state from PlaybackState and improve playback states

### DIFF
--- a/src/ipc/http.cpp
+++ b/src/ipc/http.cpp
@@ -415,9 +415,10 @@ void MpcHcServer::setPlaybackRate(double rate)
     playbackRate = rate;
 }
 
-void MpcHcServer::setPlaybackState(PlaybackManager::PlaybackState state)
+void MpcHcServer::setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused)
 {
     playbackState = state;
+    isPlaybackPaused_ = isPlaybackPaused;
 }
 
 void MpcHcServer::setVolume(int64_t volume)
@@ -668,14 +669,14 @@ void MpcHcServer::setupHttp()
             state = QString::number(-1);
             stateString = "N/A";
             break;
-        case PlaybackManager::PausedState:
-            state = QString::number(1);
-            stateString = "Paused";
-            break;
         default:
             state = QString::number(2);
             stateString = "Playing";
             break;
+        }
+        if (isPlaybackPaused_) {
+            state = QString::number(1);
+            stateString = "Paused";
         }
         QString position = QString::number(int64_t(fileTime*1000));
         QString positionString = Helpers::toDateFormatFixed(fileTime, Helpers::ShortFormat);

--- a/src/ipc/http.h
+++ b/src/ipc/http.h
@@ -166,7 +166,7 @@ public slots:
     void setNowPlaying(QUrl nowPlaying);
     void setMediaTitle(QString title);
     void setPlaybackRate(double rate);
-    void setPlaybackState(PlaybackManager::PlaybackState state);
+    void setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused);
     void setVolume(int64_t volume);
     void setVolumeMuted(bool muted);
 
@@ -195,6 +195,7 @@ private:
     QUrl nowPlaying;
     double playbackRate;
     PlaybackManager::PlaybackState playbackState;
+    bool isPlaybackPaused_ = false;
     int64_t volume;
     bool volumeMuted;
 };

--- a/src/ipc/json.cpp
+++ b/src/ipc/json.cpp
@@ -276,16 +276,12 @@ void MpcQtServer::ipc_repeat()
 
 void MpcQtServer::ipc_togglePlayback()
 {
-    switch (playbackManager->playbackState()) {
-    case PlaybackManager::StoppedState:
+    if (playbackManager->playbackState() == PlaybackManager::StoppedState)
         ipc_start();
-        break;
-    case PlaybackManager::PausedState:
+    else if (playbackManager->isPaused())
         playbackManager->unpausePlayer();
-        break;
-    default:
+    else
         playbackManager->pausePlayer();
-    }
 }
 
 void MpcQtServer::ipc_deltaExtraPlaytimes(const QVariantMap &map)

--- a/src/ipc/mpris.cpp
+++ b/src/ipc/mpris.cpp
@@ -108,9 +108,9 @@ void MprisInstance::manager_timeChanged(double time, double length)
     player->instance_timeChange(time, length);
 }
 
-void MprisInstance::manager_stateChanged(PlaybackManager::PlaybackState state)
+void MprisInstance::manager_stateChanged(PlaybackManager::PlaybackState state, bool isPlaybackPaused)
 {
-    player->instance_setPlaybackState(state);
+    player->instance_setPlaybackState(state, isPlaybackPaused);
 }
 
 void MprisInstance::manager_nowPlayingChanged(QUrl itemUrl, QUuid listUuid, QUuid itemUuid)
@@ -217,7 +217,7 @@ MprisInstance *MprisPlayerServer::instance()
 
 QString MprisPlayerServer::playbackStatus()
 {
-    if (playbackState == PlaybackManager::PausedState)
+    if (isPlaybackPaused_)
         return "Paused";
     if (playbackState != PlaybackManager::StoppedState &&
         playbackState != PlaybackManager::ErrorState)
@@ -354,18 +354,19 @@ void MprisPlayerServer::instance_setNowPlayingUrl(const QUrl &nowPlayingUrl)
     }
 }
 
-void MprisPlayerServer::instance_setPlaybackState(PlaybackManager::PlaybackState state)
+void MprisPlayerServer::instance_setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused)
 {
-    if (playbackState == state)
+    if (playbackState == state && isPlaybackPaused == isPlaybackPaused_)
         return;
     playbackState = state;
+    isPlaybackPaused_ = isPlaybackPaused;
     QVariantMap propertyMap;
     propertyMap.insert("PlaybackStatus", playbackStatus());
 
     if (maybeChangeCanPlay())
         propertyMap.insert("CanPlay", canPlay_);
 
-    bool canPause = state == PlaybackManager::PlayingState || PlaybackManager::PausedState;
+    bool canPause = state == PlaybackManager::PlayingState || isPlaybackPaused_;
     if (canPause_ != canPause) {
         canPause_ = canPause;
         canSeek_ = canPause; //FIXME: not every stream is seekable

--- a/src/ipc/mpris.h
+++ b/src/ipc/mpris.h
@@ -50,7 +50,7 @@ public slots:
     void mainwindow_fullscreenModeChanged(bool yes);
     void mainwindow_volumeChanged(int level);
     void manager_timeChanged(double time, double length);
-    void manager_stateChanged(PlaybackManager::PlaybackState state);
+    void manager_stateChanged(PlaybackManager::PlaybackState state, bool isPlaybackPaused);
     void manager_nowPlayingChanged(QUrl itemUrl, QUuid listUuid, QUuid itemUuid);
     void mpvObject_mediaTitleChanged(const QString &mediaTitle);
     void mpvObject_metaDataChanged(const QVariantMap &metadata);
@@ -171,7 +171,7 @@ public slots:
 
 private slots:
     void instance_setNowPlayingUrl(const QUrl &nowPlayingUrl);
-    void instance_setPlaybackState(PlaybackManager::PlaybackState state);
+    void instance_setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused);
     void instance_setMediaTitle(const QString &mediaTitle);
     void instance_setMetadata(const QVariantMap &metadata);
     void instance_setVolume(double volume);
@@ -183,6 +183,7 @@ private:
     bool maybeChangeMetadata();
 
     PlaybackManager::PlaybackState playbackState = PlaybackManager::StoppedState;
+    bool isPlaybackPaused_ = false;
     QString mpvMediaTitle;
     QVariantMap mpvMetadata;
     QVariantMap metadata_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -903,8 +903,6 @@ void Flow::setupMpvObjectConnections()
             mainWindow, &MainWindow::setChapterTitle);
     connect(mpvObject, &MpvObject::aspectNameChanged,
             mainWindow, &MainWindow::setAspectName);
-    connect(mpvObject, &MpvObject::mouseReleased,
-            mainWindow, &MainWindow::mpvObject_mouseReleased);
 
     // settingswindow -> log
     auto logger = Logger::singleton();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,7 +470,7 @@ void Flow::setTranslation(bool updateTranslations)
 
     if (updateTranslations) {
         mainWindow->updateLanguage();
-        mainWindow->setPlaybackState(playbackManager->playbackState(), 0);
+        mainWindow->setPlaybackState(playbackManager->playbackState(), playbackManager->isPaused(), 0);
         mainWindow->playlistWindow()->updateLanguage();
         settingsWindow->updateLanguage();
         propertiesWindow->updateLanguage();
@@ -1538,7 +1538,7 @@ void Flow::mainwindow_optionsOpenRequested()
     settingsWindow->raise();
 }
 
-void Flow::manager_stateChanged(PlaybackManager::PlaybackState state)
+void Flow::manager_stateChanged(PlaybackManager::PlaybackState state, bool isPlaybackPaused)
 {
     // Do nothing if we don't have to
     if (!manipulateScreensaver)
@@ -1547,7 +1547,7 @@ void Flow::manager_stateChanged(PlaybackManager::PlaybackState state)
     // If inhibiting the screensaver is switched off, or we just entered the
     // stopped or paused state, unihibit the screensaver
     if (!inhibitScreensaver || state == PlaybackManager::StoppedState
-                            || state == PlaybackManager::PausedState) {
+                            || isPlaybackPaused) {
         screenSaver->uninhibitSaver();
         return;
     }
@@ -1654,7 +1654,7 @@ void Flow::settingswindow_inhibitScreensaver(bool yes)
     // playback state (2022-03: which optionally re/uninhibits the
     // screensaver)
     this->inhibitScreensaver = yes;
-    manager_stateChanged(playbackManager->playbackState());
+    manager_stateChanged(playbackManager->playbackState(), playbackManager->isPaused());
 }
 
 void Flow::settingswindow_rememberHistory(bool yes, bool onlyVideos)

--- a/src/main.h
+++ b/src/main.h
@@ -84,7 +84,7 @@ private slots:
     void mainwindow_takeThumbnails();
     void mainwindow_optionsOpenRequested();
     void manager_playLengthChanged();
-    void manager_stateChanged(PlaybackManager::PlaybackState state);
+    void manager_stateChanged(PlaybackManager::PlaybackState state, bool isPlaybackPaused);
     void manager_fileClosed();
     void manager_subtitlesVisible(bool visible);
     void manager_hasNoSubtitles(bool none);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2577,14 +2577,6 @@ void MainWindow::libraryWindowClosed()
     ui->actionViewHideLibrary->setChecked(false);
 }
 
-void MainWindow::mpvObject_mouseReleased()
-{
-    if (!isPlaying && !mousePressedInBottomArea) {
-        emit playCurrentItemRequested();
-        return;
-    }
-}
-
 void MainWindow::setPlaylistVisibleState(bool yes) {
     Logger::log(logModule, "setPlaylistVisibleState");
     if (fullscreenMode_ || !ui || mainwindowIsClosing)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2235,7 +2235,7 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
         ui->status->setText(tr("Buffering (%1%)").arg(bufferFillState));
         break;
     case PlaybackManager::WaitingState:
-        ui->status->setText(tr("Unknown"));
+        ui->status->setText(tr("Loading"));
         break;
     case PlaybackManager::ErrorState:
         ui->status->setText(tr("Error"));

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -2206,7 +2206,7 @@ void MainWindow::checkExitFullscreenOnEnd()
         ui->actionViewFullscreen->setChecked(false);
 }
 
-void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState)
+void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused, int64_t bufferFillState)
 {
     // Update the fullscreen state
     if (state == PlaybackManager::StoppedState) {
@@ -2222,11 +2222,11 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t 
     case PlaybackManager::StoppedState:
         ui->status->setText(tr("Stopped"));
         break;
-    case PlaybackManager::PausedState:
-        ui->status->setText(tr("Paused"));
-        break;
     case PlaybackManager::PlayingState:
-        ui->status->setText(tr("Playing"));
+        if (isPlaybackPaused)
+            ui->status->setText(tr("Paused"));
+        else
+            ui->status->setText(tr("Playing"));
         break;
     case PlaybackManager::LoadingState:
         ui->status->setText(tr("Loading"));
@@ -2243,14 +2243,9 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t 
     }
     isPlaying = state != PlaybackManager::StoppedState &&
                 state != PlaybackManager::ErrorState;
-    isPaused = state == PlaybackManager::PausedState;
+    isPaused = isPlaybackPaused;
     setUiEnabledState(state != PlaybackManager::StoppedState);
-    if (isPaused) {
-        ui->actionPlayPause->setText(tr("&Play"));
-        ui->pause->setChecked(true);
-    }
-    else
-        ui->actionPlayPause->setText(tr("&Pause"));
+    ui->actionPlayPause->setText(isPaused ? tr("&Pause") : tr("&Play"));
 
     if (state == PlaybackManager::WaitingState) {
         mpvObject_->setLoopPoints(-1, -1);
@@ -2258,7 +2253,8 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, int64_t 
         positionSlider_->setLoopB(-1);
         ui->actionPlayLoopUse->setChecked(false);
     }
-    ui->play->setChecked(state == PlaybackManager::PlayingState);
+    ui->play->setChecked(state == PlaybackManager::PlayingState && !isPlaybackPaused);
+    ui->pause->setChecked(isPaused && state != PlaybackManager::StoppedState);
     ui->stop->setChecked(state == PlaybackManager::StoppedState);
     updateOnTop();
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -285,7 +285,7 @@ public slots:
     void setOsdTimerOnSeek(bool enabled);
     void setFullscreenHidePanels(bool hidden);
     void checkExitFullscreenOnEnd();
-    void setPlaybackState(PlaybackManager::PlaybackState state, int64_t bufferFillState);
+    void setPlaybackState(PlaybackManager::PlaybackState state, bool isPlaybackPaused, int64_t bufferFillState);
     void setPlaybackType(PlaybackManager::PlaybackType type);
     void disableChaptersMenus();
     void setChapters(QList<Chapter> chapters);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -318,7 +318,6 @@ public slots:
     void setWindowShouldBeRaised(bool yes);
     void logWindowClosed();
     void libraryWindowClosed();
-    void mpvObject_mouseReleased();
 
 private slots:
     void on_actionFileOpenQuick_triggered();

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -195,6 +195,11 @@ PlaybackManager::PlaybackState PlaybackManager::playbackState()
     return playbackState_;
 }
 
+bool PlaybackManager::isPaused()
+{
+    return isPlaybackPaused;
+}
+
 void PlaybackManager::openSeveralFiles(QList<QUrl> what, bool important)
 {
     if (!nowPlayingItem.isNull())
@@ -235,12 +240,12 @@ void PlaybackManager::playDiscFiles(QUrl where)
 {
     if (playbackState_ != StoppedState) {
         playbackState_ = StoppedState;
-        emit stateChanged(playbackState_);
+        emit stateChanged(playbackState_, isPlaybackPaused);
         mpvObject_->stopPlayback();
     }
     mpvObject_->discFilesOpen(where.toLocalFile());
     mpvObject_->setPaused(false);
-    playbackStartState = PlayingState;
+    playbackStartPaused = false;
     nowPlayingItem = QUuid();
     nowPlayingList = QUuid();
     emit nowPlayingChanged(where, QUuid(), QUuid());
@@ -289,27 +294,23 @@ void PlaybackManager::startPlayer()
 
 void PlaybackManager::playPausePlayer()
 {
-    switch (playbackState_) {
-    case PausedState:
+    if (isPlaybackPaused)
         unpausePlayer();
-        break;
-    case StoppedState:
+    else if (playbackState_ == StoppedState)
         startPlayer();
-        break;
-    default:
+    else
         pausePlayer();
-    }
 }
 
 void PlaybackManager::pausePlayer()
 {
-    if (playbackState_ == PlayingState)
+    if (!isPlaybackPaused)
         mpvObject_->setPaused(true);
 }
 
 void PlaybackManager::unpausePlayer()
 {
-    if (playbackState_ == PausedState) {
+    if (isPlaybackPaused) {
         if (eofReached_)
             navigateToTime(0);
         mpvObject_->setPaused(false);
@@ -722,7 +723,7 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
     emit windowShouldBeRaised(false);
     if (playbackState_ == WaitingState || what.isEmpty())
         return;
-    emit stateChanged(playbackState_ = WaitingState);
+    emit stateChanged(playbackState_ = WaitingState, isPlaybackPaused);
 
     if (!isRepeating)
         emit aboutToStartPlayingFile(what);
@@ -748,7 +749,6 @@ void PlaybackManager::startPlayWithUuid(QUrl what, QUuid playlistUuid,
     if (!with.isEmpty())
         mpvObject_->setSubFile(with.toString());
     mpvObject_->setPaused(playbackStartPaused);
-    playbackStartState = playbackStartPaused ? PausedState : PlayingState;
 
     if (!isRepeating && playbackPlayTimes > 1
             && playlistWindow_->extraPlayTimes(playlistUuid, itemUuid) <= 0) {
@@ -1041,7 +1041,7 @@ void PlaybackManager::mpvw_playLengthChanged(double length)
 void PlaybackManager::mpvw_playbackLoading()
 {
     playbackState_ = LoadingState;
-    emit stateChanged(playbackState_);
+    emit stateChanged(playbackState_, isPlaybackPaused);
 }
 
 void PlaybackManager::mpvw_pausedForCache(QString paused)
@@ -1052,18 +1052,18 @@ void PlaybackManager::mpvw_pausedForCache(QString paused)
         playbackState_ = PlayingState;
     else
         playbackState_ = StoppedState;
-    emit stateChanged(playbackState_);
+    emit stateChanged(playbackState_, isPlaybackPaused);
 }
 
 void PlaybackManager::mpvw_bufferFillStateChanged(int64_t percentage)
 {
-    emit stateChanged(playbackState_, percentage);
+    emit stateChanged(playbackState_, isPlaybackPaused, percentage);
 }
 
 void PlaybackManager::mpvw_playbackStarted()
 {
-    playbackState_ = playbackStartState;
-    emit stateChanged(playbackState_);
+    playbackState_ = PlayingState;
+    emit stateChanged(playbackState_, isPlaybackPaused);
 }
 
 void PlaybackManager::mpvw_pausedChanged(bool yes)
@@ -1071,8 +1071,8 @@ void PlaybackManager::mpvw_pausedChanged(bool yes)
     if (playbackState_ == StoppedState)
         return;
 
-    playbackState_ = yes ? PausedState : PlayingState;
-    emit stateChanged(playbackState_);
+    isPlaybackPaused = yes;
+    emit stateChanged(playbackState_, isPlaybackPaused, isPlaybackPaused);
 }
 
 void PlaybackManager::mpvw_playbackIdling(bool yes)
@@ -1085,7 +1085,7 @@ void PlaybackManager::mpvw_playbackIdling(bool yes)
     if (nowPlayingItem.isNull()) {
         nowPlaying_.clear();
         playbackState_ = StoppedState;
-        emit stateChanged(playbackState_);
+        emit stateChanged(playbackState_, isPlaybackPaused);
         return;
     }
 }
@@ -1093,7 +1093,7 @@ void PlaybackManager::mpvw_playbackIdling(bool yes)
 void PlaybackManager::mpvw_playbackError()
 {
     playbackState_ = ErrorState;
-    emit stateChanged(playbackState_);
+    emit stateChanged(playbackState_, isPlaybackPaused);
     checkAfterPlayback();
 }
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1051,7 +1051,7 @@ void PlaybackManager::mpvw_pausedForCache(QString paused)
     else if (paused == strFalse)
         playbackState_ = PlayingState;
     else
-        playbackState_ = StoppedState;
+        return;
     emit stateChanged(playbackState_, isPlaybackPaused);
 }
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -49,7 +49,6 @@ class PlaybackManager : public QObject
 public:
     enum PlaybackState {
         StoppedState,
-        PausedState,
         PlayingState,
         LoadingState,
         BufferingState,
@@ -64,6 +63,7 @@ public:
     void setPlaylistWindow(PlaylistWindow *playlistWindow);
     QUrl nowPlaying();
     PlaybackState playbackState();
+    bool isPaused();
     bool eofReached();
     void drawLogo();
 
@@ -73,7 +73,7 @@ signals:
     void titleChanged(QString title);
     void videoSizeChanged(QSize size);
     void playbackSpeedChanged(double speed);
-    void stateChanged(PlaybackManager::PlaybackState state, int bufferFillState = 0);
+    void stateChanged(PlaybackManager::PlaybackState state, bool paused, int bufferFillState = 0);
     void fileClosed();
     void typeChanged(PlaybackManager::PlaybackType type);
     // Transmit a map of chapter index to time,description pairs
@@ -260,7 +260,7 @@ private:
     double stepTimeNormal = 5.0;
     double stepTimeLarge = 20.0;
     PlaybackState playbackState_ = StoppedState;
-    PlaybackState playbackStartState = PlayingState;
+    bool isPlaybackPaused = false;
 
     QList<Track> videoList;
     QList<Track> audioList;

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -1207,7 +1207,6 @@ void MpvGlWidget::mouseReleaseEvent(QMouseEvent *event)
         return;
     }
     QOpenGLWidget::mouseReleaseEvent(event);
-    emit mpvObject->mouseReleased();
 }
 
 void MpvGlWidget::keyPressEvent(QKeyEvent *event)

--- a/src/mpvwidget.h
+++ b/src/mpvwidget.h
@@ -169,7 +169,6 @@ signals:
 
     void mouseMoved(int x, int y);
     void mousePress(int x, int y, int btn);
-    void mouseReleased();
     void keyPress(int key);
     void keyRelease(int key);
 


### PR DESCRIPTION
* Revert "Trigger Play from stopped state when clicking on mpvWidget"

> This isn't needed anymore since the very next commit https://github.com/mpc-qt/mpc-qt/commit/5500c653344fbd56aee8fb1499488f8f7a8ff51f ("mainwindow: Make Play / Pause action trigger Play button").
> 
> Once we split the paused state from the PlaybackState (thus letting the user pause during loading, buffering or seeking), this second play /pause trigger would pause the file.
> 
> This also avoids hardcoding a left click on the mpv widget to the "start from stopped state" action.
> 
> Reverts https://github.com/mpc-qt/mpc-qt/commit/e252ceeb07aad8aa47cbef9c6b3f6a3d5a71cdd5 ("Trigger Play from stopped state when clicking on mpvWidget").

* Split paused state from PlaybackState

> mpv can combine the paused state with various playback states (loading, buffering, seeking...).
> 
> Separating the paused state from the other playback states allows us to correctly restore the previous playback state.
> So if the player is paused during loading, buffering or seeking, it will remain paused once loading, buffering or seeking is complete.
> 
> This is also needed to implement a seeking state, as seeking can be done while the player is playing or paused.

* mainwindow: Show "Loading" instead of "Unknown" for the waiting state

> This avoids very quickly blinking "Unknown" in the status bar.
> 
> We use the WaitingState for a very short time between the moment we start loading a file (waiting for mpv to update the state) and the moment mpv reports that it's loading a file.

* manager: Don't change playback state to StoppedState between files

> We're actually loading the next file, so show "Loading" instead of "Stopped".
> 
> Fixes: https://github.com/mpc-qt/mpc-qt/commit/ae2952c0ac66b58bbaa96053231a5c9504a680c4 ("Display buffering state and progress in status bar on buffer underrun")