### PR TITLE
Fix default window size

### DIFF
--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -660,6 +660,19 @@ QVariantMap Helpers::rectToVmap(const QRect &r) {
     };
 }
 
+QSize Helpers::vmapToSize(const QVariantMap &m)
+{
+    return QSize(m["w"].toInt(), m["h"].toInt());
+}
+
+QVariantMap Helpers::sizeToVmap(const QSize &s)
+{
+    return QVariantMap {
+        { "w", s.width() },
+        { "h", s.height() }
+    };
+}
+
 template <class T>
 bool pairFromString(T &result, const QString &text)
 {

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -70,6 +70,8 @@ namespace Helpers {
     QString normalizedSuffix(const QFileInfo &fileInfo);
     QRect vmapToRect(const QVariantMap &m);
     QVariantMap rectToVmap(const QRect &r);
+    QSize vmapToSize(const QVariantMap &m);
+    QVariantMap sizeToVmap(const QSize &s);
     bool sizeFromString(QSize &size, const QString &text);
     bool pointFromString(QPoint &point, const QString &text);
     QRect availableGeometryFromPoint(const QPoint &point);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -337,6 +337,16 @@ QPoint MainWindow::desirablePosition(QSize &size, bool first_run) const
                                size, available).topLeft() + clientOffset;
 }
 
+QSize MainWindow::chromeSize() const
+{
+    return size() - (mpvw ? mpvw->size() : noVideoSize_);
+}
+
+QSize MainWindow::noVideoSize() const
+{
+    return noVideoSize_;
+}
+
 void MainWindow::unfreezeWindow()
 {
     frozenWindow = false;
@@ -601,11 +611,6 @@ MainWindow::DecorationState MainWindow::decorationState() const
 bool MainWindow::fullscreenMode() const
 {
     return fullscreenMode_;
-}
-
-QSize MainWindow::noVideoSize() const
-{
-    return noVideoSize_;
 }
 
 double MainWindow::sizeFactor() const

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -45,6 +45,8 @@ public:
     void setScreensaverAbilities(QSet<ScreenSaver::Ability> ab);
     QSize desirableSize(bool first_run = false);
     QPoint desirablePosition(QSize &size, bool first_run = false) const;
+    QSize chromeSize() const;
+    QSize noVideoSize() const;
     void unfreezeWindow();
     void fixMpvwSize();
     void setActionPlayLoopUse();
@@ -73,7 +75,6 @@ private:
 
     DecorationState decorationState() const;
     bool fullscreenMode() const;
-    QSize noVideoSize() const;
     double sizeFactor() const;
 
     void setDiscState(bool playingADisc);

--- a/src/platform/windowmanager.cpp
+++ b/src/platform/windowmanager.cpp
@@ -10,6 +10,7 @@
 #include "windowmanager.h"
 
 static constexpr char logModule[] =  "windowmanager";
+static constexpr char keyChromeSize[] = "chromeSize";
 static constexpr char keyGeometry[] = "geometry";
 static constexpr char keyMaximized[] = "maximized";
 static constexpr char keyQtState[] = "qtState";
@@ -42,6 +43,7 @@ void WindowManager::saveAppWindow(MainWindow *window, bool rememberWindowGeometr
     if (rememberPanels)
         panels = window->state();
     QVariantMap data = {
+        { keyChromeSize, !rememberWindowGeometry ? Helpers::sizeToVmap(window->chromeSize()) : QVariantMap() },
         { keyGeometry, rememberWindowGeometry ? appWindowGeometryCurrent : QVariantMap() },
         { keyState, panels },
         { keyMaximized, rememberWindowGeometry ? window->isMaximized() : false }
@@ -81,6 +83,7 @@ void WindowManager::restoreAppWindow(MainWindow *window, const CliInfo &cliInfo)
     QVariantMap data = json_[window->objectName()].toMap();
 
     // restore main window geometry and override it if requested
+    QSize chromeSize = Helpers::vmapToSize(data[keyChromeSize].toMap());
     QRect geometry = Helpers::vmapToRect(data[keyGeometry].toMap());
     appWindowGeometryCurrent = data[keyGeometry].toMap();
     appWindowGeometryPrevious = appWindowGeometryCurrent;
@@ -89,7 +92,7 @@ void WindowManager::restoreAppWindow(MainWindow *window, const CliInfo &cliInfo)
     bool checkMainWindow = data.isEmpty() || geometry.isEmpty();
 
     if (checkMainWindow)
-        desiredSize = window->desirableSize(true);
+        desiredSize = chromeSize.isNull() ? window->size() : window->noVideoSize() + chromeSize;
     if (cliInfo.validCliSize)
         desiredSize = cliInfo.cliSize;
 


### PR DESCRIPTION
The - currently not user-defined - `noVideoSize_` default mpv widget size wasn't being used when geometry saving is disabled (the setting "Remember last window size and position").
Instead, we were using the size defined in mainwindow.ui, which is intended to include the UI chrome including the width of the playlist window docked on the right on first start. So if the user closed, resized or moved the playlist, or showed or hid other interface widgets, that size was no longer correct.

Use the size defined in mainwindow.ui for first start size, and save the UI window chrome size on each app stop.
Then on each following start, use the combined saved UI window chrome size and `noVideoSize_` as default window size (when geometry saving is disabled).
Querying and saving the UI chrome size on stop instead of querying on start means that we don't slow down app start and simplifies the size querying to avoid potential regressions.