### PR TITLE
Add Hold-to-Speed Feature for Quick Playback Control

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -544,6 +544,10 @@ void Flow::setupMainWindowConnections()
             playbackManager, &PlaybackManager::speedUp);
     connect(mainWindow, &MainWindow::speedReset,
             playbackManager, &PlaybackManager::speedReset);
+    connect(mainWindow, &MainWindow::holdSpeedStart,
+            playbackManager, &PlaybackManager::startHoldSpeed);
+    connect(mainWindow, &MainWindow::holdSpeedEnd,
+            playbackManager, &PlaybackManager::endHoldSpeed);
     connect(mainWindow, &MainWindow::relativeSeek,
             playbackManager, &PlaybackManager::relativeSeek);
     connect(mainWindow, &MainWindow::audioTrackSelected,
@@ -799,6 +803,8 @@ void Flow::setupSettingsConnections()
             playbackManager, &PlaybackManager::setSpeedStep);
     connect(settingsWindow, &SettingsWindow::speedStepAdditive,
             playbackManager, &PlaybackManager::setSpeedStepAdditive);
+    connect(settingsWindow, &SettingsWindow::holdSpeed,
+            playbackManager, &PlaybackManager::setHoldSpeed);
     connect(settingsWindow, &SettingsWindow::stepTimeNormal,
             playbackManager, &PlaybackManager::setStepTimeNormal);
     connect(settingsWindow, &SettingsWindow::stepTimeLarge,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QDesktopServices>
 #include <QMessageBox>
 #include <QScreen>
+#include <QGuiApplication>
 #include <QStyle>
 #include <QSvgRenderer>
 #include <QPainter>
@@ -51,6 +52,12 @@ MainWindow::MainWindow(QWidget *parent) :
     setupSizing();
     setupBottomArea();
     setupHideTimer();
+    holdSpeedTimer.setSingleShot(true);
+    holdSpeedTimer.setInterval(150);
+    connect(&holdSpeedTimer, &QTimer::timeout, this, [this]() {
+        if (QGuiApplication::mouseButtons() & Qt::LeftButton)
+            beginHoldSpeed();
+    });
     setupIconThemer();
 
     if (mpvw)
@@ -415,16 +422,53 @@ void MainWindow::changeEvent(QEvent *event)
         }
     }
 }
-
 void MainWindow::moveEvent(QMoveEvent *event)
 {
     Q_UNUSED(event)
     emit windowMoved();
 }
 
+void MainWindow::beginHoldSpeed()
+{
+    if (holdSpeedActive || !isPlaying || isPaused)
+        return;
+    holdSpeedActive = true;
+    if (mpvw)
+        mpvw->grabMouse();
+    emit holdSpeedStart();
+}
+
+void MainWindow::finishHoldSpeed()
+{
+    holdSpeedTimer.stop();
+    if (mpvw && QWidget::mouseGrabber() == mpvw)
+        mpvw->releaseMouse();
+    if (!holdSpeedActive)
+        return;
+    holdSpeedActive = false;
+    emit holdSpeedEnd();
+}
+
 bool MainWindow::eventFilter(QObject *object, QEvent *event)
 {
     bool insideMpv = mpvw ? object == mpvw : false;
+    if (insideMpv && event->type() == QEvent::MouseButtonPress) {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        if (mouseEvent->button() == Qt::LeftButton
+            && mouseEvent->modifiers() == Qt::NoModifier) {
+            holdSpeedTimer.start();
+        }
+    } else if (insideMpv && event->type() == QEvent::MouseButtonRelease) {
+        auto *mouseEvent = static_cast<QMouseEvent *>(event);
+        if (mouseEvent->button() == Qt::LeftButton) {
+            holdSpeedTimer.stop();
+            if (holdSpeedActive) {
+                finishHoldSpeed();
+                event->accept();
+                return true;
+            }
+        }
+    }
     if ((insideMpv || object == playlistWindow_) && event->type() == QEvent::MouseMove) {
         this->mouseMoveEvent(static_cast<QMouseEvent*>(event));
     } else if (insideMpv && firstMpvwPaint && event->type() == QEvent::Paint && mpvw->isVisible()) {
@@ -864,6 +908,7 @@ void MainWindow::setupMpvWidget(Helpers::MpvWidgetType widgetType)
                 this, &MainWindow::mpvw_customContextMenuRequested);
         // CHECKME: mouse tracking could be set by mpvObject's setWidgetType func
         mpvw->setMouseTracking(true);
+        mpvw->installEventFilter(this);
     }
 
     if (embeddedBottomArea)
@@ -2248,6 +2293,8 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
     isPlaying = state != PlaybackManager::StoppedState &&
                 state != PlaybackManager::ErrorState;
     isPaused = isPlaybackPaused;
+    if (!isPlaying || isPaused)
+        finishHoldSpeed();
     setUiEnabledState(state != PlaybackManager::StoppedState);
     ui->actionPlayPause->setText(isPaused ? tr("&Pause") : tr("&Play"));
 
@@ -3310,6 +3357,7 @@ void MainWindow::on_actionPlayPause_triggered()
 
 void MainWindow::on_actionPlayStop_triggered()
 {
+    finishHoldSpeed();
     emit stopped();
     isPlaying = false;
     updateSize();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -69,6 +69,8 @@ protected:
 
 private:
     bool mouseStateEvent(const MouseState &state);
+    void beginHoldSpeed();
+    void finishHoldSpeed();
 
     MediaSlider *positionSlider();
     VolumeSlider *volumeSlider();
@@ -160,6 +162,8 @@ signals:
     void speedDown();
     void speedUp();
     void speedReset();
+    void holdSpeedStart();
+    void holdSpeedEnd();
     void relativeSeek(bool forwards, bool isLarge);
     void audioTrackSelected(int64_t id, bool userSelected);
     void subtitleTrackSelected(int64_t id, bool userSelected);
@@ -521,6 +525,7 @@ private:
     QMenu *contextMenu = nullptr;
     QMenu *trayMenu = nullptr;
     QTimer hideTimer;
+    QTimer holdSpeedTimer;
     QSystemTrayIcon *trayIcon = nullptr;
     QActionGroup* audioTracksGroup = nullptr;
     QActionGroup* videoTracksGroup = nullptr;
@@ -551,6 +556,7 @@ private:
     bool timeTooltipAbove = true;
     bool osdTimerOnSeek = false;
     bool mousePressedInBottomArea = false;
+    bool holdSpeedActive = false;
     QPoint mousePressPosition;
 
     QString previousOpenDir;

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <QRegularExpression>
 #include <QFile>
 #include <QFileInfo>
@@ -477,6 +478,23 @@ void PlaybackManager::speedReset()
     setPlaybackSpeed(1.0);
 }
 
+void PlaybackManager::startHoldSpeed()
+{
+    if (holdSpeedActive)
+        return;
+    speedBeforeHold = mpvSpeed;
+    holdSpeedActive = true;
+    setPlaybackSpeed(holdSpeed);
+}
+
+void PlaybackManager::endHoldSpeed()
+{
+    if (!holdSpeedActive)
+        return;
+    holdSpeedActive = false;
+    setPlaybackSpeed(speedBeforeHold);
+}
+
 void PlaybackManager::relativeSeek(bool forwards, bool isLarge)
 {
     mpvObject_->seek((forwards ? 1.0 : -1.0) *
@@ -504,6 +522,11 @@ void PlaybackManager::setSpeedStep(double step)
 void PlaybackManager::setSpeedStepAdditive(bool isAdditive)
 {
     speedStepAdditive = isAdditive;
+}
+
+void PlaybackManager::setHoldSpeed(double speed)
+{
+    holdSpeed = std::clamp(speed, 1.0, 100.0);
 }
 
 void PlaybackManager::setStepTimeNormal(int normalMsec)

--- a/src/manager.h
+++ b/src/manager.h
@@ -151,6 +151,8 @@ public slots:
     void speedUp();
     void speedDown();
     void speedReset();
+    void startHoldSpeed();
+    void endHoldSpeed();
     void relativeSeek(bool forwards, bool isLarge);
 
     // output functions
@@ -158,6 +160,7 @@ public slots:
     void setAppendToQuickPlaylist(bool isAppend);
     void setSpeedStep(double step);
     void setSpeedStepAdditive(bool isAdditive);
+    void setHoldSpeed(double speed);
     void setStepTimeNormal(int normalMsec);
     void setStepTimeLarge(int largeMsec);
     void setSubtitleTrackPreference(QString langs);
@@ -257,6 +260,9 @@ private:
     double mpvSpeed = 1.0;
     double speedStep = 1.25;
     bool speedStepAdditive = true;
+    double holdSpeed = 2.5;
+    double speedBeforeHold = 1.0;
+    bool holdSpeedActive = false;
     bool eofReached_ = false;
     bool fastHardwareDecoding = false;
     double stepTimeNormal = 5.0;

--- a/src/mpvwidget.cpp
+++ b/src/mpvwidget.cpp
@@ -1180,6 +1180,7 @@ void MpvGlWidget::mouseMoveEvent(QMouseEvent *event)
         if (e == 0) {
             setCursor(Qt::ArrowCursor);
             if (!windowDragging
+                && QWidget::mouseGrabber() != this
                 && event->buttons().testAnyFlag(Qt::LeftButton)
                 && (event->position() - mousePressPosition).manhattanLength()
                     > QApplication::startDragDistance()) {

--- a/src/settingswindow.cpp
+++ b/src/settingswindow.cpp
@@ -787,6 +787,7 @@ void SettingsWindow::sendSignals()
         emit speedStep(i > 0 ? 1.0 + i/100.0 : 1.25);
         emit speedStepAdditive(WIDGET_LOOKUP(ui->playbackSpeedStepAdditive).toBool());
     }
+    emit holdSpeed(WIDGET_LOOKUP(ui->playbackHoldSpeed).toDouble());
     emit stepTimeNormal(WIDGET_LOOKUP(ui->playbackNormalStep).toInt());
     emit stepTimeLarge(WIDGET_LOOKUP(ui->playbackLargeStep).toInt());
 

--- a/src/settingswindow.h
+++ b/src/settingswindow.h
@@ -125,6 +125,7 @@ signals:
     void volumeStep(int amount);
     void speedStep(double amount);
     void speedStepAdditive(bool isAdditive);
+    void holdSpeed(double speed);
     void stepTimeNormal(int msec);
     void stepTimeLarge(int msec);
     void zoomPreset(int which, double fitFactor);

--- a/src/settingswindow.ui
+++ b/src/settingswindow.ui
@@ -1213,6 +1213,38 @@ media file played</string>
                 </property>
                </widget>
               </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="playbackHoldSpeedLabel">
+                <property name="text">
+                 <string>Hold-to-speed</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="1">
+               <widget class="QDoubleSpinBox" name="playbackHoldSpeed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="suffix">
+                 <string notr="true">x</string>
+                </property>
+                <property name="minimum">
+                 <double>1.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>2.500000000000000</double>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>


### PR DESCRIPTION
This PR adds a new "Pressed Speed" feature that allows users to temporarily change the playback speed by holding down the left mouse button in the video window. When the button is released, playback returns to normal speed.

I personally was missing this feature - don't know if there is interest. I use it all the time.
