### PR TITLE
mainwindow: Don't use noVideoSize_ for Wayland video overflow workaround

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -346,7 +346,7 @@ void MainWindow::unfreezeWindow()
 void MainWindow::fixMpvwSize()
 {
     QSize size = mpvw->size();
-    mpvw->resize(noVideoSize_);
+    mpvw->resize(size.width() + 1, size.height() + 1);
     mpvw->resize(size);
 }
 


### PR DESCRIPTION
If the window happened to be the exact size of noVideoSize_, no resize would be done and the workaround wouldn't work.

Fixes: a14b1dd80f943c2b61a9f5882a38017c64a05331 ("Work around bug on Wayland where video doesn't fit window")