### PR TITLE
drawnstatus: Add option for status time tooltip in context menu and simplify showContextMenu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -189,7 +189,8 @@ QVariantMap MainWindow::state()
         { "shownStatsPage", mpvObject_->selectedStatsPage() },
         { "timeShortMode", ui->statusTime->shortMode() },
         { "timeRemainingMode", ui->statusTime->remainingMode() },
-        { "timePercentageMode", ui->statusTime->percentMode() }
+        { "timePercentageMode", ui->statusTime->percentMode() },
+        { "timeHoverTooltip", ui->statusTime->showTooltip() }
     };
 #undef WRAP
 }
@@ -235,6 +236,7 @@ void MainWindow::setState(const QVariantMap &map)
     ui->statusTime->setShortMode(map.value("timeShortMode", true).toBool());
     ui->statusTime->setRemainingMode(map.value("timeRemainingMode", false).toBool());
     ui->statusTime->setPercentMode(map.value("timePercentageMode", false).toBool());
+    ui->statusTime->setShowTooltip(map.value("timeHoverTooltip", true).toBool());
     updateOnTop();
 
 #undef UNWRAP

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -58,6 +58,11 @@ void StatusTime::setPercentMode(bool isPercent)
     updateText();
 }
 
+void StatusTime::setShowTooltip(bool yes)
+{
+    showHoverTooltip = yes;
+}
+
 void StatusTime::updateTimeFormat()
 {
     Helpers::TimeFormat format;
@@ -155,6 +160,18 @@ void StatusTime::showContextMenu(const QPointF &p)
     });
     m->addAction(a);
 
+    m->addSeparator();
+
+    a = new QAction(m);
+    a->setText(tr("Show tooltip"));
+    a->setCheckable(true);
+    a->setChecked(showHoverTooltip);
+    connect(a, &QAction::triggered,
+            this, [this]() {
+        showHoverTooltip = !showHoverTooltip;
+    });
+    m->addAction(a);
+
     m->exec(mapToGlobal(p).toPoint());
     if (hoverTooltip)
         hoverTooltip->hide();
@@ -163,7 +180,7 @@ void StatusTime::showContextMenu(const QPointF &p)
 
 void StatusTime::updateHoverTooltip()
 {
-    if (!hoverTooltip)
+    if (!hoverTooltip || !showHoverTooltip)
         return;
     QWidget *top = window();
     if (!top)

--- a/src/widgets/drawnstatus.cpp
+++ b/src/widgets/drawnstatus.cpp
@@ -127,36 +127,33 @@ void StatusTime::showContextMenu(const QPointF &p)
     QMenu *m = new QMenu(window());
     QAction *a;
 
-    bool isTimeRemaingMode = remainingMode_;
     a = new QAction(m);
     a->setText(tr("Remaining time"));
     a->setCheckable(true);
     a->setChecked(remainingMode_);
     connect(a, &QAction::triggered,
-            this, [this, isTimeRemaingMode]() {
-        setRemainingMode(!isTimeRemaingMode);
+            this, [this]() {
+        setRemainingMode(!remainingMode_);
     });
     m->addAction(a);
 
-    bool isTimeShortMode = shortMode_;
     a = new QAction(m);
     a->setText(tr("High precision"));
     a->setCheckable(true);
     a->setChecked(!shortMode_);
     connect(a, &QAction::triggered,
-            this, [this, isTimeShortMode]() {
-        setShortMode(!isTimeShortMode);
+            this, [this]() {
+        setShortMode(!shortMode_);
     });
     m->addAction(a);
 
-    bool isTimePercentageMode = percentMode_;
     a = new QAction(m);
     a->setText(tr("Show percentage"));
     a->setCheckable(true);
     a->setChecked(percentMode_);
     connect(a, &QAction::triggered,
-            this, [this, isTimePercentageMode]() {
-        setPercentMode(!isTimePercentageMode);
+            this, [this]() {
+        setPercentMode(!percentMode_);
     });
     m->addAction(a);
 

--- a/src/widgets/drawnstatus.h
+++ b/src/widgets/drawnstatus.h
@@ -17,12 +17,14 @@ public:
     void setShortMode(bool shortened);
     void setRemainingMode(bool isRemaining);
     void setPercentMode(bool isPercent);
+    void setShowTooltip(bool yes);
     void updatePalette();
     void showContextMenu(const QPointF &p);
 
     bool shortMode() const { return shortMode_; };
     bool remainingMode() const { return remainingMode_; };
     bool percentMode() const { return percentMode_; };
+    bool showTooltip() const { return showHoverTooltip; };
 
 signals:
     void doubleClicked();
@@ -41,6 +43,7 @@ private:
     bool shortMode_ = false;
     bool remainingMode_ = false;
     bool percentMode_ = false;
+    bool showHoverTooltip = true;
     bool hovered = false;
     Helpers::TimeFormat timeFormat = Helpers::LongFormat;
     double currentTime = 0;

--- a/translations/mpc-qt_ar.ts
+++ b/translations/mpc-qt_ar.ts
@@ -4511,6 +4511,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ca.ts
+++ b/translations/mpc-qt_ca.ts
@@ -4921,6 +4921,10 @@ arxiu multimèdia reproduït</translation>
         <translation>Mostrar el percentatge</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Reproduït: %1</translation>
     </message>

--- a/translations/mpc-qt_cs.ts
+++ b/translations/mpc-qt_cs.ts
@@ -4934,6 +4934,10 @@ přehrávaný mediální soubor</translation>
         <translation>Zobrazit procenta</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Přehráno: %1</translation>
     </message>

--- a/translations/mpc-qt_de.ts
+++ b/translations/mpc-qt_de.ts
@@ -4925,6 +4925,10 @@ media file played</source>
         <translation>Prozentsatz anzeigen</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Abgespielt: %1</translation>
     </message>

--- a/translations/mpc-qt_en.ts
+++ b/translations/mpc-qt_en.ts
@@ -4963,6 +4963,10 @@ media file played</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_es.ts
+++ b/translations/mpc-qt_es.ts
@@ -4735,6 +4735,10 @@ archivo multimedia reproducido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fi.ts
+++ b/translations/mpc-qt_fi.ts
@@ -4541,6 +4541,10 @@ toistetulle mediatiedostolle</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_fr.ts
+++ b/translations/mpc-qt_fr.ts
@@ -4914,6 +4914,10 @@ fichier média lu</translation>
         <translation>Afficher le pourcentage</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Lu&#xa0;: %1</translation>
     </message>

--- a/translations/mpc-qt_id.ts
+++ b/translations/mpc-qt_id.ts
@@ -4729,6 +4729,10 @@ file media yang diputar</translation>
         <translation>Tampilkan persentase</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Dimainkan: %1</translation>
     </message>

--- a/translations/mpc-qt_it.ts
+++ b/translations/mpc-qt_it.ts
@@ -4651,6 +4651,10 @@ ogni file multimediale riprodotto</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ja.ts
+++ b/translations/mpc-qt_ja.ts
@@ -4982,6 +4982,10 @@ media file played</source>
         <translation>パーセンテージを表示</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>再生 : %1</translation>
     </message>

--- a/translations/mpc-qt_ko.ts
+++ b/translations/mpc-qt_ko.ts
@@ -4884,6 +4884,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nb_NO.ts
+++ b/translations/mpc-qt_nb_NO.ts
@@ -4468,6 +4468,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_nl.ts
+++ b/translations/mpc-qt_nl.ts
@@ -4495,6 +4495,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pl.ts
+++ b/translations/mpc-qt_pl.ts
@@ -4823,6 +4823,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt.ts
+++ b/translations/mpc-qt_pt.ts
@@ -4951,6 +4951,10 @@ ficheiro de média reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_pt_BR.ts
+++ b/translations/mpc-qt_pt_BR.ts
@@ -4571,6 +4571,10 @@ arquivo de mídia reproduzido</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_ru.ts
+++ b/translations/mpc-qt_ru.ts
@@ -4889,6 +4889,10 @@ media file played</source>
         <translation>Показать процент</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Воспроизводится: %1</translation>
     </message>

--- a/translations/mpc-qt_ta.ts
+++ b/translations/mpc-qt_ta.ts
@@ -4949,6 +4949,10 @@ media file played</source>
         <translation type="unfinished">சதவீதத்தைக் காட்டு</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_tr.ts
+++ b/translations/mpc-qt_tr.ts
@@ -4945,6 +4945,10 @@ yeni bir &amp;oynatıcı aç</translation>
         <translation>Yüzdeyi göster</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Oynatılan: %1</translation>
     </message>

--- a/translations/mpc-qt_ur.ts
+++ b/translations/mpc-qt_ur.ts
@@ -4639,6 +4639,10 @@ media file played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/mpc-qt_vi.ts
+++ b/translations/mpc-qt_vi.ts
@@ -4962,6 +4962,10 @@ tệp phương tiện đã được phát</translation>
         <translation>Hiển thị phần trăm</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>Đã phát: %1</translation>
     </message>

--- a/translations/mpc-qt_zh_CN.ts
+++ b/translations/mpc-qt_zh_CN.ts
@@ -4858,6 +4858,10 @@ media file played</source>
         <translation>显示百分比</translation>
     </message>
     <message>
+        <source>Show tooltip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Played: %1</source>
         <translation>已播放：%1</translation>
     </message>


### PR DESCRIPTION
* drawnstatus: Add option for status time tooltip in context menu

> Follow-up to https://github.com/mpc-qt/mpc-qt/commit/336c722bb4b3ba527af510f401b65694e04eb220 ("widgets: add status time hover tooltip and double-click goto").
> 
> Mentioned in https://github.com/mpc-qt/mpc-qt/issues/1026 ("Various bugs and requests").

* drawnstatus: Simplify showContextMenu

> Remove extraneous variables.