### PR TITLE
videopreview: Add a drop shadow and fix 1-pixel black line on right side with fractional scaling

### DIFF
--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -1,16 +1,25 @@
 #include <QApplication>
+#include <QGraphicsDropShadowEffect>
 #include "videopreview.h"
 
 static constexpr char logModule[] =  "videopreview";
 static constexpr int previewMarginX = 20;
 static constexpr int labelHeight = 20;
+static constexpr int shadowMargin = 8;
 
 VideoPreview::VideoPreview(QWidget *parent) : QWidget(parent)
 {
     mpv = new MpvObject(this);
-    videoWidget = new MpvGlWidget(mpv, parent);
+    videoContainer = new QWidget(parent);
+    auto *shadow = new QGraphicsDropShadowEffect(videoContainer);
+    shadow->setBlurRadius(40);
+    shadow->setOffset(0);
+    shadow->setColor(QColor(0, 0, 0));
+    videoContainer->setGraphicsEffect(shadow);
+
+    videoWidget = new MpvGlWidget(mpv, videoContainer);
     mpv->setWidgetType(Helpers::CustomWidget, videoWidget);
-    textLabel = new QLabel(parent);
+    textLabel = new QLabel(videoContainer);
     textLabel->setAlignment(Qt::AlignCenter);
 
     textLabel->setAutoFillBackground(true);
@@ -80,7 +89,7 @@ void VideoPreview::show(const QString &text, double videoPosition, const QPoint 
 
 void VideoPreview::setPreviewPosition(const QPoint &where, int mainWindowWidth)
 {
-    int tooltipWidth = videoWidget->width();
+    int tooltipWidth = videoContainer->width();
     int xPos = where.x() - std::round(tooltipWidth / 2);
     if (xPos + tooltipWidth + previewMarginX > mainWindowWidth)
         xPos = mainWindowWidth - tooltipWidth - previewMarginX;
@@ -99,6 +108,10 @@ void VideoPreview::updateWidth(double newAspect)
     int newWidth = int(videoWidget->height() * newAspect);
     videoWidget->setFixedWidth(newWidth);
     textLabel->setFixedSize(newWidth, labelHeight);
+    videoWidget->move(0, shadowMargin);
+    textLabel->move(0, shadowMargin + videoWidget->height());
+    videoContainer->setFixedSize(newWidth + shadowMargin * 2,
+                                 videoWidget->height() + labelHeight + shadowMargin * 2);
     aspectRatioSet = true;
     if (shouldBeShown)
         show();
@@ -119,14 +132,11 @@ void VideoPreview::show()
         shouldBeShown = true;
         return;
     }
-    videoWidget->move(previewBottomLeft.x(),
-                      previewBottomLeft.y() - videoWidget->height() - textLabel->height());
-    textLabel->move(previewBottomLeft.x(),
-                    previewBottomLeft.y() - textLabel->height());
+    videoContainer->move(previewBottomLeft.x(),
+                         previewBottomLeft.y() - videoContainer->height());
 }
 
 void VideoPreview::hide() {
     shouldBeShown = false;
-    videoWidget->move(-50000, -50000);
-    textLabel->move(-50000, -50000);
+    videoContainer->move(-50000, -50000);
 }

--- a/src/widgets/videopreview.cpp
+++ b/src/widgets/videopreview.cpp
@@ -105,7 +105,8 @@ void VideoPreview::updateWidth(double newAspect)
         return;
     }
     aspectRatio = newAspect;
-    int newWidth = int(videoWidget->height() * newAspect);
+    double dpr = devicePixelRatioF();
+    int newWidth = floor(round(videoWidget->height() * dpr) * newAspect) / dpr;
     videoWidget->setFixedWidth(newWidth);
     textLabel->setFixedSize(newWidth, labelHeight);
     videoWidget->move(0, shadowMargin);

--- a/src/widgets/videopreview.h
+++ b/src/widgets/videopreview.h
@@ -19,9 +19,10 @@ class VideoPreview : public QWidget {
         void updateWidth(double newAspect);
         void setYtdlRawOptions();
 
-        QLabel *textLabel;
+        QLabel *textLabel = nullptr;
         MpvObject *mpv = nullptr;
         MpvGlWidget *videoWidget = nullptr;
+        QWidget *videoContainer = nullptr;
         double aspectRatio = 0;
         bool aspectRatioSet = false;
         bool shouldBeShown = false;


### PR DESCRIPTION
* videopreview: Add a drop shadow

> This is mostly cosmetic, but it helps differentiate the preview from the actual video.

* videopreview: Fix 1-pixel black line on right side with fractional scaling

> With some combinations of fractional scaling, aspect ratio and preview size setting, a 1-pixel black line was shown on the right side of the video preview.