### PR TITLE
Clear playlist widget focus on double click and when clicking outside of it

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -508,6 +508,7 @@ static bool insideWidget(QPoint p, QWidget const *widget) {
 
 void MainWindow::mousePressEvent(QMouseEvent *event)
 {
+    playlistWindow_->clearWidgetFocus();
     mousePressPosition = event->globalPosition().toPoint();
     bool isInMpvw = mpvw ? insideWidget(mousePressPosition, mpvw) : false;
     mousePressedInBottomArea = ui->bottomArea->isVisible() ?
@@ -2260,8 +2261,6 @@ void MainWindow::setPlaybackState(PlaybackManager::PlaybackState state, bool isP
     ui->play->setChecked(state != PlaybackManager::StoppedState &&
                          state != PlaybackManager::ErrorState &&
                          !isPlaybackPaused);
-    if (ui->play->isChecked())
-        ui->play->setFocus();
     ui->pause->setChecked(isPaused && state != PlaybackManager::StoppedState);
     ui->stop->setChecked(state == PlaybackManager::StoppedState);
     updateOnTop();

--- a/src/playlistwindow.cpp
+++ b/src/playlistwindow.cpp
@@ -283,7 +283,7 @@ void PlaylistWindow::tabsFromVList(const QVariantList &qvl)
         qdp->setDisplayParser(&displayParser);
         qdp->fromVMap(qvm);
         connect(qdp, &DrawnPlaylist::itemDesiredByDoubleClick,
-                this, &PlaylistWindow::itemDesired);
+                this, &PlaylistWindow::itemDoubleClicked);
         connect(qdp, &DrawnPlaylist::contextMenuRequested,
                 this, &PlaylistWindow::playlist_contextMenuRequested);
         auto pl = PlaylistCollection::getSingleton()->getPlaylist(qdp->uuid());
@@ -305,6 +305,12 @@ void PlaylistWindow::updateIcons()
 void PlaylistWindow::updateLanguage()
 {
     ui->retranslateUi(this);
+}
+
+void PlaylistWindow::clearWidgetFocus()
+{
+    if (currentPlaylistWidget()->hasFocus())
+        currentPlaylistWidget()->clearFocus();
 }
 
 bool PlaylistWindow::eventFilter(QObject *obj, QEvent *event)
@@ -419,7 +425,7 @@ void PlaylistWindow::addNewTab(QUuid playlist, QString title)
     auto qdp = new DrawnPlaylist(PlaylistCollection::getSingleton());
     qdp->setDisplayParser(&displayParser);
     qdp->setUuid(playlist);
-    connect(qdp, &DrawnPlaylist::itemDesiredByDoubleClick, this, &PlaylistWindow::itemDesired);
+    connect(qdp, &DrawnPlaylist::itemDesiredByDoubleClick, this, &PlaylistWindow::itemDoubleClicked);
     connect(qdp, &DrawnPlaylist::contextMenuRequested,
             this, &PlaylistWindow::playlist_contextMenuRequested);
     widgets.insert(playlist, qdp);
@@ -433,8 +439,14 @@ void PlaylistWindow::addQuickQueue()
     queueWidget->setDisplayParser(&displayParser);
     queueWidget->setUuid(QUuid());
     connect(queueWidget, &DrawnQueue::itemDesiredByDoubleClick,
-            this, &PlaylistWindow::itemDesired);
+            this, &PlaylistWindow::itemDoubleClicked);
     ui->quickPage->layout()->addWidget(queueWidget);
+}
+
+void PlaylistWindow::itemDoubleClicked(QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist)
+{
+    clearWidgetFocus();
+    itemDesired(playlistUuid, itemUuid, clickedInPlaylist);
 }
 
 void PlaylistWindow::setIconTheme(IconThemer::FolderMode folderMode, const QString &customFolder)

--- a/src/playlistwindow.h
+++ b/src/playlistwindow.h
@@ -43,6 +43,7 @@ public:
     void setExtraPlayTimes(QUuid list, QUuid item, int amount);
     void deltaExtraPlayTimes(QUuid list, QUuid item, int delta);
     void reshufflePlaylist(const QUuid &playlistUuid);
+    void clearWidgetFocus();
 
     QVariantList tabsToVList(bool saveQuickPlaylist) const;
     void tabsFromVList(const QVariantList &qvl);
@@ -67,6 +68,7 @@ private:
     void setPlaylistFilters(QString filterText);
     void addNewTab(QUuid playlist, QString title);
     void addQuickQueue();
+    void itemDoubleClicked(QUuid playlistUuid, QUuid itemUuid, bool clickedInPlaylist);
 
 signals:
     void windowDocked();


### PR DESCRIPTION
When a user clicked in the playlist then clicked anywhere in the window, the focus was being kept in the playlist (except on KDE), preventing the user from using the Up/Down/PageUp/PageDown key shortcuts (see 2608008105f6e290d511c2d09061fa885e5bf67f and
b738840b13d50c5944f6de0fd286c950f168bb76).

When double-clicking on an item to open it, the user is most likely not going to use the keyboard to navigate in the playlist.

Reverts 44b071c9e2244245f6b693cf8e0d3cf654859e7f ("mainwindow: Refocus the play button after changing file") which doesn't seem needed anymore and which prevented continuous keyboard navigation in the playlist.

Fixes #1103 ("Docked playlist retains keyboard focus indefinitely, blocking Up/Down seek on the video").