### PR TITLE
playlistwindow: Append file extension when exporting playlist

### DIFF
--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -6,6 +6,8 @@
 #include <QInputDialog>
 #include <QFileDialog>
 #include <QMenu>
+#include <QFileInfo>
+#include <QMessageBox>
 #include "logger.h"
 #include "playlistwindow.h"
 #include "ui_playlistwindow.h"
@@ -763,14 +765,42 @@ void PlaylistWindow::finishSearch()
 void PlaylistWindow::savePlaylist(const QUuid &playlistUuid)
 {
     static QFileDialog::Options options = QFileDialog::Options();
+
 #ifdef Q_OS_MAC
     options = QFileDialog::DontUseNativeDialog;
 #endif
-    QString file;
-    file = QFileDialog::getSaveFileName(this, tr("Export Playlist File"), QString(),
-                                        tr("Playlist files (*.m3u *.m3u8)"), nullptr, options);
+
+    QString file = tr("Playlist") + ".m3u";
+    bool confirmOverwrite = false;
+
+    while (true) {
+        file = QFileDialog::getSaveFileName(this, tr("Export Playlist File"), file,
+                                            tr("Playlist files") + " (*.m3u *.m3u8)", nullptr, options);
+        if(file.isEmpty())
+            return;
+
+        if (!file.endsWith(".m3u")) {
+            file.append(".m3u");
+            confirmOverwrite = true;
+        }
+
+        QFileInfo info(file);
+        if (confirmOverwrite && info.exists()) {
+            QMessageBox msgBox(this);
+            msgBox.setIcon(QMessageBox::Warning);
+            msgBox.setWindowTitle(tr("Export Playlist File"));
+            msgBox.setText(tr("File \"%1\" already exists.\nDo you want to replace it?").arg(info.fileName()));
+            msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+
+            if (msgBox.exec() != QMessageBox::Ok) {
+                confirmOverwrite = false;
+                continue;
+            }
+        }
+        break;
+    }
     auto pl = PlaylistCollection::getSingleton()->getPlaylist(playlistUuid);
-    if (!file.isEmpty() && pl)
+    if (pl)
         emit exportPlaylist(file, pl->toStringList());
 }
 

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -2042,10 +2042,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2087,6 +2083,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Enter playlist name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -2261,7 +2261,7 @@ No s&apos;activarà cap acció.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Fitxers de llista de reproducció (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Fitxers de llista de reproducció (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2318,6 +2318,15 @@ No s&apos;activarà cap acció.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Introduir nom de la llista de reproducció</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -2281,7 +2281,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Playlistové soubory (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Playlistové soubory (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2338,6 +2338,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Zadejte název playlistu</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -2297,7 +2297,7 @@ Es wird keine Aktion ausgelöst.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Playlist-Dateien (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Playlist-Dateien (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Open</source>
@@ -2350,6 +2350,15 @@ Es wird keine Aktion ausgelöst.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Playlist-Name eingeben</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -2299,7 +2299,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Playlist files (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Playlist files (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2356,6 +2356,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Enter playlist name</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -2143,7 +2143,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Archivos de lista de reproducción (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Archivos de lista de reproducción (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2200,6 +2200,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Introduzca el nombre de la lista de reproducción</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -2113,7 +2113,7 @@ Mitään toimintoa ei suoriteta.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Soittolistatiedostot (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Soittolistatiedostot (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2170,6 +2170,15 @@ Mitään toimintoa ei suoriteta.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Kirjoita Soittolistan Nimi</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -2241,7 +2241,7 @@ Aucune action ne sera déclenchée.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Fichiers de liste (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Fichiers de liste (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2290,6 +2290,15 @@ Aucune action ne sera déclenchée.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Entrer le nom de la liste</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -2225,7 +2225,7 @@ Tidak ada tindakan yang akan dipicu.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>File daftar putar (*.m3u *.m3u8)</translation>
+        <translation type="vanished">File daftar putar (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Open</source>
@@ -2274,6 +2274,15 @@ Tidak ada tindakan yang akan dipicu.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Masukkan nama daftar putar</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -2131,7 +2131,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>File di scaletta (*.mp3u *.m3u8)</translation>
+        <translation type="vanished">File di scaletta (*.mp3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2176,6 +2176,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Inserisci nome scaletta</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -2305,7 +2305,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>再生リスト ファイル (*.m3u *.m3u8)</translation>
+        <translation type="vanished">再生リスト ファイル (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2362,6 +2362,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>再生リスト名の入力</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -2247,10 +2247,6 @@ No action will be triggered.</source>
         <translation type="vanished">Import File</translation>
     </message>
     <message>
-        <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Export File</source>
         <translation type="vanished">Export File</translation>
     </message>
@@ -2300,6 +2296,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Enter playlist name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -2030,10 +2030,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Export File</source>
         <translation type="vanished">Eksporter fil</translation>
     </message>
@@ -2083,6 +2079,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Enter playlist name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -2046,10 +2046,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2091,6 +2087,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Enter playlist name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -2267,7 +2267,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Pliki list odtwarzania (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Pliki list odtwarzania (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2324,6 +2324,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Wpisz nazwę listy odtwarzania</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -2299,7 +2299,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Ficheiros da Playlist (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Ficheiros da Playlist (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2356,6 +2356,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Nome da Playlist</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -2075,7 +2075,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Arquivos da Playlist (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Arquivos da Playlist (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Open</source>
@@ -2128,6 +2128,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Nome da Playlist</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -5,15 +5,15 @@
     <name>About</name>
     <message>
         <source>Development Build</source>
-        <translation type="unfinished">Разрабатываемая версия</translation>
+        <translation>Разрабатываемая версия</translation>
     </message>
     <message>
         <source>Version %1</source>
-        <translation type="unfinished">Версия %1</translation>
+        <translation>Версия %1</translation>
     </message>
     <message>
         <source>Built on %1 at %2</source>
-        <translation type="unfinished">Скомпилировано %1 в %2</translation>
+        <translation>Скомпилировано %1 в %2</translation>
     </message>
     <message>
         <source>(Unknown)</source>
@@ -21,19 +21,19 @@
     </message>
     <message>
         <source>About Media Player Classic Qute Theater</source>
-        <translation type="unfinished">О Media Player Classic Qute Theater</translation>
+        <translation>О Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>Media Player Classic Qute Theater</source>
-        <translation type="unfinished">Media Player Classic Qute Theater</translation>
+        <translation>Media Player Classic Qute Theater</translation>
     </message>
     <message>
         <source>A clone of Media Player Classic written in Qt</source>
-        <translation type="unfinished">Клон Media Player Classic, написанный на Qt</translation>
+        <translation>Клон Media Player Classic, написанный на Qt</translation>
     </message>
     <message>
         <source>Based on Qt %1 and %2</source>
-        <translation type="unfinished">Используется Qt %1 и %2</translation>
+        <translation>Используется Qt %1 и %2</translation>
     </message>
     <message>
         <source>Running on %1</source>
@@ -164,7 +164,7 @@
     </message>
     <message>
         <source>Disable Aspect ratio</source>
-        <translation type="unfinished">Отключить соотношение сторон</translation>
+        <translation>Отключить соотношение сторон</translation>
     </message>
     <message>
         <source>Decrease Pan and Scan</source>
@@ -1748,7 +1748,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>&amp;Input Cache Statistics</source>
-        <translation type="unfinished">Статистика входного &amp;кэша</translation>
+        <translation>Статистика входного &amp;кэша</translation>
     </message>
     <message>
         <source>&amp;Previous Subtitles track</source>
@@ -1776,7 +1776,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Screenshot</source>
-        <translation type="unfinished">Снимок экрана</translation>
+        <translation>Снимок экрана</translation>
     </message>
     <message>
         <source>&amp;Crossfeed (for headphones)</source>
@@ -2297,12 +2297,12 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files</source>
-        <translation type="unfinished"></translation>
+        <translation>Файлы списков воспроизведения</translation>
     </message>
     <message>
         <source>File &quot;%1&quot; already exists.
 Do you want to replace it?</source>
-        <translation type="unfinished"></translation>
+        <translation>Файл &quot;%1&quot; уже существует. Заменить его?</translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>
@@ -4847,7 +4847,7 @@ media file played</source>
     </message>
     <message>
         <source>Show video preview (restart required), set its height to (% of screen):</source>
-        <translation type="unfinished">Показывать предпросмотр видео (требуется перезапуск), высота в процентах от экрана:</translation>
+        <translation>Показывать предпросмотр видео (требуется перезапуск), высота в процентах от экрана:</translation>
     </message>
     <message>
         <source>Minimize to tray</source>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -2237,7 +2237,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Файлы списков воспроизведения (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Файлы списков воспроизведения (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2294,6 +2294,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>Введите название списка воспроизведения</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -2281,7 +2281,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>பிளேலிச்ட் கோப்புகள் ( *.m3u *.m3u8)</translation>
+        <translation type="vanished">பிளேலிச்ட் கோப்புகள் ( *.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2338,6 +2338,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>பிளேலிச்ட் பெயரை உள்ளிடவும்</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -2285,7 +2285,7 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Oynatma listesi dosyaları (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Oynatma listesi dosyaları (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2342,6 +2342,15 @@ Herhangi bir eylem tetiklenmeyecek.</translation>
     <message>
         <source>Enter playlist name</source>
         <translation>Oynatma listesi adı gir</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -2162,10 +2162,6 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2218,7 +2214,16 @@ No action will be triggered.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Export Playlist File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -2303,7 +2303,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>Các tệp danh sách phát (*.m3u *.m3u8)</translation>
+        <translation type="vanished">Các tệp danh sách phát (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2359,6 +2359,15 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Enter playlist name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -2261,7 +2261,7 @@ No action will be triggered.</source>
     </message>
     <message>
         <source>Playlist files (*.m3u *.m3u8)</source>
-        <translation>播放列表文件 (*.m3u *.m3u8)</translation>
+        <translation type="vanished">播放列表文件 (*.m3u *.m3u8)</translation>
     </message>
     <message>
         <source>Export File</source>
@@ -2318,6 +2318,15 @@ No action will be triggered.</source>
     <message>
         <source>Enter playlist name</source>
         <translation>输入播放列表名称</translation>
+    </message>
+    <message>
+        <source>Playlist files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File &quot;%1&quot; already exists.
+Do you want to replace it?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&amp;New Playlist</source>


### PR DESCRIPTION
On GNOME and GTK-based DEs, the extension is not automatically added when exporting a playlist.
Because of this, when exporting/importing a playlist, playlists with the correct MIME type but without an extension are not displayed in the file dialog.