### PR TITLE
mainwindow: Remove X11 sync code

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -66,16 +66,6 @@ MainWindow::MainWindow(QWidget *parent) :
     setUiEnabledState(false);
     setDiscState(false);
 
-    // Sync with X11
-    if (Platform::isUnix) {
-        setAttribute(Qt::WA_DontShowOnScreen, true);
-        show();
-        QApplication::processEvents(QEventLoop::AllEvents |
-                            QEventLoop::WaitForMoreEvents,
-                            50);
-        hide();
-        setAttribute(Qt::WA_DontShowOnScreen, false);
-    }
     setRemoveFileNotRecycle();
 }
 


### PR DESCRIPTION
That code was exposing the window to the windowing system so things like window chrome could be reliably calculated.

Removing it is also needed to trigger the Wayland video overflow workaround on first mpv widget paint event
(445ca056638ddfa5f9419675ce4b63e7ab4cda60).

The underlying issue seems to have been fixed in a Qt version before 6.5:
Tested for regressions with a Qt 6.5 Flatpak, on KDE Wayland, XWayland, X11, and Cinnamon with window auto-resize on and off. Tested with Kubuntu 24.04 (Plasma 5.27) and Ubuntu 22.04 (GNOME). Older MPC-QT versions (down to 24.12) built with Qt 6.11 don't have any issue either.

Partially reverts 167072ed2138200d769fc3cb57b567ce791595e7 ("mainwindow: simplify resizing quite a bit").