### PR TITLE
settingswindow: Disable "Minimize to tray" in Wayland mode

### DIFF
--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -1416,6 +1416,12 @@ void SettingsWindow::on_playerAppendToQuickPlaylist_toggled(bool checked)
         ui->playerRememberQuickPlaylist->setChecked(false);
 }
 
+void SettingsWindow::on_playerTrayIcon_toggled(bool checked)
+{
+    ui->playerMinimizeToTray->setEnabled(QGuiApplication::platformName() == "wayland" ? false : checked);
+    ui->playerCloseToTray->setEnabled(checked);
+}
+
 void SettingsWindow::on_playerKeepHistory_toggled(bool checked)
 {
     bool playerKeepHistoryEnabled = checked;

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -240,6 +240,8 @@ private slots:
 
     void on_playerAppendToQuickPlaylist_toggled(bool checked);
 
+    void on_playerTrayIcon_toggled(bool checked);
+
     void on_playerKeepHistory_toggled(bool checked);
 
     void on_interfaceIconsTheme_currentIndexChanged(int index);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -8850,38 +8850,6 @@ media file played</string>
    </hints>
   </connection>
   <connection>
-   <sender>playerTrayIcon</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>playerCloseToTray</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>718</x>
-     <y>84</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>718</x>
-     <y>112</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>playerTrayIcon</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>playerMinimizeToTray</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>718</x>
-     <y>84</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>718</x>
-     <y>112</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>tweaksVideoPreview</sender>
    <signal>toggled(bool)</signal>
    <receiver>tweaksVideoPreviewHeight</receiver>


### PR DESCRIPTION
Wayland support requires a Wayland protocol addition to inform the application that it's minimized.
Link: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/414

Fixes: c03dc4625d08b5b18f41d0b37621fa64fc4fdb46 ("Add "Close / Minimize to tray" feature")