### PR TITLE
mainwindow: Delay Wayland video overflow workaround

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -345,7 +345,6 @@ void MainWindow::unfreezeWindow()
 // REMOVEME: work around bug on Wayland where video doesn't fit window
 void MainWindow::fixMpvwSize()
 {
-    firstMpvwPaint = false;
     if (QGuiApplication::platformName() != "wayland")
         return;
     QSize size = mpvw->size();
@@ -427,7 +426,8 @@ bool MainWindow::eventFilter(QObject *object, QEvent *event)
     if ((insideMpv || object == playlistWindow_) && event->type() == QEvent::MouseMove) {
         this->mouseMoveEvent(static_cast<QMouseEvent*>(event));
     } else if (insideMpv && firstMpvwPaint && event->type() == QEvent::Paint && mpvw->isVisible()) {
-        fixMpvwSize();
+        firstMpvwPaint = false;
+        QTimer::singleShot(0, this, &MainWindow::fixMpvwSize);
     }
     if (object == ui->bottomArea) {
         if (event->type() == QEvent::Leave) {


### PR DESCRIPTION
In some conditions, it can start an infinite loop when the Paint event gets fired asynchronously before we've had a chance to change the firstMpvwPaint variable.

Fixes: 445ca056638ddfa5f9419675ce4b63e7ab4cda60 ("Trigger Wayland video overflow workaround on first mpv widget paint event")
Fixes #1091 ("startup crashes, error messages with latest build (flatpak)").