### PR TITLE
Trigger Wayland video overflow workaround on first mpv widget paint event

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1598,10 +1598,6 @@ void Flow::manager_openingNewFile()
 
 void Flow::manager_aboutToStartPlayingFile()
 {
-    if (firstFile) {
-        firstFile = false;
-        mainWindow->fixMpvwSize();
-    }
     if (rememberFilePosition)
         updateRecentPosition(false);
 }

--- a/src/main.h
+++ b/src/main.h
@@ -156,7 +156,6 @@ private:
 
     static bool isWayland;
     static bool isWaylandMode;
-    bool firstFile = true;
     bool playlistsBackupLoaded = false;
     bool inhibitScreensaver = false;
     bool manipulateScreensaver = false;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -355,6 +355,9 @@ void MainWindow::unfreezeWindow()
 // REMOVEME: work around bug on Wayland where video doesn't fit window
 void MainWindow::fixMpvwSize()
 {
+    firstMpvwPaint = false;
+    if (QGuiApplication::platformName() != "wayland")
+        return;
     QSize size = mpvw->size();
     mpvw->resize(size.width() + 1, size.height() + 1);
     mpvw->resize(size);
@@ -433,6 +436,8 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     bool insideMpv = mpvw ? object == mpvw : false;
     if ((insideMpv || object == playlistWindow_) && event->type() == QEvent::MouseMove) {
         this->mouseMoveEvent(static_cast<QMouseEvent*>(event));
+    } else if (insideMpv && firstMpvwPaint && event->type() == QEvent::Paint && mpvw->isVisible()) {
+        fixMpvwSize();
     }
     if (object == ui->bottomArea) {
         if (event->type() == QEvent::Leave) {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -588,6 +588,7 @@ private:
     QUrl currentFile;
     QString currentFileTitle;
     int previewHeightPercent = 0;
+    bool firstMpvwPaint = true;
 
     IconThemer themer;
     QList<QAction *> menuFavoritesTail;


### PR DESCRIPTION
In multi-window mode, it needs to get applied to each window. Triggering it on first paint instead of on first file start means that it's fixed on start and works for all media types (including discs and DVD/BD).

Fixes: a14b1dd80f943c2b61a9f5882a38017c64a05331 ("Work around bug on Wayland where video doesn't fit window")