### PR TITLE
manager: Preserve "-" inside tracks languages preferences

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -10,7 +10,7 @@ static constexpr char logModule[] =  "manager";
 static constexpr char strTrue[] =  "true";
 static constexpr char strFalse[] =  "false";
 
-Q_GLOBAL_STATIC_WITH_ARGS(QRegularExpression, wordSplitter, ("\\W+"));
+Q_GLOBAL_STATIC_WITH_ARGS(QRegularExpression, wordSplitter, ("[^\\w-]+"));
 
 
 TrackData TrackData::fromMap(const QVariantMap &map)


### PR DESCRIPTION
Otherwise, "es,es-419,en" would be split as "es,es,419,en".

Fixes: b1c1b2905bbbb0b37b4de4cc05afb6f0c1f81166 ("manager: use track data preferences")

Fixes #1078 ("Selected subtitle consistency across videos "broken" after update").