### PR TITLE
settingswindow: Download auto-generated subtitles matching user options

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -797,7 +797,11 @@ void SettingsWindow::sendSignals()
     emit afterPlaybackDefault(Helpers::AfterPlayback(WIDGET_LOOKUP(ui->afterPlaybackDefault).toInt()));
 
     emit option("ytdl-format", QString("bestvideo+bestaudio/best"));
-    emit option("ytdl-raw-options", QString("format-sort=res:%1,js-runtimes=quickjs,remote-components=ejs:github").arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight)));
+    QStringList subtitleLangPref = WIDGET_PLACEHOLD_LOOKUP(ui->playbackSubtitleTracks).split(QRegularExpression("[^\\w-]+"), Qt::SkipEmptyParts);
+    emit option("ytdl-raw-options",
+        QString("format-sort=res:%1,js-runtimes=quickjs,remote-components=ejs:github,write-auto-subs=,sub-langs=[%2,.*-orig]")
+        .arg(WIDGET_TO_TEXT(ui->ytdlpMaxHeight))
+        .arg(subtitleLangPref.join(",")));
 
     emit zoomCenter(WIDGET_LOOKUP(ui->playbackAutoCenterWindow).toBool());
     double factor = WIDGET_LOOKUP(ui->playbackAutoFitFactor).toInt() / 100.0;


### PR DESCRIPTION
YouTube returns an error when yt-dlp tries to download all (300+) auto-translated subtitles.
But downloading just the ones from Options > Playback > Default track preference > Subtitles is fine.

Also download auto-generated subtitles in the video language.

The way they are displayed isn't as good as normal subtitles (only one line is refreshed at a time).